### PR TITLE
refactor synchronization for Channel

### DIFF
--- a/irc/chanserv.go
+++ b/irc/chanserv.go
@@ -105,16 +105,13 @@ func (server *Server) chanservReceivePrivmsg(client *Client, message string) {
 			server.logger.Info("chanserv", fmt.Sprintf("Client %s registered channel %s", client.nick, channelName))
 			server.snomasks.Send(sno.LocalChannels, fmt.Sprintf(ircfmt.Unescape("Channel registered $c[grey][$r%s$c[grey]] by $c[grey][$r%s$c[grey]]"), channelName, client.nickMaskString))
 
-			channelInfo.membersMutex.Lock()
-			defer channelInfo.membersMutex.Unlock()
-
 			// give them founder privs
 			change := channelInfo.applyModeMemberNoMutex(client, ChannelFounder, Add, client.nickCasefolded)
 			if change != nil {
 				//TODO(dan): we should change the name of String and make it return a slice here
 				//TODO(dan): unify this code with code in modes.go
 				args := append([]string{channelName}, strings.Split(change.String(), " ")...)
-				for member := range channelInfo.members {
+				for _, member := range channelInfo.Members() {
 					member.Send(nil, fmt.Sprintf("ChanServ!services@%s", client.server.name), "MODE", args...)
 				}
 			}

--- a/irc/modes.go
+++ b/irc/modes.go
@@ -327,17 +327,16 @@ func (client *Client) applyUserModeChanges(force bool, changes ModeChanges) Mode
 // MODE <target> [<modestring> [<mode arguments>...]]
 func umodeHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 	nickname, err := CasefoldName(msg.Params[0])
-
 	target := server.clients.Get(nickname)
-	targetNick := target.getNick()
-	hasPrivs := client == target || msg.Command == "SAMODE"
-
 	if err != nil || target == nil {
 		if len(msg.Params[0]) > 0 {
 			client.Send(nil, server.name, ERR_NOSUCHNICK, client.nick, msg.Params[0], "No such nick")
 		}
 		return false
 	}
+
+	targetNick := target.getNick()
+	hasPrivs := client == target || msg.Command == "SAMODE"
 
 	if !hasPrivs {
 		if len(msg.Params) > 1 {

--- a/irc/roleplay.go
+++ b/irc/roleplay.go
@@ -88,14 +88,12 @@ func sendRoleplayMessage(server *Server, client *Client, source string, targetSt
 			return
 		}
 
-		channel.membersMutex.RLock()
-		for member := range channel.members {
+		for _, member := range channel.Members() {
 			if member == client && !client.capabilities.Has(caps.EchoMessage) {
 				continue
 			}
 			member.Send(nil, source, "PRIVMSG", channel.name, message)
 		}
-		channel.membersMutex.RUnlock()
 	} else {
 		target, err := CasefoldName(targetString)
 		user := server.clients.Get(target)

--- a/irc/types.go
+++ b/irc/types.go
@@ -139,13 +139,3 @@ func (members MemberSet) AnyHasMode(mode Mode) bool {
 
 // ChannelSet is a set of channels.
 type ChannelSet map[*Channel]bool
-
-// Add adds the given channel to this set.
-func (channels ChannelSet) Add(channel *Channel) {
-	channels[channel] = true
-}
-
-// Remove removes the given channel from this set.
-func (channels ChannelSet) Remove(channel *Channel) {
-	delete(channels, channel)
-}


### PR DESCRIPTION
This eliminates `Channel.membersMutex` in favor of a finer-grained (tier 1) mutex, `Channel.stateMutex`. Lots of moving parts, unfortunately.

`Channel.Members()` returns a cached slice of the current channel members. This allows code external to `Channel` to iterate over the members without holding any locks. Normally, this would raise a concern about turning O(1) map writes into O(n) operations, but in this context, we send O(n) messages to the preexisting/remaining channel members after any join or part, so it's fine.