### PR TITLE
remove registeredChannelsMutex

### DIFF
--- a/irc/channelreg.go
+++ b/irc/channelreg.go
@@ -4,15 +4,18 @@
 package irc
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	"encoding/json"
 
 	"github.com/tidwall/buntdb"
 )
+
+// this is exclusively the *persistence* layer for channel registration;
+// channel creation/tracking/destruction is in channelmanager.go
 
 const (
 	keyChannelExists       = "channel.exists %s"
@@ -28,7 +31,18 @@ const (
 )
 
 var (
-	errChanExists = errors.New("Channel already exists")
+	channelKeyStrings = []string{
+		keyChannelExists,
+		keyChannelName,
+		keyChannelRegTime,
+		keyChannelFounder,
+		keyChannelTopic,
+		keyChannelTopicSetBy,
+		keyChannelTopicSetTime,
+		keyChannelBanlist,
+		keyChannelExceptlist,
+		keyChannelInvitelist,
+	}
 )
 
 // RegisteredChannel holds details about a given registered channel.
@@ -53,62 +67,142 @@ type RegisteredChannel struct {
 	Invitelist []string
 }
 
-// deleteChannelNoMutex deletes a given channel from our store.
-func (server *Server) deleteChannelNoMutex(tx *buntdb.Tx, channelKey string) {
-	tx.Delete(fmt.Sprintf(keyChannelExists, channelKey))
-	server.registeredChannels[channelKey] = nil
+type ChannelRegistry struct {
+	// this serializes operations of the form (read channel state, synchronously persist it);
+	// this is enough to guarantee eventual consistency of the database with the
+	// ChannelManager and Channel objects, which are the source of truth.
+	// Wwe could use the buntdb RW transaction lock for this purpose but we share
+	// that with all the other modules, so let's not.
+	sync.Mutex // tier 2
+	server     *Server
+	channels   map[string]*RegisteredChannel
 }
 
-// loadChannelNoMutex loads a channel from the store.
-func (server *Server) loadChannelNoMutex(tx *buntdb.Tx, channelKey string) *RegisteredChannel {
-	// return loaded chan if it already exists
-	if server.registeredChannels[channelKey] != nil {
-		return server.registeredChannels[channelKey]
+func NewChannelRegistry(server *Server) *ChannelRegistry {
+	return &ChannelRegistry{
+		server: server,
 	}
-	_, err := tx.Get(fmt.Sprintf(keyChannelExists, channelKey))
-	if err == buntdb.ErrNotFound {
-		// chan does not already exist, return
+}
+
+// StoreChannel obtains a consistent view of a channel, then persists it to the store.
+func (reg *ChannelRegistry) StoreChannel(channel *Channel, includeLists bool) {
+	if !reg.server.ChannelRegistrationEnabled() {
+		return
+	}
+
+	reg.Lock()
+	defer reg.Unlock()
+
+	key := channel.NameCasefolded()
+	info := channel.ExportRegistration(includeLists)
+	if info.Founder == "" {
+		// sanity check, don't try to store an unregistered channel
+		return
+	}
+
+	reg.server.store.Update(func(tx *buntdb.Tx) error {
+		reg.saveChannel(tx, key, info, includeLists)
+		return nil
+	})
+}
+
+// LoadChannel loads a channel from the store.
+func (reg *ChannelRegistry) LoadChannel(nameCasefolded string) (info *RegisteredChannel) {
+	if !reg.server.ChannelRegistrationEnabled() {
 		return nil
 	}
 
-	// channel exists, load it
-	name, _ := tx.Get(fmt.Sprintf(keyChannelName, channelKey))
-	regTime, _ := tx.Get(fmt.Sprintf(keyChannelRegTime, channelKey))
-	regTimeInt, _ := strconv.ParseInt(regTime, 10, 64)
-	founder, _ := tx.Get(fmt.Sprintf(keyChannelFounder, channelKey))
-	topic, _ := tx.Get(fmt.Sprintf(keyChannelTopic, channelKey))
-	topicSetBy, _ := tx.Get(fmt.Sprintf(keyChannelTopicSetBy, channelKey))
-	topicSetTime, _ := tx.Get(fmt.Sprintf(keyChannelTopicSetTime, channelKey))
-	topicSetTimeInt, _ := strconv.ParseInt(topicSetTime, 10, 64)
-	banlistString, _ := tx.Get(fmt.Sprintf(keyChannelBanlist, channelKey))
-	exceptlistString, _ := tx.Get(fmt.Sprintf(keyChannelExceptlist, channelKey))
-	invitelistString, _ := tx.Get(fmt.Sprintf(keyChannelInvitelist, channelKey))
+	channelKey := nameCasefolded
+	// nice to have: do all JSON (de)serialization outside of the buntdb transaction
+	reg.server.store.View(func(tx *buntdb.Tx) error {
+		_, err := tx.Get(fmt.Sprintf(keyChannelExists, channelKey))
+		if err == buntdb.ErrNotFound {
+			// chan does not already exist, return
+			return nil
+		}
 
-	var banlist []string
-	_ = json.Unmarshal([]byte(banlistString), &banlist)
-	var exceptlist []string
-	_ = json.Unmarshal([]byte(exceptlistString), &exceptlist)
-	var invitelist []string
-	_ = json.Unmarshal([]byte(invitelistString), &invitelist)
+		// channel exists, load it
+		name, _ := tx.Get(fmt.Sprintf(keyChannelName, channelKey))
+		regTime, _ := tx.Get(fmt.Sprintf(keyChannelRegTime, channelKey))
+		regTimeInt, _ := strconv.ParseInt(regTime, 10, 64)
+		founder, _ := tx.Get(fmt.Sprintf(keyChannelFounder, channelKey))
+		topic, _ := tx.Get(fmt.Sprintf(keyChannelTopic, channelKey))
+		topicSetBy, _ := tx.Get(fmt.Sprintf(keyChannelTopicSetBy, channelKey))
+		topicSetTime, _ := tx.Get(fmt.Sprintf(keyChannelTopicSetTime, channelKey))
+		topicSetTimeInt, _ := strconv.ParseInt(topicSetTime, 10, 64)
+		banlistString, _ := tx.Get(fmt.Sprintf(keyChannelBanlist, channelKey))
+		exceptlistString, _ := tx.Get(fmt.Sprintf(keyChannelExceptlist, channelKey))
+		invitelistString, _ := tx.Get(fmt.Sprintf(keyChannelInvitelist, channelKey))
 
-	chanInfo := RegisteredChannel{
-		Name:         name,
-		RegisteredAt: time.Unix(regTimeInt, 0),
-		Founder:      founder,
-		Topic:        topic,
-		TopicSetBy:   topicSetBy,
-		TopicSetTime: time.Unix(topicSetTimeInt, 0),
-		Banlist:      banlist,
-		Exceptlist:   exceptlist,
-		Invitelist:   invitelist,
-	}
-	server.registeredChannels[channelKey] = &chanInfo
+		var banlist []string
+		_ = json.Unmarshal([]byte(banlistString), &banlist)
+		var exceptlist []string
+		_ = json.Unmarshal([]byte(exceptlistString), &exceptlist)
+		var invitelist []string
+		_ = json.Unmarshal([]byte(invitelistString), &invitelist)
 
-	return &chanInfo
+		info = &RegisteredChannel{
+			Name:         name,
+			RegisteredAt: time.Unix(regTimeInt, 0),
+			Founder:      founder,
+			Topic:        topic,
+			TopicSetBy:   topicSetBy,
+			TopicSetTime: time.Unix(topicSetTimeInt, 0),
+			Banlist:      banlist,
+			Exceptlist:   exceptlist,
+			Invitelist:   invitelist,
+		}
+		return nil
+	})
+
+	return info
 }
 
-// saveChannelNoMutex saves a channel to the store.
-func (server *Server) saveChannelNoMutex(tx *buntdb.Tx, channelKey string, channelInfo RegisteredChannel) {
+// Rename handles the persistence part of a channel rename: the channel is
+// persisted under its new name, and the old name is cleaned up if necessary.
+func (reg *ChannelRegistry) Rename(channel *Channel, casefoldedOldName string) {
+	if !reg.server.ChannelRegistrationEnabled() {
+		return
+	}
+
+	reg.Lock()
+	defer reg.Unlock()
+
+	includeLists := true
+	oldKey := casefoldedOldName
+	key := channel.NameCasefolded()
+	info := channel.ExportRegistration(includeLists)
+	if info.Founder == "" {
+		return
+	}
+
+	reg.server.store.Update(func(tx *buntdb.Tx) error {
+		reg.deleteChannel(tx, oldKey, info)
+		reg.saveChannel(tx, key, info, includeLists)
+		return nil
+	})
+}
+
+// delete a channel, unless it was overwritten by another registration of the same channel
+func (reg *ChannelRegistry) deleteChannel(tx *buntdb.Tx, key string, info RegisteredChannel) {
+	_, err := tx.Get(fmt.Sprintf(keyChannelExists, key))
+	if err == nil {
+		regTime, _ := tx.Get(fmt.Sprintf(keyChannelRegTime, key))
+		regTimeInt, _ := strconv.ParseInt(regTime, 10, 64)
+		registeredAt := time.Unix(regTimeInt, 0)
+		founder, _ := tx.Get(fmt.Sprintf(keyChannelFounder, key))
+
+		// to see if we're deleting the right channel, confirm the founder and the registration time
+		if founder == info.Founder && registeredAt == info.RegisteredAt {
+			for _, keyFmt := range channelKeyStrings {
+				tx.Delete(fmt.Sprintf(keyFmt, key))
+			}
+		}
+	}
+}
+
+// saveChannel saves a channel to the store.
+func (reg *ChannelRegistry) saveChannel(tx *buntdb.Tx, channelKey string, channelInfo RegisteredChannel, includeLists bool) {
 	tx.Set(fmt.Sprintf(keyChannelExists, channelKey), "1", nil)
 	tx.Set(fmt.Sprintf(keyChannelName, channelKey), channelInfo.Name, nil)
 	tx.Set(fmt.Sprintf(keyChannelRegTime, channelKey), strconv.FormatInt(channelInfo.RegisteredAt.Unix(), 10), nil)
@@ -117,12 +211,12 @@ func (server *Server) saveChannelNoMutex(tx *buntdb.Tx, channelKey string, chann
 	tx.Set(fmt.Sprintf(keyChannelTopicSetBy, channelKey), channelInfo.TopicSetBy, nil)
 	tx.Set(fmt.Sprintf(keyChannelTopicSetTime, channelKey), strconv.FormatInt(channelInfo.TopicSetTime.Unix(), 10), nil)
 
-	banlistString, _ := json.Marshal(channelInfo.Banlist)
-	tx.Set(fmt.Sprintf(keyChannelBanlist, channelKey), string(banlistString), nil)
-	exceptlistString, _ := json.Marshal(channelInfo.Exceptlist)
-	tx.Set(fmt.Sprintf(keyChannelExceptlist, channelKey), string(exceptlistString), nil)
-	invitelistString, _ := json.Marshal(channelInfo.Invitelist)
-	tx.Set(fmt.Sprintf(keyChannelInvitelist, channelKey), string(invitelistString), nil)
-
-	server.registeredChannels[channelKey] = &channelInfo
+	if includeLists {
+		banlistString, _ := json.Marshal(channelInfo.Banlist)
+		tx.Set(fmt.Sprintf(keyChannelBanlist, channelKey), string(banlistString), nil)
+		exceptlistString, _ := json.Marshal(channelInfo.Exceptlist)
+		tx.Set(fmt.Sprintf(keyChannelExceptlist, channelKey), string(exceptlistString), nil)
+		invitelistString, _ := json.Marshal(channelInfo.Invitelist)
+		tx.Set(fmt.Sprintf(keyChannelInvitelist, channelKey), string(invitelistString), nil)
+	}
 }

--- a/irc/chanserv.go
+++ b/irc/chanserv.go
@@ -6,12 +6,10 @@ package irc
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/goshuirc/irc-go/ircfmt"
 	"github.com/goshuirc/irc-go/ircmsg"
 	"github.com/oragono/oragono/irc/sno"
-	"github.com/tidwall/buntdb"
 )
 
 // csHandler handles the /CS and /CHANSERV commands
@@ -56,9 +54,6 @@ func (server *Server) chanservReceivePrivmsg(client *Client, message string) {
 			return
 		}
 
-		server.registeredChannelsMutex.Lock()
-		defer server.registeredChannelsMutex.Unlock()
-
 		channelName := params[1]
 		channelKey, err := CasefoldChannel(channelName)
 		if err != nil {
@@ -67,57 +62,41 @@ func (server *Server) chanservReceivePrivmsg(client *Client, message string) {
 		}
 
 		channelInfo := server.channels.Get(channelKey)
-		if channelInfo == nil {
+		if channelInfo == nil || !channelInfo.ClientIsAtLeast(client, ChannelOperator) {
 			client.ChanServNotice("You must be an oper on the channel to register it")
 			return
 		}
 
-		if !channelInfo.ClientIsAtLeast(client, ChannelOperator) {
-			client.ChanServNotice("You must be an oper on the channel to register it")
+		if client.account == &NoAccount {
+			client.ChanServNotice("You must be logged in to register a channel")
 			return
 		}
 
-		server.store.Update(func(tx *buntdb.Tx) error {
-			currentChan := server.loadChannelNoMutex(tx, channelKey)
-			if currentChan != nil {
-				client.ChanServNotice("Channel is already registered")
-				return nil
+		// this provides the synchronization that allows exactly one registration of the channel:
+		err = channelInfo.SetRegistered(client.AccountName())
+		if err != nil {
+			client.ChanServNotice(err.Error())
+			return
+		}
+
+		// registration was successful: make the database reflect it
+		go server.channelRegistry.StoreChannel(channelInfo, true)
+
+		client.ChanServNotice(fmt.Sprintf("Channel %s successfully registered", channelName))
+
+		server.logger.Info("chanserv", fmt.Sprintf("Client %s registered channel %s", client.nick, channelName))
+		server.snomasks.Send(sno.LocalChannels, fmt.Sprintf(ircfmt.Unescape("Channel registered $c[grey][$r%s$c[grey]] by $c[grey][$r%s$c[grey]]"), channelName, client.nickMaskString))
+
+		// give them founder privs
+		change := channelInfo.applyModeMemberNoMutex(client, ChannelFounder, Add, client.NickCasefolded())
+		if change != nil {
+			//TODO(dan): we should change the name of String and make it return a slice here
+			//TODO(dan): unify this code with code in modes.go
+			args := append([]string{channelName}, strings.Split(change.String(), " ")...)
+			for _, member := range channelInfo.Members() {
+				member.Send(nil, fmt.Sprintf("ChanServ!services@%s", client.server.name), "MODE", args...)
 			}
-
-			account := client.account
-			if account == &NoAccount {
-				client.ChanServNotice("You must be logged in to register a channel")
-				return nil
-			}
-
-			chanRegInfo := RegisteredChannel{
-				Name:         channelName,
-				RegisteredAt: time.Now(),
-				Founder:      account.Name,
-				Topic:        channelInfo.topic,
-				TopicSetBy:   channelInfo.topicSetBy,
-				TopicSetTime: channelInfo.topicSetTime,
-			}
-			server.saveChannelNoMutex(tx, channelKey, chanRegInfo)
-
-			client.ChanServNotice(fmt.Sprintf("Channel %s successfully registered", channelName))
-
-			server.logger.Info("chanserv", fmt.Sprintf("Client %s registered channel %s", client.nick, channelName))
-			server.snomasks.Send(sno.LocalChannels, fmt.Sprintf(ircfmt.Unescape("Channel registered $c[grey][$r%s$c[grey]] by $c[grey][$r%s$c[grey]]"), channelName, client.nickMaskString))
-
-			// give them founder privs
-			change := channelInfo.applyModeMemberNoMutex(client, ChannelFounder, Add, client.nickCasefolded)
-			if change != nil {
-				//TODO(dan): we should change the name of String and make it return a slice here
-				//TODO(dan): unify this code with code in modes.go
-				args := append([]string{channelName}, strings.Split(change.String(), " ")...)
-				for _, member := range channelInfo.Members() {
-					member.Send(nil, fmt.Sprintf("ChanServ!services@%s", client.server.name), "MODE", args...)
-				}
-			}
-
-			return nil
-		})
+		}
 	} else {
 		client.ChanServNotice("Sorry, I don't know that command")
 	}

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -47,6 +47,12 @@ func (server *Server) DefaultChannelModes() Modes {
 	return server.defaultChannelModes
 }
 
+func (server *Server) ChannelRegistrationEnabled() bool {
+	server.configurableStateMutex.RLock()
+	defer server.configurableStateMutex.RUnlock()
+	return server.channelRegistrationEnabled
+}
+
 func (client *Client) Nick() string {
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()
@@ -93,6 +99,12 @@ func (client *Client) Destroyed() bool {
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()
 	return client.isDestroyed
+}
+
+func (client *Client) AccountName() string {
+	client.stateMutex.RLock()
+	defer client.stateMutex.RUnlock()
+	return client.account.Name
 }
 
 func (client *Client) HasMode(mode Mode) bool {
@@ -172,6 +184,12 @@ func (channel *Channel) HasMode(mode Mode) bool {
 	channel.stateMutex.RLock()
 	defer channel.stateMutex.RUnlock()
 	return channel.flags[mode]
+}
+
+func (channel *Channel) Founder() string {
+	channel.stateMutex.RLock()
+	defer channel.stateMutex.RUnlock()
+	return channel.registeredFounder
 }
 
 // set a channel mode, return whether it was already set


### PR DESCRIPTION
This moves channel registration to an eventual consistency model, where the in-memory datastructures (Channel and ChannelManager) are the exclusive source of truth about the current state of the world, and updates to them get persisted asynchronously to the DB. None of the actual components know about buntdb directly; instead, there's a `ChannelRegistry` struct that exposes load, store, and rename methods.

The eventual consistency rationale is the same as on #160. Suppose we have two concurrent updates to the topic (for example). Those updates are linearly ordered by `Channel.stateMutex`. Each update triggers an asynchronous update of the persistence layer, where we acquire a lock (`ChannelRegistry.Lock()`), read a snapshot of the channel state, persist it to the DB, and release the lock. The final asynchronous update will see all the updates to the source-of-truth and idempotently apply them to the database.