### PR TITLE
Makefile for os-specific builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+BUILD=./build/
+WIN=$(BUILD)win/
+LINUX=$(BUILD)linux/
+OSX=$(BUILD)osx/
+ARM6=$(BUILD)arm/
+SOURCE=oragono.go
+VERS=XXX
+
+.PHONY: all
+
+add-files = mkdir -p $1; \
+	cp oragono.yaml $1; \
+	cp oragono.motd $1; \
+	cp LICENSE $1; \
+	cp ./docs/README $1; \
+	mkdir -p $1/docs; \
+	cp ./CHANGELOG.md $1/docs/; \
+	cp ./docs/logo* $1/docs/;
+
+all: clean windows osx linux arm6
+
+clean:
+	rm -rf $(BUILD)
+	mkdir -p $(BUILD)
+
+windows:
+	GOOS=windows GOARCH=amd64 go build $(SOURCE)
+	$(call add-files,$(WIN))
+	mv oragono.exe $(WIN)
+	cd $(WIN) && zip -r ../oragono-$(VERS)-windows.zip *
+
+osx:
+	GOOS=darwin GOARCH=amd64 go build oragono.go
+	$(call add-files,$(OSX))
+	mv oragono $(OSX)
+	cd $(OSX) && tar -czvf ../oragono-$(VERS)-osx.tgz *
+
+linux:
+	GOOS=linux GOARCH=amd64 go build oragono.go
+	$(call add-files,$(LINUX))
+	mv oragono $(LINUX)
+	cd $(LINUX) && tar -czvf ../oragono-$(VERS)-linux.tgz *
+
+arm6:
+	GOARM=6 GOARCH=arm go build oragono.go
+	$(call add-files,$(ARM6))
+	mv oragono $(ARM6)
+	cd $(ARM6) && tar -czvf ../oragono-$(VERS)-arm.tgz *

--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ You can also install this repo and use that instead! However, keep some things i
 
 The `master` branch _should_ usually be stable, but may contain database changes that either have not been finalised or not had database upgrade code written yet. Don't run `master` on a live production network. If you'd like to, run the latest tagged version in production instead.
 
+from the root folder, run make (for all target systems/release)
+```
+make
+```
+
+or restrict to a specific target system
+```
+# for windows
+make windows
+
+# for linux
+make linux
+
+# for osx
+make osx
+
+# for arm6
+make arm6
+```
+
 ## Configuration
 
 The default config file [`oragono.yaml`](oragono.yaml) helps walk you through what each option means and changes. The configuration's intended to be sparse, so if there are options missing it's either because that feature isn't written/configurable yet or because we don't think it should be configurable.


### PR DESCRIPTION
This would help me (and others doing clone and/or builds from source) - so only some target systems can be built.

In theory this would replace the `build.sh` script but I didn't want to drop that if you wanted to still use it short term. I did my best to run both `build.sh` and `make` and compare directory outputs and nothing looked amiss from that (for what it is worth).