### PR TITLE
tweak some defaults

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -29,7 +29,7 @@ const (
 	// QuitTimeout is how long without traffic (after they're considered idle) that clients are killed.
 	QuitTimeout = time.Minute
 	// IdentTimeoutSeconds is how many seconds before our ident (username) check times out.
-	IdentTimeoutSeconds = 5
+	IdentTimeoutSeconds = 1.5
 )
 
 var (

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -79,10 +79,10 @@ server:
         enabled: true
 
         # how wide the cidr should be for IPv4
-        cidr-len-ipv4: 24
+        cidr-len-ipv4: 32
 
         # how wide the cidr should be for IPv6
-        cidr-len-ipv6: 120
+        cidr-len-ipv6: 64
 
         # maximum number of IPs per subnet (defined above by the cird length)
         ips-per-subnet: 16
@@ -108,7 +108,7 @@ server:
         duration: 10m
 
         # maximum number of connections, per subnet, within the given duration
-        max-connections: 12
+        max-connections: 64
 
         # how long to ban offenders for, and the message to use
         # after banning them, the number of connections is reset (which lets you use UNDLINE to unban people)


### PR DESCRIPTION
* Lower ident timeout to 1.5 seconds, as discussed in #oragono
* Enforce connection limits at the granularity of ipv4 /32's and ipv6 /64's
* Raise the limit on number of new connections to 64 every 10 minutes
  (for the benefit of people behind large IPv4 NATs)