### PR TITLE
fix a wide-ranging assortment of crash bugs

### DIFF
--- a/irc/channelmanager.go
+++ b/irc/channelmanager.go
@@ -43,7 +43,10 @@ func (cm *ChannelManager) Get(name string) *Channel {
 	if err == nil {
 		cm.RLock()
 		defer cm.RUnlock()
-		return cm.chans[name].channel
+		entry := cm.chans[name]
+		if entry != nil {
+			return entry.channel
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
I introduced this in #157. This is pretty bad; I originally triggered it with `/mode #nonexistent_channel b`. On the other hand, the error recovery code from #156 successfully mitigates --- you just get disconnected instead of crashing the server.

This is another good candidate for an irctest test.