### PR TITLE
implement #132 (configurable default channel modes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ Temporary Items
 # Linux trash folder which might appear on any partition or disk
 .Trash-*
 
+# vim swapfiles
+*.swp
 
 ### Go ###
 # Compiled Object files, Static and Dynamic libs (Shared Objects)

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -57,7 +57,7 @@ func NewChannel(s *Server, name string, addDefaultModes bool) *Channel {
 	}
 
 	if addDefaultModes {
-		for _, mode := range DefaultChannelModes {
+		for _, mode := range s.defaultChannelModes {
 			channel.flags[mode] = true
 		}
 	}

--- a/irc/config.go
+++ b/irc/config.go
@@ -217,6 +217,7 @@ type Config struct {
 	}
 
 	Channels struct {
+		DefaultModes *string `yaml:"default-modes"`
 		Registration ChannelRegistrationConfig
 	}
 

--- a/irc/modes_test.go
+++ b/irc/modes_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2017 Daniel Oaks
+// released under the MIT license
+
+package irc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseDefaultChannelModes(t *testing.T) {
+	nt := "+nt"
+	n := "+n"
+	empty := ""
+	tminusi := "+t -i"
+
+	var parseTests = []struct {
+		raw      *string
+		expected Modes
+	}{
+		{&nt, Modes{NoOutside, OpOnlyTopic}},
+		{&n, Modes{NoOutside}},
+		{&empty, Modes{}},
+		{&tminusi, Modes{OpOnlyTopic}},
+		{nil, Modes{NoOutside, OpOnlyTopic}},
+	}
+
+	var config Config
+	for _, testcase := range parseTests {
+		config.Channels.DefaultModes = testcase.raw
+		result := ParseDefaultChannelModes(&config)
+		if !reflect.DeepEqual(result, testcase.expected) {
+			t.Errorf("expected modes %s, got %s", testcase.expected, result)
+		}
+	}
+}

--- a/irc/server.go
+++ b/irc/server.go
@@ -97,6 +97,7 @@ type Server struct {
 	connectionThrottleMutex      sync.Mutex // used when affecting the connection limiter, to make sure rehashing doesn't make things go out-of-whack
 	ctime                        time.Time
 	currentOpers                 map[*Client]bool
+	defaultChannelModes          Modes
 	dlines                       *DLineManager
 	isupport                     *ISupportList
 	klines                       *KLineManager
@@ -205,6 +206,7 @@ func NewServer(configFilename string, config *Config, logger *logger.Manager) (*
 		connectionThrottle:           connectionThrottle,
 		ctime:                        time.Now(),
 		currentOpers:                 make(map[*Client]bool),
+		defaultChannelModes:          ParseDefaultChannelModes(config),
 		limits: Limits{
 			AwayLen:        int(config.Limits.AwayLen),
 			ChannelLen:     int(config.Limits.ChannelLen),
@@ -1619,6 +1621,8 @@ func (server *Server) rehash() error {
 	accountReg := NewAccountRegistration(config.Accounts.Registration)
 	server.accountRegistration = &accountReg
 	server.channelRegistrationEnabled = config.Channels.Registration.Enabled
+
+	server.defaultChannelModes = ParseDefaultChannelModes(config)
 
 	// set new sendqueue size
 	if config.Server.MaxSendQBytes != server.MaxSendQBytes {

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -137,6 +137,11 @@ accounts:
 
 # channel options
 channels:
+    # modes that are set when new channels are created
+    # +n is no-external-messages and +t is op-only-topic
+    # see  /QUOTE HELP cmodes  for more channel modes
+    default-modes: +nt
+
     # channel registration - requires an account
     registration:
         # can users register new channels?


### PR DESCRIPTION
Thanks for the pointers!

This should be backwards-compatible: if the line is not present in the config, it should default to `+nt`.