### PR TITLE
refactor create/update/destroy of listeners

### DIFF
--- a/irc/config.go
+++ b/irc/config.go
@@ -368,6 +368,7 @@ func (conf *Config) TLSListeners() map[string]*tls.Config {
 	tlsListeners := make(map[string]*tls.Config)
 	for s, tlsListenersConf := range conf.Server.TLSListeners {
 		config, err := tlsListenersConf.Config()
+		config.ClientAuth = tls.RequestClientCert
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/irc/server.go
+++ b/irc/server.go
@@ -436,10 +436,12 @@ func (server *Server) Run() {
 
 		case <-server.rehashSignal:
 			server.logger.Info("rehash", "Rehashing due to SIGHUP")
-			err := server.rehash()
-			if err != nil {
-				server.logger.Error("rehash", fmt.Sprintln("Failed to rehash:", err.Error()))
-			}
+			go func() {
+				err := server.rehash()
+				if err != nil {
+					server.logger.Error("rehash", fmt.Sprintln("Failed to rehash:", err.Error()))
+				}
+			}()
 
 		case conn := <-server.newConns:
 			// check connection limits


### PR DESCRIPTION
There are a lot of changes here and it's all kind of fiddly, so a careful review would be much appreciated :-)

Here's an overview of the changes:

1. `server.listeners` is now read and written only from `createServer` and `rehash`, not from the listener goroutine. This fixes the crash from #134.
1. I've given up on getting the API to provide a reasonable guarantee of when addresses are safe to rebind to (golang/go#21833). Therefore, the operation of updating a listener no longer stops the existing listener; instead, `rehash()` modifies the listener's `*tls.Config` in place, protected by a mutex. These updates are then picked up every time the listener accepts a connection. (I'm relying on the assumption that uncontended lock acquisition on modern systems is generally fast.) The same mechanism is also used to stop listeners.
1. (Why not use a channel for config updates? Since we no longer interrupt the listener's `Accept()` call to apply config updates, we could rehash multiple times without the listener ever reading from the channel, at which point the channel would fill up and block.)
1. As Vendan on freenode's #go-nuts pointed out to me, instead of using `tls.NewListener`, we can just manually wrap the accepted `TCPConn` in a `tls.Server`, which eliminates the need to destroy the `tls.listener` and replace it with a `net.TCPListener` in the case where `rehash()` removes TLS on a port. This is what `NewListener` does under the hood anyway, so there's no performance penalty; I think all the actual caching is happening inside the `tls.Config` object.
1. rehash() now executes on a separate goroutine. This prevents a deadlock where rehash is trying to stop a listener, the listener needs to hand off a connection to the main goroutine, but the main goroutine is blocked on rehash().

I've tried to stress-test this change somewhat:

1. I built the binary with the `-race`
1. then repeatedly sent oragono `SIGHUP` via a bash loop
1. while repeatedly connecting and disconnecting in another bash loop: `while true; do echo -e "quit\n" | nc localhost 6667; sleep 0.1; done;`
1. and repeatedly changing the listen ports by swapping out the config file in yet another bash loop

but it's easy to imagine that I might have missed something.