### PR TITLE
fix hostmask issue

### DIFF
--- a/irc/net.go
+++ b/irc/net.go
@@ -28,16 +28,19 @@ func AddrLookupHostname(addr net.Addr) string {
 // LookupHostname returns the hostname for `addr` if it has one. Otherwise, just returns `addr`.
 func LookupHostname(addr string) string {
 	names, err := net.LookupAddr(addr)
-	if err != nil || len(names) < 1 || !IsHostname(names[0]) {
-		// return original address if no hostname found
-		if len(addr) > 0 && addr[0] == ':' {
-			// fix for IPv6 hostnames (so they don't start with a colon), same as all other IRCds
-			addr = "0" + addr
+	if err == nil && len(names) > 0 {
+		candidate := strings.TrimSuffix(names[0], ".")
+		if IsHostname(candidate) {
+			return candidate
 		}
-		return addr
 	}
 
-	return names[0]
+	// return original address if no hostname found
+	if len(addr) > 0 && addr[0] == ':' {
+		// fix for IPv6 hostnames (so they don't start with a colon), same as all other IRCds
+		addr = "0" + addr
+	}
+	return addr
 }
 
 var allowedHostnameChars = "abcdefghijklmnopqrstuvwxyz1234567890-."


### PR DESCRIPTION
PTR records ending in `.` (e.g., `google-public-dns-b.google.com.`) were considered invalid and therefore the IP address was displayed instead of the hostname. This trims the trailing period.

I think this broke in 5e72409695d34d1b9cd5bfdfa0a22e698effe030 ?