### PR TITLE
fix a race condition in client timeouts

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -261,6 +261,8 @@ func (client *Client) run() {
 
 // Active updates when the client was last 'active' (i.e. the user should be sitting in front of their client).
 func (client *Client) Active() {
+	client.stateMutex.Lock()
+	defer client.stateMutex.Unlock()
 	client.atime = time.Now()
 }
 
@@ -298,6 +300,8 @@ func (client *Client) Register() {
 
 // IdleTime returns how long this client's been idle.
 func (client *Client) IdleTime() time.Duration {
+	client.stateMutex.RLock()
+	defer client.stateMutex.RUnlock()
 	return time.Since(client.atime)
 }
 


### PR DESCRIPTION
squigz on freenode reported an issue where bots were responding to PING
on time, but were occasionally being timed out regardless. This was a race
condition: timeout was detected as idleTime >= it.quitTimeout, but if
the client responded promptly to its PING message and sent no further messages,
but the main loop subsequently slept for longer than expected (i.e., significantly
longer than quitTimeout), this condition would be met through no fault of the
client's.

The fix here is to explicitly track the last time the ping was sent, then test
!lastSeen.After(lastPinged) instead (making use of time.Time's monotonicity).
It is sufficient that the measurement of lastPinged happens-before the PING is sent.