### PR TITLE
fix #148

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,4 @@ deps:
 
 test:
 	cd irc && go test .
+	cd irc && go vet .


### PR DESCRIPTION
````
$ go vet github.com/oragono/oragono/irc
irc/server.go:1605: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
````

I'm still trying to fully understand how context lifecycles work, but this seems to be the correct solution as per:

1. https://blog.golang.org/context
1. https://stackoverflow.com/questions/44393995/what-happens-if-i-dont-cancel-a-context