### PR TITLE
eliminate all Client mutexes other than stateMutex

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -25,12 +25,6 @@ import (
 )
 
 const (
-	// RegisterTimeout is how long clients have to register before we disconnect them
-	RegisterTimeout = time.Minute
-	// IdleTimeout is how long without traffic before a registered client is considered idle.
-	IdleTimeout = time.Minute + time.Second*30
-	// QuitTimeout is how long without traffic before an idle client is disconnected
-	QuitTimeout = time.Minute
 	// IdentTimeoutSeconds is how many seconds before our ident (username) check times out.
 	IdentTimeoutSeconds = 1.5
 )

--- a/irc/client.go
+++ b/irc/client.go
@@ -475,7 +475,7 @@ func (client *Client) RplISupport() {
 	}
 }
 
-// Quit sends the given quit message to the client (but does not destroy them).
+// Quit sets the given quit message for the client and tells the client to quit out.
 func (client *Client) Quit(message string) {
 	client.stateMutex.Lock()
 	alreadyQuit := client.isQuitting

--- a/irc/commands.go
+++ b/irc/commands.go
@@ -39,8 +39,7 @@ func (cmd *Command) Run(server *Server, client *Client, msg ircmsg.IrcMessage) b
 	if !cmd.leaveClientActive {
 		client.Active()
 	}
-	// only touch client if they're registered so that unregistered clients timeout appropriately
-	if client.registered && !cmd.leaveClientIdle {
+	if !cmd.leaveClientIdle {
 		client.Touch()
 	}
 	exiting := cmd.handler(server, client, msg)

--- a/irc/gateways.go
+++ b/irc/gateways.go
@@ -67,9 +67,7 @@ func webircHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 
 	clientAddress := utils.IPString(client.socket.conn.RemoteAddr())
 	clientHostname := client.hostname
-	server.configurableStateMutex.RLock()
-	defer server.configurableStateMutex.RUnlock()
-	for _, info := range server.webirc {
+	for _, info := range server.WebIRCConfig() {
 		for _, address := range info.Hosts {
 			if clientHostname == address || clientAddress == address {
 				// confirm password and/or fingerprint
@@ -101,9 +99,7 @@ func proxyHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 
 	clientAddress := utils.IPString(client.socket.conn.RemoteAddr())
 	clientHostname := client.hostname
-	server.configurableStateMutex.RLock()
-	defer server.configurableStateMutex.RUnlock()
-	for _, address := range server.proxyAllowedFrom {
+	for _, address := range server.ProxyAllowedFrom() {
 		if clientHostname == address || clientAddress == address {
 			proxiedIP := msg.Params[1]
 

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -23,6 +23,18 @@ func (server *Server) getPassword() []byte {
 	return server.password
 }
 
+func (server *Server) ProxyAllowedFrom() []string {
+	server.configurableStateMutex.RLock()
+	defer server.configurableStateMutex.RUnlock()
+	return server.proxyAllowedFrom
+}
+
+func (server *Server) WebIRCConfig() []webircConfig {
+	server.configurableStateMutex.RLock()
+	defer server.configurableStateMutex.RUnlock()
+	return server.webirc
+}
+
 func (client *Client) getNick() string {
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -40,3 +40,15 @@ func (client *Client) getNickCasefolded() string {
 	defer client.stateMutex.RUnlock()
 	return client.nickCasefolded
 }
+
+func (client *Client) Registered() bool {
+	client.stateMutex.RLock()
+	defer client.stateMutex.RUnlock()
+	return client.registered
+}
+
+func (client *Client) Destroyed() bool {
+	client.stateMutex.RLock()
+	defer client.stateMutex.RUnlock()
+	return client.isDestroyed
+}

--- a/irc/idletimer.go
+++ b/irc/idletimer.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2017 Shivaram Lingamneni <slingamn@cs.stanford.edu>
+// released under the MIT license
+
+package irc
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// client idleness state machine
+
+type TimerState uint
+
+const (
+	TimerUnregistered TimerState = iota // client is unregistered
+	TimerActive                         // client is actively sending commands
+	TimerIdle                           // client is idle, we sent PING and are waiting for PONG
+)
+
+type IdleTimer struct {
+	sync.Mutex
+
+	// immutable after construction
+	registerTimeout time.Duration
+	idleTimeout     time.Duration
+	quitTimeout     time.Duration
+
+	// mutable
+	client   *Client
+	state    TimerState
+	lastSeen time.Time
+}
+
+// NewIdleTimer sets up a new IdleTimer using constant timeouts.
+func NewIdleTimer(client *Client) *IdleTimer {
+	it := IdleTimer{
+		registerTimeout: RegisterTimeout,
+		idleTimeout:     IdleTimeout,
+		quitTimeout:     QuitTimeout,
+		client:          client,
+		state:           TimerUnregistered,
+	}
+	return &it
+}
+
+// Start starts counting idle time; if there is no activity from the client,
+// it will eventually be stopped.
+func (it *IdleTimer) Start() {
+	it.Lock()
+	it.lastSeen = time.Now()
+	it.Unlock()
+	go it.mainLoop()
+}
+
+func (it *IdleTimer) mainLoop() {
+	for {
+		it.Lock()
+		client := it.client
+		state := it.state
+		lastSeen := it.lastSeen
+		it.Unlock()
+
+		if client == nil {
+			return
+		}
+
+		registered := client.Registered()
+		now := time.Now()
+		idleTime := now.Sub(lastSeen)
+		newState := state
+
+		switch state {
+		case TimerUnregistered:
+			if registered {
+				// transition to TimerActive state
+				newState = TimerActive
+			}
+		case TimerActive:
+			if idleTime >= IdleTimeout {
+				newState = TimerIdle
+				client.Ping()
+			}
+		case TimerIdle:
+			if idleTime < IdleTimeout {
+				// new ping came in after we transitioned to TimerIdle
+				newState = TimerActive
+			}
+		}
+
+		it.Lock()
+		it.state = newState
+		it.Unlock()
+
+		var nextSleep time.Duration
+		switch newState {
+		case TimerUnregistered:
+			nextSleep = it.registerTimeout - idleTime
+		case TimerActive:
+			nextSleep = it.idleTimeout - idleTime
+		case TimerIdle:
+			nextSleep = (it.idleTimeout + it.quitTimeout) - idleTime
+		}
+
+		if nextSleep <= 0 {
+			// ran out of time, hang them up
+			client.Quit(it.quitMessage(newState))
+			client.destroy()
+			return
+		}
+
+		time.Sleep(nextSleep)
+	}
+}
+
+// Touch registers activity (e.g., sending a command) from an client.
+func (it *IdleTimer) Touch() {
+	it.Lock()
+	client := it.client
+	it.Unlock()
+
+	// ignore touches for unregistered clients
+	if client != nil && !client.Registered() {
+		return
+	}
+
+	it.Lock()
+	it.lastSeen = time.Now()
+	it.Unlock()
+}
+
+// Stop stops counting idle time.
+func (it *IdleTimer) Stop() {
+	it.Lock()
+	defer it.Unlock()
+	// no need to stop the goroutine, it'll clean itself up in a few minutes;
+	// just ensure the Client object is collectable
+	it.client = nil
+}
+
+func (it *IdleTimer) quitMessage(state TimerState) string {
+	switch state {
+	case TimerUnregistered:
+		return fmt.Sprintf("Registration timeout: %v", it.registerTimeout)
+	case TimerIdle:
+		// how many seconds before registered clients are timed out (IdleTimeout plus QuitTimeout).
+		return fmt.Sprintf("Ping timeout: %v", (it.idleTimeout + it.quitTimeout))
+	default:
+		// shouldn't happen
+		return ""
+	}
+}

--- a/irc/server.go
+++ b/irc/server.go
@@ -415,7 +415,7 @@ func (server *Server) tryRegister(c *Client) {
 		if info.Time != nil {
 			reason += fmt.Sprintf(" [%s]", info.Time.Duration.String())
 		}
-		c.Send(nil, "", "ERROR", fmt.Sprintf("You are banned from this server (%s)", reason))
+		c.Quit(fmt.Sprintf("You are banned from this server (%s)", reason))
 		c.destroy()
 		return
 	}

--- a/irc/server.go
+++ b/irc/server.go
@@ -416,7 +416,6 @@ func (server *Server) tryRegister(c *Client) {
 			reason += fmt.Sprintf(" [%s]", info.Time.Duration.String())
 		}
 		c.Send(nil, "", "ERROR", fmt.Sprintf("You are banned from this server (%s)", reason))
-		c.quitMessageSent = true
 		c.destroy()
 		return
 	}


### PR DESCRIPTION
A few different things happening (hopefully mostly separated by commits):

1. Eliminate `Client.quitMutex` and `Client.destroyMutex` in favor of `stateMutex`
1. Eliminate `Client.timerMutex` and the whole timer setup, which didn't work correctly (instead falling back to the TCP implementation's timeouts). This breaks out the timeout setup into a separate type that implements a state machine. (The state machine doesn't use `time.Timer` because `Timer.Reset()` apparently has [esoteric race conditions](https://golang.org/pkg/time/#Timer.Reset) requiring client workarounds.)
1. Code outside the core `Server` implementation shouldn't acquire `configurableStateMutex` (a tier 1 mutex) on its own; rather, it should defer to getters.

There are a lot of potential edge cases in the timeout stuff. I've tested the core cases manually: pre-registration timeouts, successful keepalive via PING and PONG, and timeout of active connections after failure to respond to server PING. The setup is "mockable" enough that I could potentially write unit tests (with mocks replacing `time.Now()` and `time.Sleep()`), but I'm not sure how much more confidence they'd provide in themselves.