### PR TITLE
remove channelJoinPartMutex

### DIFF
--- a/irc/channelmanager.go
+++ b/irc/channelmanager.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2017 Shivaram Lingamneni <slingamn@cs.stanford.edu>
+// released under the MIT license
+
+package irc
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	InvalidChannelName = errors.New("Invalid channel name")
+	NoSuchChannel      = errors.New("No such channel")
+	ChannelNameInUse   = errors.New("Channel name in use")
+)
+
+type channelManagerEntry struct {
+	channel *Channel
+	// this is a refcount for joins, so we can avoid a race where we incorrectly
+	// think the channel is empty (without holding a lock across the entire Channel.Join()
+	// call)
+	pendingJoins int
+}
+
+// ChannelManager keeps track of all the channels on the server,
+// providing synchronization for creation of new channels on first join,
+// cleanup of empty channels on last part, and renames.
+type ChannelManager struct {
+	sync.RWMutex // tier 2
+	chans        map[string]*channelManagerEntry
+}
+
+// NewChannelManager returns a new ChannelManager.
+func NewChannelManager() *ChannelManager {
+	return &ChannelManager{
+		chans: make(map[string]*channelManagerEntry),
+	}
+}
+
+// Get returns an existing channel with name equivalent to `name`, or nil
+func (cm *ChannelManager) Get(name string) *Channel {
+	name, err := CasefoldChannel(name)
+	if err == nil {
+		cm.RLock()
+		defer cm.RUnlock()
+		return cm.chans[name].channel
+	}
+	return nil
+}
+
+// Join causes `client` to join the channel named `name`, creating it if necessary.
+func (cm *ChannelManager) Join(client *Client, name string, key string) error {
+	server := client.server
+	casefoldedName, err := CasefoldChannel(name)
+	if err != nil || len(casefoldedName) > server.getLimits().ChannelLen {
+		return NoSuchChannel
+	}
+
+	cm.Lock()
+	entry := cm.chans[casefoldedName]
+	if entry == nil {
+		entry = &channelManagerEntry{
+			channel:      NewChannel(server, name, true),
+			pendingJoins: 0,
+		}
+		cm.chans[casefoldedName] = entry
+	}
+	entry.pendingJoins += 1
+	cm.Unlock()
+
+	entry.channel.Join(client, key)
+
+	cm.maybeCleanup(entry, true)
+
+	return nil
+}
+
+func (cm *ChannelManager) maybeCleanup(entry *channelManagerEntry, afterJoin bool) {
+	cm.Lock()
+	defer cm.Unlock()
+
+	if entry.channel == nil {
+		return
+	}
+	if afterJoin {
+		entry.pendingJoins -= 1
+	}
+	if entry.channel.IsEmpty() && entry.pendingJoins == 0 {
+		// reread the name, handling the case where the channel was renamed
+		casefoldedName := entry.channel.NameCasefolded()
+		delete(cm.chans, casefoldedName)
+		// invalidate the entry (otherwise, a subsequent cleanup attempt could delete
+		// a valid, distinct entry under casefoldedName):
+		entry.channel = nil
+	}
+}
+
+// Part parts `client` from the channel named `name`, deleting it if it's empty.
+func (cm *ChannelManager) Part(client *Client, name string, message string) error {
+	casefoldedName, err := CasefoldChannel(name)
+	if err != nil {
+		return NoSuchChannel
+	}
+
+	cm.RLock()
+	entry := cm.chans[casefoldedName]
+	cm.RUnlock()
+
+	if entry == nil {
+		return NoSuchChannel
+	}
+	entry.channel.Part(client, message)
+	cm.maybeCleanup(entry, false)
+	return nil
+}
+
+// Rename renames a channel (but does not notify the members)
+func (cm *ChannelManager) Rename(name string, newname string) error {
+	cfname, err := CasefoldChannel(name)
+	if err != nil {
+		return NoSuchChannel
+	}
+
+	cfnewname, err := CasefoldChannel(newname)
+	if err != nil {
+		return InvalidChannelName
+	}
+
+	cm.Lock()
+	defer cm.Unlock()
+
+	if cm.chans[cfnewname] != nil {
+		return ChannelNameInUse
+	}
+	entry := cm.chans[cfname]
+	if entry == nil {
+		return NoSuchChannel
+	}
+	delete(cm.chans, cfname)
+	cm.chans[cfnewname] = entry
+	entry.channel.setName(newname)
+	entry.channel.setNameCasefolded(cfnewname)
+	return nil
+
+}
+
+// Len returns the number of channels
+func (cm *ChannelManager) Len() int {
+	cm.RLock()
+	defer cm.RUnlock()
+	return len(cm.chans)
+}
+
+// Channels returns a slice containing all current channels
+func (cm *ChannelManager) Channels() (result []*Channel) {
+	cm.RLock()
+	defer cm.RUnlock()
+	for _, entry := range cm.chans {
+		result = append(result, entry.channel)
+	}
+	return
+}

