### PR TITLE
fix various data races, including 2 introduced by #139

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -94,7 +94,7 @@ func NewClient(server *Server, conn net.Conn, isTLS bool) *Client {
 	go socket.RunSocketWriter()
 	client := &Client{
 		atime:          now,
-		authorized:     server.password == nil,
+		authorized:     server.getPassword() == nil,
 		capabilities:   caps.NewSet(),
 		capState:       CapNone,
 		capVersion:     caps.Cap301,
@@ -182,10 +182,11 @@ func (client *Client) maxlens() (int, int) {
 		maxlenTags = 4096
 	}
 	if client.capabilities.Has(caps.MaxLine) {
-		if client.server.limits.LineLen.Tags > maxlenTags {
-			maxlenTags = client.server.limits.LineLen.Tags
+		limits := client.server.getLimits()
+		if limits.LineLen.Tags > maxlenTags {
+			maxlenTags = limits.LineLen.Tags
 		}
-		maxlenRest = client.server.limits.LineLen.Rest
+		maxlenRest = limits.LineLen.Rest
 	}
 	return maxlenTags, maxlenRest
 }
@@ -679,7 +680,7 @@ func (client *Client) Send(tags *map[string]ircmsg.TagValue, prefix string, comm
 func (client *Client) Notice(text string) {
 	limit := 400
 	if client.capabilities.Has(caps.MaxLine) {
-		limit = client.server.limits.LineLen.Rest - 110
+		limit = client.server.getLimits().LineLen.Rest - 110
 	}
 	lines := wordWrap(text, limit)
 

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2017 Shivaram Lingamneni <slingamn@cs.stanford.edu>
+// released under the MIT license
+
+package irc
+
+func (server *Server) getISupport() *ISupportList {
+	server.configurableStateMutex.RLock()
+	defer server.configurableStateMutex.RUnlock()
+	return server.isupport
+}
+
+func (server *Server) getLimits() Limits {
+	server.configurableStateMutex.RLock()
+	defer server.configurableStateMutex.RUnlock()
+	return server.limits
+}
+
+func (server *Server) getPassword() []byte {
+	server.configurableStateMutex.RLock()
+	defer server.configurableStateMutex.RUnlock()
+	return server.password
+}

--- a/irc/isupport.go
+++ b/irc/isupport.go
@@ -142,7 +142,7 @@ func (il *ISupportList) RegenerateCachedReply() {
 
 // RplISupport outputs our ISUPPORT lines to the client. This is used on connection and in VERSION responses.
 func (client *Client) RplISupport() {
-	for _, tokenline := range client.server.isupport.CachedReply {
+	for _, tokenline := range client.server.getISupport().CachedReply {
 		// ugly trickery ahead
 		client.Send(nil, client.server.name, RPL_ISUPPORT, append([]string{client.nick}, tokenline...)...)
 	}

--- a/irc/nickname.go
+++ b/irc/nickname.go
@@ -34,7 +34,7 @@ func nickHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 		return false
 	}
 
-	if err != nil || len(nicknameRaw) > server.limits.NickLen || restrictedNicknames[nickname] {
+	if err != nil || len(nicknameRaw) > server.getLimits().NickLen || restrictedNicknames[nickname] {
 		client.Send(nil, server.name, ERR_ERRONEUSNICKNAME, client.nick, nicknameRaw, "Erroneous nickname")
 		return false
 	}


### PR DESCRIPTION
I shook loose some data races --- some more harmful than others --- via the following procedure:

1. Build with `-race`
1. Send `SIGHUP` repeatedly in a bash loop
1. Connect, authenticate, and disconnect a client repeatedly using netcat in another bash loop

The two worst races were the ones on `server.name` and `server.caseFoldedName` introduced by #139; even though these were no-op assignments in functional terms (since the server name cannot change at runtime), string assignment is always race-y in Go because strings are [multiword values](https://research.swtch.com/gorace). This patch makes it so they're not assigned to during `Rehash()`.

Apart from that, this patch sets out the pattern for how to resolve other rehash-related races:

1. Configurable server state should be accessed via getter methods that acquire `configurableStateMutex.RLock()`
1. `Rehash()` should acquire `configurableStateMutex.Lock()` when modifying that state
1. In both cases, the locks should be held as briefly as possible (in particular, not across any network calls to clients)