### PR TITLE
refactor ClientManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The `stable` branch contains the latest release. You can run this for a producti
 
 [![Build Status](https://travis-ci.org/oragono/oragono.svg?branch=master)](https://travis-ci.org/oragono/oragono)
 
-Clone the appropriate branch. From the root folder, run `make` to generate all release files for all of our target OSes:
+Clone the appropriate branch. If necessary, do `git submodule update --init` to set up vendored dependencies. From the root folder, run `make` to generate all release files for all of our target OSes:
 ```
 make
 ```

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -35,7 +35,7 @@ type Channel struct {
 	createdTime       time.Time
 	registeredFounder string
 	registeredTime    time.Time
-	stateMutex        sync.RWMutex
+	stateMutex        sync.RWMutex // tier 1
 	topic             string
 	topicSetBy        string
 	topicSetTime      time.Time

--- a/irc/client_lookup_set.go
+++ b/irc/client_lookup_set.go
@@ -39,7 +39,7 @@ func ExpandUserHost(userhost string) (expanded string) {
 // ClientManager keeps track of clients by nick, enforcing uniqueness of casefolded nicks
 type ClientManager struct {
 	sync.RWMutex // tier 2
-	byNick      map[string]*Client
+	byNick       map[string]*Client
 }
 
 // NewClientManager returns a new ClientManager.
@@ -70,7 +70,7 @@ func (clients *ClientManager) Get(nick string) *Client {
 }
 
 func (clients *ClientManager) removeInternal(client *Client) (removed bool) {
-	// requires holding ByNickMutex
+	// requires holding the writable Lock()
 	oldcfnick := client.NickCasefolded()
 	currentEntry, present := clients.byNick[oldcfnick]
 	if present {
@@ -123,7 +123,7 @@ func (clients *ClientManager) AllClients() (result []*Client) {
 	defer clients.RUnlock()
 	result = make([]*Client, len(clients.byNick))
 	i := 0
-	for _, client := range(clients.byNick) {
+	for _, client := range clients.byNick {
 		result[i] = client
 		i++
 	}

--- a/irc/dline.go
+++ b/irc/dline.go
@@ -82,7 +82,7 @@ type dLineNet struct {
 
 // DLineManager manages and dlines.
 type DLineManager struct {
-	sync.RWMutex
+	sync.RWMutex // tier 1
 	// addresses that are dlined
 	addresses map[string]*dLineAddr
 	// networks that are dlined
@@ -386,8 +386,7 @@ func dlineHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 		var killedClientNicks []string
 		var toKill bool
 
-		server.clients.ByNickMutex.RLock()
-		for _, mcl := range server.clients.ByNick {
+		for _, mcl := range server.clients.AllClients() {
 			if hostNet == nil {
 				toKill = hostAddr.Equal(mcl.IP())
 			} else {
@@ -399,7 +398,6 @@ func dlineHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 				killedClientNicks = append(killedClientNicks, mcl.nick)
 			}
 		}
-		server.clients.ByNickMutex.RUnlock()
 
 		for _, mcl := range clientsToKill {
 			mcl.exitedSnomaskSent = true

--- a/irc/idletimer.go
+++ b/irc/idletimer.go
@@ -29,7 +29,7 @@ const (
 )
 
 type IdleTimer struct {
-	sync.Mutex
+	sync.Mutex // tier 1
 
 	// immutable after construction
 	registerTimeout time.Duration

--- a/irc/kline.go
+++ b/irc/kline.go
@@ -35,7 +35,7 @@ type KLineInfo struct {
 
 // KLineManager manages and klines.
 type KLineManager struct {
-	sync.RWMutex
+	sync.RWMutex // tier 1
 	// kline'd entries
 	entries map[string]*KLineInfo
 }
@@ -282,8 +282,7 @@ func klineHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 		var clientsToKill []*Client
 		var killedClientNicks []string
 
-		server.clients.ByNickMutex.RLock()
-		for _, mcl := range server.clients.ByNick {
+		for _, mcl := range server.clients.AllClients() {
 			for _, clientMask := range mcl.AllNickmasks() {
 				if matcher.Match(clientMask) {
 					clientsToKill = append(clientsToKill, mcl)
@@ -291,7 +290,6 @@ func klineHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 				}
 			}
 		}
-		server.clients.ByNickMutex.RUnlock()
 
 		for _, mcl := range clientsToKill {
 			mcl.exitedSnomaskSent = true

--- a/irc/monitor.go
+++ b/irc/monitor.go
@@ -15,7 +15,7 @@ import (
 
 // MonitorManager keeps track of who's monitoring which nicks.
 type MonitorManager struct {
-	sync.RWMutex
+	sync.RWMutex // tier 2
 	// client -> nicks it's watching
 	watching map[*Client]map[string]bool
 	// nick -> clients watching it

--- a/irc/nickname.go
+++ b/irc/nickname.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/goshuirc/irc-go/ircfmt"
 	"github.com/goshuirc/irc-go/ircmsg"
+	"github.com/oragono/oragono/irc/sno"
 )
 
 var (
@@ -26,7 +28,11 @@ func nickHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 		return true
 	}
 
-	nicknameRaw := strings.TrimSpace(msg.Params[0])
+	return performNickChange(server, client, client, msg.Params[0])
+}
+
+func performNickChange(server *Server, client *Client, target *Client, newnick string) bool {
+	nicknameRaw := strings.TrimSpace(newnick)
 	nickname, err := CasefoldName(nicknameRaw)
 
 	if len(nicknameRaw) < 1 {
@@ -39,16 +45,14 @@ func nickHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 		return false
 	}
 
-	if client.nick == nickname {
+	if target.Nick() == nicknameRaw {
 		return false
 	}
 
-	// bleh, this will be replaced and done below
-	if client.registered {
-		err = client.ChangeNickname(nicknameRaw)
-	} else {
-		err = client.SetNickname(nicknameRaw)
-	}
+	hadNick := target.HasNick()
+	origNick := target.Nick()
+	origNickMask := target.NickMaskString()
+	err = client.server.clients.SetNick(target, nickname)
 	if err == ErrNicknameInUse {
 		client.Send(nil, server.name, ERR_NICKNAMEINUSE, client.nick, nicknameRaw, "Nickname is already in use")
 		return false
@@ -56,49 +60,31 @@ func nickHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 		client.Send(nil, server.name, ERR_UNKNOWNERROR, client.nick, "NICK", fmt.Sprintf("Could not set or change nickname: %s", err.Error()))
 		return false
 	}
-	if client.registered {
-		client.server.monitorManager.AlertAbout(client, true)
+
+	client.server.logger.Debug("nick", fmt.Sprintf("%s changed nickname to %s", origNickMask, nickname))
+	if hadNick {
+		target.server.snomasks.Send(sno.LocalNicks, fmt.Sprintf(ircfmt.Unescape("$%s$r changed nickname to %s"), origNick, nicknameRaw))
+		target.server.whoWas.Append(client)
+		for friend := range target.Friends() {
+			friend.Send(nil, origNickMask, "NICK", nicknameRaw)
+		}
 	}
-	server.tryRegister(client)
+
+	if target.registered {
+		client.server.monitorManager.AlertAbout(target, true)
+	} else {
+		server.tryRegister(target)
+	}
 	return false
 }
 
 // SANICK <oldnick> <nickname>
 func sanickHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
-	if !client.authorized {
-		client.Quit("Bad password")
-		return true
-	}
-
-	oldnick, oerr := CasefoldName(msg.Params[0])
-	nickname, err := CasefoldName(msg.Params[1])
-
-	if len(nickname) < 1 {
-		client.Send(nil, server.name, ERR_NONICKNAMEGIVEN, client.nick, "No nickname given")
-		return false
-	}
-
-	if oerr != nil || err != nil || len(strings.TrimSpace(msg.Params[1])) > server.limits.NickLen || restrictedNicknames[nickname] {
-		client.Send(nil, server.name, ERR_ERRONEUSNICKNAME, client.nick, msg.Params[0], "Erroneous nickname")
-		return false
-	}
-
-	if client.nick == msg.Params[1] {
-		return false
-	}
-
-	target := server.clients.Get(oldnick)
+	targetNick := strings.TrimSpace(msg.Params[0])
+	target := server.clients.Get(targetNick)
 	if target == nil {
 		client.Send(nil, server.name, ERR_NOSUCHNICK, client.nick, msg.Params[0], "No such nick")
 		return false
 	}
-
-	//TODO(dan): There's probably some races here, we should be changing this in the primary server thread
-	if server.clients.Get(nickname) != nil && server.clients.Get(nickname) != target {
-		client.Send(nil, server.name, ERR_NICKNAMEINUSE, client.nick, msg.Params[0], "Nickname is already in use")
-		return false
-	}
-
-	target.ChangeNickname(msg.Params[1])
-	return false
+	return performNickChange(server, client, target, msg.Params[1])
 }

--- a/irc/nickname.go
+++ b/irc/nickname.go
@@ -61,7 +61,7 @@ func performNickChange(server *Server, client *Client, target *Client, newnick s
 		return false
 	}
 
-	client.server.logger.Debug("nick", fmt.Sprintf("%s changed nickname to %s", origNickMask, nickname))
+	client.server.logger.Debug("nick", fmt.Sprintf("%s changed nickname to %s [%s]", origNickMask, nicknameRaw, nickname))
 	if hadNick {
 		target.server.snomasks.Send(sno.LocalNicks, fmt.Sprintf(ircfmt.Unescape("$%s$r changed nickname to %s"), origNick, nicknameRaw))
 		target.server.whoWas.Append(client)

--- a/irc/snomanager.go
+++ b/irc/snomanager.go
@@ -10,7 +10,7 @@ import (
 
 // SnoManager keeps track of which clients to send snomasks to.
 type SnoManager struct {
-	sendListMutex sync.RWMutex
+	sendListMutex sync.RWMutex // tier 2
 	sendLists     map[sno.Mask]map[*Client]bool
 }
 

--- a/irc/whowas.go
+++ b/irc/whowas.go
@@ -14,7 +14,7 @@ type WhoWasList struct {
 	start  int
 	end    int
 
-	accessMutex sync.RWMutex
+	accessMutex sync.RWMutex // tier 2
 }
 
 // WhoWas is an entry in the WhoWasList.


### PR DESCRIPTION
This should finish #152. Anyway:

1. This allows capitalization-only nickname changes (they were previously ignored)
1. `ClientManager` now synchronizes `Client.nick` with the casefolded nickname the server is using to track the client. This is probably unnecessary.