--- a/irc/client.go
+++ b/irc/client.go
@@ -548,14 +548,12 @@ func (client *Client) destroy() {
 	client.server.monitorManager.RemoveAll(client)
 
 	// clean up channels
-	client.server.channelJoinPartMutex.Lock()
-	for channel := range client.channels {
+	for _, channel := range client.Channels() {
 		channel.Quit(client)
 		for _, member := range channel.Members() {
 			friends.Add(member)
 		}
 	}
-	client.server.channelJoinPartMutex.Unlock()
 
 	// clean up server
 	client.server.clients.Remove(client)

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -41,6 +41,12 @@ func (server *Server) WebIRCConfig() []webircConfig {
 	return server.webirc
 }
 
+func (server *Server) DefaultChannelModes() Modes {
+	server.configurableStateMutex.RLock()
+	defer server.configurableStateMutex.RUnlock()
+	return server.defaultChannelModes
+}
+
 func (client *Client) getNick() string {
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()
@@ -112,6 +118,24 @@ func (channel *Channel) Name() string {
 	channel.stateMutex.RLock()
 	defer channel.stateMutex.RUnlock()
 	return channel.name
+}
+
+func (channel *Channel) setName(name string) {
+	channel.stateMutex.Lock()
+	defer channel.stateMutex.Unlock()
+	channel.name = name
+}
+
+func (channel *Channel) NameCasefolded() string {
+	channel.stateMutex.RLock()
+	defer channel.stateMutex.RUnlock()
+	return channel.nameCasefolded
+}
+
+func (channel *Channel) setNameCasefolded(nameCasefolded string) {
+	channel.stateMutex.Lock()
+	defer channel.stateMutex.Unlock()
+	channel.nameCasefolded = nameCasefolded
 }
 
 func (channel *Channel) Members() (result []*Client) {

--- a/irc/monitor.go
+++ b/irc/monitor.go
@@ -52,12 +52,9 @@ func (manager *MonitorManager) AlertAbout(client *Client, online bool) {
 		command = RPL_MONONLINE
 	}
 
-	// asynchronously send all the notifications
-	go func() {
-		for _, mClient := range watchers {
-			mClient.Send(nil, client.server.name, command, mClient.getNick(), nick)
-		}
-	}()
+	for _, mClient := range watchers {
+		mClient.Send(nil, client.server.name, command, mClient.getNick(), nick)
+	}
 }
 
 // Add registers `client` to receive notifications about `nick`.

--- a/irc/types.go
+++ b/irc/types.go
@@ -6,63 +6,8 @@
 package irc
 
 import (
-	"fmt"
 	"strings"
-	"sync"
 )
-
-// ChannelNameMap is a map that converts channel names to actual channel objects.
-type ChannelNameMap struct {
-	ChansLock sync.RWMutex
-	Chans     map[string]*Channel
-}
-
-// NewChannelNameMap returns a new ChannelNameMap.
-func NewChannelNameMap() *ChannelNameMap {
-	var channels ChannelNameMap
-	channels.Chans = make(map[string]*Channel)
-	return &channels
-}
-
-// Get returns the given channel if it exists.
-func (channels *ChannelNameMap) Get(name string) *Channel {
-	name, err := CasefoldChannel(name)
-	if err == nil {
-		channels.ChansLock.RLock()
-		defer channels.ChansLock.RUnlock()
-		return channels.Chans[name]
-	}
-	return nil
-}
-
-// Add adds the given channel to our map.
-func (channels *ChannelNameMap) Add(channel *Channel) error {
-	channels.ChansLock.Lock()
-	defer channels.ChansLock.Unlock()
-	if channels.Chans[channel.nameCasefolded] != nil {
-		return fmt.Errorf("%s: already set", channel.name)
-	}
-	channels.Chans[channel.nameCasefolded] = channel
-	return nil
-}
-
-// Remove removes the given channel from our map.
-func (channels *ChannelNameMap) Remove(channel *Channel) error {
-	channels.ChansLock.Lock()
-	defer channels.ChansLock.Unlock()
-	if channel != channels.Chans[channel.nameCasefolded] {
-		return fmt.Errorf("%s: mismatch", channel.name)
-	}
-	delete(channels.Chans, channel.nameCasefolded)
-	return nil
-}
-
-// Len returns how many channels we have.
-func (channels *ChannelNameMap) Len() int {
-	channels.ChansLock.RLock()
-	defer channels.ChansLock.RUnlock()
-	return len(channels.Chans)
-}
 
 // ModeSet holds a set of modes.
 type ModeSet map[Mode]bool


### PR DESCRIPTION
This splits out channel name synchronization into a separate `ChannelManager` type protected by a tier-2 mutex, removing `channelJoinPartMutex`.

My Hexchat install doesn't correctly interpret Oragono's `/rename` responses (it gets the JOIN and PART messages, but it doesn't correctly display the WHO list or attempt to read the topic). I'm guessing some of this is Hexchat's fault? Anyway, this branch doesn't change the behavior there AFAICT, it's just something we might want to look into later.