### PR TITLE
rename some getters

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -211,9 +211,9 @@ func (channel *Channel) nicks(target *Client) []string {
 	i = 0
 	for i < length {
 		if isUserhostInNames {
-			result[i] += clients[i].getNickMaskString()
+			result[i] += clients[i].NickMaskString()
 		} else {
-			result[i] += clients[i].getNick()
+			result[i] += clients[i].Nick()
 		}
 		i++
 	}
@@ -644,7 +644,7 @@ func (channel *Channel) ShowMaskList(client *Client, mode Mode) {
 		rplendoflist = RPL_ENDOFINVITELIST
 	}
 
-	nick := client.getNick()
+	nick := client.Nick()
 	channel.stateMutex.RLock()
 	// XXX don't acquire any new locks in this section, besides Socket.Write
 	for mask := range channel.lists[mode].masks {
@@ -711,13 +711,13 @@ func (channel *Channel) Kick(client *Client, target *Client, comment string) {
 		return
 	}
 
-	kicklimit := client.server.getLimits().KickLen
+	kicklimit := client.server.Limits().KickLen
 	if len(comment) > kicklimit {
 		comment = comment[:kicklimit]
 	}
 
-	clientMask := client.getNickMaskString()
-	targetNick := target.getNick()
+	clientMask := client.NickMaskString()
+	targetNick := target.Nick()
 	for _, member := range channel.Members() {
 		member.Send(nil, clientMask, "KICK", channel.name, targetNick, comment)
 	}
@@ -739,7 +739,7 @@ func (channel *Channel) Invite(invitee *Client, inviter *Client) {
 
 	//TODO(dan): handle this more nicely, keep a list of last X invited channels on invitee rather than explicitly modifying the invite list?
 	if channel.flags[InviteOnly] {
-		nmc := invitee.getNickCasefolded()
+		nmc := invitee.NickCasefolded()
 		channel.stateMutex.Lock()
 		channel.lists[InviteMask].Add(nmc)
 		channel.stateMutex.Unlock()
@@ -747,7 +747,7 @@ func (channel *Channel) Invite(invitee *Client, inviter *Client) {
 
 	for _, member := range channel.Members() {
 		if member.capabilities.Has(caps.InviteNotify) && member != inviter && member != invitee && channel.ClientIsAtLeast(member, Halfop) {
-			member.Send(nil, inviter.getNickMaskString(), "INVITE", invitee.getNick(), channel.name)
+			member.Send(nil, inviter.NickMaskString(), "INVITE", invitee.Nick(), channel.name)
 		}
 	}
 

--- a/irc/channelmanager.go
+++ b/irc/channelmanager.go
@@ -52,7 +52,7 @@ func (cm *ChannelManager) Get(name string) *Channel {
 func (cm *ChannelManager) Join(client *Client, name string, key string) error {
 	server := client.server
 	casefoldedName, err := CasefoldChannel(name)
-	if err != nil || len(casefoldedName) > server.getLimits().ChannelLen {
+	if err != nil || len(casefoldedName) > server.Limits().ChannelLen {
 		return NoSuchChannel
 	}
 

--- a/irc/client.go
+++ b/irc/client.go
@@ -86,7 +86,7 @@ func NewClient(server *Server, conn net.Conn, isTLS bool) *Client {
 	go socket.RunSocketWriter()
 	client := &Client{
 		atime:          now,
-		authorized:     server.getPassword() == nil,
+		authorized:     server.Password() == nil,
 		capabilities:   caps.NewSet(),
 		capState:       CapNone,
 		capVersion:     caps.Cap301,
@@ -173,7 +173,7 @@ func (client *Client) recomputeMaxlens() (int, int) {
 		maxlenTags = 4096
 	}
 	if client.capabilities.Has(caps.MaxLine) {
-		limits := client.server.getLimits()
+		limits := client.server.Limits()
 		if limits.LineLen.Tags > maxlenTags {
 			maxlenTags = limits.LineLen.Tags
 		}
@@ -486,7 +486,7 @@ func (client *Client) LoggedIntoAccount() bool {
 
 // RplISupport outputs our ISUPPORT lines to the client. This is used on connection and in VERSION responses.
 func (client *Client) RplISupport() {
-	for _, tokenline := range client.server.getISupport().CachedReply {
+	for _, tokenline := range client.server.ISupport().CachedReply {
 		// ugly trickery ahead
 		client.Send(nil, client.server.name, RPL_ISUPPORT, append([]string{client.nick}, tokenline...)...)
 	}
@@ -679,7 +679,7 @@ func (client *Client) Send(tags *map[string]ircmsg.TagValue, prefix string, comm
 func (client *Client) Notice(text string) {
 	limit := 400
 	if client.capabilities.Has(caps.MaxLine) {
-		limit = client.server.getLimits().LineLen.Rest - 110
+		limit = client.server.Limits().LineLen.Rest - 110
 	}
 	lines := wordWrap(text, limit)
 

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -5,19 +5,19 @@ package irc
 
 import "github.com/oragono/oragono/irc/isupport"
 
-func (server *Server) getISupport() *isupport.List {
+func (server *Server) ISupport() *isupport.List {
 	server.configurableStateMutex.RLock()
 	defer server.configurableStateMutex.RUnlock()
 	return server.isupport
 }
 
-func (server *Server) getLimits() Limits {
+func (server *Server) Limits() Limits {
 	server.configurableStateMutex.RLock()
 	defer server.configurableStateMutex.RUnlock()
 	return server.limits
 }
 
-func (server *Server) getPassword() []byte {
+func (server *Server) Password() []byte {
 	server.configurableStateMutex.RLock()
 	defer server.configurableStateMutex.RUnlock()
 	return server.password
@@ -47,19 +47,19 @@ func (server *Server) DefaultChannelModes() Modes {
 	return server.defaultChannelModes
 }
 
-func (client *Client) getNick() string {
+func (client *Client) Nick() string {
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()
 	return client.nick
 }
 
-func (client *Client) getNickMaskString() string {
+func (client *Client) NickMaskString() string {
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()
 	return client.nickMaskString
 }
 
-func (client *Client) getNickCasefolded() string {
+func (client *Client) NickCasefolded() string {
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()
 	return client.nickCasefolded

--- a/irc/modes.go
+++ b/irc/modes.go
@@ -335,7 +335,7 @@ func umodeHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 		return false
 	}
 
-	targetNick := target.getNick()
+	targetNick := target.Nick()
 	hasPrivs := client == target || msg.Command == "SAMODE"
 
 	if !hasPrivs {
@@ -513,9 +513,9 @@ func (channel *Channel) ApplyChannelModeChanges(client *Client, isSamode bool, c
 
 			switch change.op {
 			case Add:
-				if channel.lists[change.mode].Length() >= client.server.getLimits().ChanListModes {
+				if channel.lists[change.mode].Length() >= client.server.Limits().ChanListModes {
 					if !listFullWarned[change.mode] {
-						client.Send(nil, client.server.name, ERR_BANLISTFULL, client.getNick(), channel.Name(), change.mode.String(), "Channel list is full")
+						client.Send(nil, client.server.name, ERR_BANLISTFULL, client.Nick(), channel.Name(), change.mode.String(), "Channel list is full")
 						listFullWarned[change.mode] = true
 					}
 					continue

--- a/irc/nickname.go
+++ b/irc/nickname.go
@@ -34,7 +34,7 @@ func nickHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 		return false
 	}
 
-	if err != nil || len(nicknameRaw) > server.getLimits().NickLen || restrictedNicknames[nickname] {
+	if err != nil || len(nicknameRaw) > server.Limits().NickLen || restrictedNicknames[nickname] {
 		client.Send(nil, server.name, ERR_ERRONEUSNICKNAME, client.nick, nicknameRaw, "Erroneous nickname")
 		return false
 	}

--- a/irc/server.go
+++ b/irc/server.go
@@ -577,7 +577,7 @@ func renameHandler(server *Server, client *Client, msg ircmsg.IrcMessage) (resul
 		default:
 			code = ERR_UNKNOWNERROR
 		}
-		client.Send(nil, server.name, code, client.getNick(), "RENAME", name, err.Error())
+		client.Send(nil, server.name, code, client.Nick(), "RENAME", name, err.Error())
 	}
 
 	oldName := strings.TrimSpace(msg.Params[0])
@@ -697,7 +697,7 @@ func joinHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 		}
 		err := server.channels.Join(client, name, key)
 		if err == NoSuchChannel {
-			client.Send(nil, server.name, ERR_NOSUCHCHANNEL, client.getNick(), name, "No such channel")
+			client.Send(nil, server.name, ERR_NOSUCHCHANNEL, client.Nick(), name, "No such channel")
 		}
 	}
 	return false
@@ -1044,7 +1044,7 @@ func (target *Client) rplWhoReply(channel *Channel, client *Client) {
 		flags += channel.ClientPrefixes(client, target.capabilities.Has(caps.MultiPrefix))
 		channelName = channel.name
 	}
-	target.Send(nil, target.server.name, RPL_WHOREPLY, target.nick, channelName, client.Username(), client.Hostname(), client.server.name, client.getNick(), flags, strconv.Itoa(client.hops)+" "+client.Realname())
+	target.Send(nil, target.server.name, RPL_WHOREPLY, target.nick, channelName, client.Username(), client.Hostname(), client.server.name, client.Nick(), flags, strconv.Itoa(client.hops)+" "+client.Realname())
 }
 
 func whoChannel(client *Client, channel *Channel, friends ClientSet) {
@@ -1586,7 +1586,7 @@ func awayHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 	if len(msg.Params) > 0 {
 		isAway = true
 		text = msg.Params[0]
-		awayLen := server.getLimits().AwayLen
+		awayLen := server.Limits().AwayLen
 		if len(text) > awayLen {
 			text = text[:awayLen]
 		}


### PR DESCRIPTION
"Effective Go" says getters shouldn't start with "get":

https://golang.org/doc/effective_go.html#Getters

I've been inconsistent about this so I thought I'd fix it up in between branches.