### PR TITLE
Adds Docker support for Oragono by adding a Dockerfile and Stackfile (docker-compose.yml)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:alpine
+
+EXPOSE 6667/tcp 6697/tcp 8080/tcp
+
+RUN \
+    apk add --update git && \
+    rm -rf /var/cache/apk/*
+
+RUN mkdir -p /go/src/github.com/oragono/oragono
+WORKDIR /go/src/github.com/oragono/oragono
+
+COPY . /go/src/github.com/oragono/oragono
+
+RUN go get -v -d
+RUN go build .
+
+CMD ["./run.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.2"
+
+services:
+  oragono:
+    image: oragono/oragono
+    ports:
+      - "6667:6667/tcp"
+      - "6697:6697/tcp"
+    deploy:
+      placement:
+        constraints:
+          - "node.role == manager"
+      restart_policy:
+        condition: on-failure
+      replicas: 1
+
+networks:
+  traefik:
+    external: true

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+if [ ! -f ./ircd.yaml ]; then
+  cp oragono.yaml ircd.yaml
+fi
+
+if [ ! -f ircd.db ]; then
+  ./oragono initdb
+fi
+
+if [ ! -f tls.crt ]; then
+  ./oragono mkcerts
+fi
+
+./oragono run


### PR DESCRIPTION
TODO:

- Publish this to the [Docker Hub](https://hub.docker.com) -- Really the owner of this project should d this ideally :D

Usage:

```#!bash
docker build oragano/oragono .
docker stack deploy -c docker-compose.yml oragono
```