### PR TITLE
recover from client-caused panics

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -184,6 +184,15 @@ func (client *Client) run() {
 	var line string
 	var msg ircmsg.IrcMessage
 
+	defer func() {
+		if r := recover(); r != nil {
+			client.server.logger.Error("internal", fmt.Sprintf("Client caused panic, disconnecting: %v", r))
+			debug.PrintStack()
+		}
+		// ensure client connection gets closed
+		client.destroy()
+	}()
+
 	client.idletimer = NewIdleTimer(client)
 	client.idletimer.Start()
 
@@ -225,9 +234,6 @@ func (client *Client) run() {
 			break
 		}
 	}
-
-	// ensure client connection gets closed
-	client.destroy()
 }
 
 //

--- a/irc/client.go
+++ b/irc/client.go
@@ -186,8 +186,8 @@ func (client *Client) run() {
 
 	defer func() {
 		if r := recover(); r != nil {
-			client.server.logger.Error("internal", fmt.Sprintf("Client caused panic, disconnecting: %v", r))
-			debug.PrintStack()
+			client.server.logger.Error("internal",
+				fmt.Sprintf("Client caused panic, disconnecting: %v\n%s", r, debug.Stack()))
 		}
 		// ensure client connection gets closed
 		client.destroy()

--- a/irc/client.go
+++ b/irc/client.go
@@ -185,9 +185,11 @@ func (client *Client) run() {
 	var msg ircmsg.IrcMessage
 
 	defer func() {
-		if r := recover(); r != nil {
-			client.server.logger.Error("internal",
-				fmt.Sprintf("Client caused panic, disconnecting: %v\n%s", r, debug.Stack()))
+		if client.server.RecoverFromErrors() {
+			if r := recover(); r != nil {
+				client.server.logger.Error("internal",
+					fmt.Sprintf("Client caused panic, disconnecting: %v\n%s", r, debug.Stack()))
+			}
 		}
 		// ensure client connection gets closed
 		client.destroy()

--- a/irc/client.go
+++ b/irc/client.go
@@ -185,10 +185,13 @@ func (client *Client) run() {
 	var msg ircmsg.IrcMessage
 
 	defer func() {
-		if client.server.RecoverFromErrors() {
-			if r := recover(); r != nil {
-				client.server.logger.Error("internal",
-					fmt.Sprintf("Client caused panic, disconnecting: %v\n%s", r, debug.Stack()))
+		if r := recover(); r != nil {
+			client.server.logger.Error("internal",
+				fmt.Sprintf("Client caused panic: %v\n%s", r, debug.Stack()))
+			if client.server.RecoverFromErrors() {
+				client.server.logger.Error("internal", "Disconnecting client and attempting to recover")
+			} else {
+				panic(r)
 			}
 		}
 		// ensure client connection gets closed

--- a/irc/config.go
+++ b/irc/config.go
@@ -188,7 +188,8 @@ type Config struct {
 	Logging []logger.LoggingConfig
 
 	Debug struct {
-		StackImpact StackImpactConfig
+		RecoverFromErrors *bool `yaml:"recover-from-errors"`
+		StackImpact       StackImpactConfig
 	}
 
 	Limits struct {

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -23,6 +23,12 @@ func (server *Server) getPassword() []byte {
 	return server.password
 }
 
+func (server *Server) RecoverFromErrors() bool {
+	server.configurableStateMutex.RLock()
+	defer server.configurableStateMutex.RUnlock()
+	return server.recoverFromErrors
+}
+
 func (server *Server) ProxyAllowedFrom() []string {
 	server.configurableStateMutex.RLock()
 	defer server.configurableStateMutex.RUnlock()

--- a/irc/server.go
+++ b/irc/server.go
@@ -109,6 +109,7 @@ type Server struct {
 	operclasses                  map[string]OperClass
 	password                     []byte
 	passwords                    *passwd.SaltedManager
+	recoverFromErrors            bool
 	registeredChannels           map[string]*RegisteredChannel
 	registeredChannelsMutex      sync.RWMutex
 	rehashMutex                  sync.Mutex
@@ -1250,21 +1251,23 @@ func (server *Server) applyConfig(config *Config, initial bool) error {
 		server.name = config.Server.Name
 		server.nameCasefolded = casefoldedName
 	}
-	server.networkName = config.Network.Name
 
 	server.configurableStateMutex.Lock()
+	server.networkName = config.Network.Name
 	if config.Server.Password != "" {
 		server.password = config.Server.PasswordBytes()
 	} else {
 		server.password = nil
 	}
-	server.configurableStateMutex.Unlock()
-
 	// apply new WebIRC command restrictions
 	server.webirc = config.Server.WebIRC
-
 	// apply new PROXY command restrictions
 	server.proxyAllowedFrom = config.Server.ProxyAllowedFrom
+	server.recoverFromErrors = true
+	if config.Debug.RecoverFromErrors != nil {
+		server.recoverFromErrors = *config.Debug.RecoverFromErrors
+	}
+	server.configurableStateMutex.Unlock()
 
 	err = server.connectionLimiter.ApplyConfig(config.Server.ConnectionLimiter)
 	if err != nil {

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -267,6 +267,14 @@ logging:
 
 # debug options
 debug:
+    # when enabled, oragono will attempt to recover from certain kinds of
+    # client-triggered runtime errors that would normally crash the server.
+    # this makes the server more resilient to DoS, but could result in incorrect
+    # behavior. deployments that would prefer to "start from scratch", e.g., by
+    # letting the process crash and auto-restarting it with systemd, can set
+    # this to false.
+    recover-from-errors: true
+
     # enabling StackImpact profiling
     stackimpact:
         # whether to use StackImpact


### PR DESCRIPTION
I accidentally wrote an edge case with a nil dereference over on #155. Then I fixed it, but it seems like we can mostly just work around them using the `recover()` function.

To test this change, I reverted 2791476f16634ae664fbd86a946de09fe1f7fa9b and triggered the underlying crash. The following output was logged (the first line via the logging mechanism, and the rest to stderr directly): https://gist.github.com/slingamn/661b326b5b0cafca36fcb8cb7e4dde17

Other clients, and the overall server state, were not disrupted.

Any concerns about logging private data? It's vaguely possible that something private could be in the string value of the panic itself, but the stack trace seems fine to me.