### PR TITLE
irc: fix timer memleak

### DIFF
--- a/irc/socket.go
+++ b/irc/socket.go
@@ -133,10 +133,12 @@ func (socket *Socket) Write(data string) error {
 
 // timedFillLineToSendExists either sends the note or times out.
 func (socket *Socket) timedFillLineToSendExists(duration time.Duration) {
+	lineToSendTimeout := time.NewTimer(duration)
+	defer lineToSendTimeout.Stop()
 	select {
 	case socket.lineToSendExists <- true:
 		// passed data successfully
-	case <-time.After(duration):
+	case <-lineToSendTimeout.C:
 		// timed out send
 	}
 }


### PR DESCRIPTION
This is a gotcha called out in the `time.After` docs. `time.After` will
leak the underlying channel if nothing ever receives on it.