### PR TITLE
remove some unused members

### DIFF
--- a/irc/channelreg.go
+++ b/irc/channelreg.go
@@ -75,7 +75,6 @@ type ChannelRegistry struct {
 	// that with all the other modules, so let's not.
 	sync.Mutex // tier 2
 	server     *Server
-	channels   map[string]*RegisteredChannel
 }
 
 func NewChannelRegistry(server *Server) *ChannelRegistry {

--- a/irc/commands.go
+++ b/irc/commands.go
@@ -53,256 +53,260 @@ func (cmd *Command) Run(server *Server, client *Client, msg ircmsg.IrcMessage) b
 }
 
 // Commands holds all commands executable by a client connected to us.
-var Commands = map[string]Command{
-	"ACC": {
-		handler:   accHandler,
-		minParams: 3,
-	},
-	"AMBIANCE": {
-		handler:   sceneHandler,
-		minParams: 2,
-	},
-	"AUTHENTICATE": {
-		handler:      authenticateHandler,
-		usablePreReg: true,
-		minParams:    1,
-	},
-	"AWAY": {
-		handler:   awayHandler,
-		minParams: 0,
-	},
-	"CAP": {
-		handler:      capHandler,
-		usablePreReg: true,
-		minParams:    1,
-	},
-	"CHANSERV": {
-		handler:   csHandler,
-		minParams: 1,
-	},
-	"CS": {
-		handler:   csHandler,
-		minParams: 1,
-	},
-	"DEBUG": {
-		handler:   debugHandler,
-		minParams: 1,
-	},
-	"DLINE": {
-		handler:   dlineHandler,
-		minParams: 1,
-		oper:      true,
-	},
-	"HELP": {
-		handler:   helpHandler,
-		minParams: 0,
-	},
-	"HELPOP": {
-		handler:   helpHandler,
-		minParams: 0,
-	},
-	"INFO": {
-		handler: infoHandler,
-	},
-	"INVITE": {
-		handler:   inviteHandler,
-		minParams: 2,
-	},
-	"ISON": {
-		handler:   isonHandler,
-		minParams: 1,
-	},
-	"JOIN": {
-		handler:   joinHandler,
-		minParams: 1,
-	},
-	"KICK": {
-		handler:   kickHandler,
-		minParams: 2,
-	},
-	"KILL": {
-		handler:   killHandler,
-		minParams: 1,
-		oper:      true,
-		capabs:    []string{"oper:local_kill"}, //TODO(dan): when we have S2S, this will be checked in the command handler itself
-	},
-	"KLINE": {
-		handler:   klineHandler,
-		minParams: 1,
-		oper:      true,
-	},
-	"LANGUAGE": {
-		handler:      languageHandler,
-		usablePreReg: true,
-		minParams:    1,
-	},
-	"LIST": {
-		handler:   listHandler,
-		minParams: 0,
-	},
-	"LUSERS": {
-		handler:   lusersHandler,
-		minParams: 0,
-	},
-	"MODE": {
-		handler:   modeHandler,
-		minParams: 1,
-	},
-	"MONITOR": {
-		handler:   monitorHandler,
-		minParams: 1,
-	},
-	"MOTD": {
-		handler:   motdHandler,
-		minParams: 0,
-	},
-	"NAMES": {
-		handler:   namesHandler,
-		minParams: 0,
-	},
-	"NICK": {
-		handler:      nickHandler,
-		usablePreReg: true,
-		minParams:    1,
-	},
-	"NICKSERV": {
-		handler:   nsHandler,
-		minParams: 1,
-	},
-	"NOTICE": {
-		handler:   noticeHandler,
-		minParams: 2,
-	},
-	"NPC": {
-		handler:   npcHandler,
-		minParams: 3,
-	},
-	"NPCA": {
-		handler:   npcaHandler,
-		minParams: 3,
-	},
-	"NS": {
-		handler:   nsHandler,
-		minParams: 1,
-	},
-	"OPER": {
-		handler:   operHandler,
-		minParams: 2,
-	},
-	"PART": {
-		handler:   partHandler,
-		minParams: 1,
-	},
-	"PASS": {
-		handler:      passHandler,
-		usablePreReg: true,
-		minParams:    1,
-	},
-	"PING": {
-		handler:           pingHandler,
-		usablePreReg:      true,
-		minParams:         1,
-		leaveClientActive: true,
-	},
-	"PONG": {
-		handler:           pongHandler,
-		usablePreReg:      true,
-		minParams:         1,
-		leaveClientActive: true,
-	},
-	"PRIVMSG": {
-		handler:   privmsgHandler,
-		minParams: 2,
-	},
-	"PROXY": {
-		handler:      proxyHandler,
-		usablePreReg: true,
-		minParams:    5,
-	},
-	"RENAME": {
-		handler:   renameHandler,
-		minParams: 2,
-	},
-	"RESUME": {
-		handler:      resumeHandler,
-		usablePreReg: true,
-		minParams:    1,
-	},
-	"SANICK": {
-		handler:   sanickHandler,
-		minParams: 2,
-		oper:      true,
-	},
-	"SAMODE": {
-		handler:   modeHandler,
-		minParams: 1,
-		capabs:    []string{"samode"},
-	},
-	"SCENE": {
-		handler:   sceneHandler,
-		minParams: 2,
-	},
-	"TAGMSG": {
-		handler:   tagmsgHandler,
-		minParams: 1,
-	},
-	"QUIT": {
-		handler:      quitHandler,
-		usablePreReg: true,
-		minParams:    0,
-	},
-	"REHASH": {
-		handler:   rehashHandler,
-		minParams: 0,
-		oper:      true,
-		capabs:    []string{"oper:rehash"},
-	},
-	"TIME": {
-		handler:   timeHandler,
-		minParams: 0,
-	},
-	"TOPIC": {
-		handler:   topicHandler,
-		minParams: 1,
-	},
-	"UNDLINE": {
-		handler:   unDLineHandler,
-		minParams: 1,
-		oper:      true,
-	},
-	"UNKLINE": {
-		handler:   unKLineHandler,
-		minParams: 1,
-		oper:      true,
-	},
-	"USER": {
-		handler:      userHandler,
-		usablePreReg: true,
-		minParams:    4,
-	},
-	"USERHOST": {
-		handler:   userhostHandler,
-		minParams: 1,
-	},
-	"VERSION": {
-		handler:   versionHandler,
-		minParams: 0,
-	},
-	"WEBIRC": {
-		handler:      webircHandler,
-		usablePreReg: true,
-		minParams:    4,
-	},
-	"WHO": {
-		handler:   whoHandler,
-		minParams: 1,
-	},
-	"WHOIS": {
-		handler:   whoisHandler,
-		minParams: 1,
-	},
-	"WHOWAS": {
-		handler:   whowasHandler,
-		minParams: 1,
-	},
+var Commands map[string]Command
+
+func init() {
+	Commands = map[string]Command{
+		"ACC": {
+			handler:   accHandler,
+			minParams: 3,
+		},
+		"AMBIANCE": {
+			handler:   sceneHandler,
+			minParams: 2,
+		},
+		"AUTHENTICATE": {
+			handler:      authenticateHandler,
+			usablePreReg: true,
+			minParams:    1,
+		},
+		"AWAY": {
+			handler:   awayHandler,
+			minParams: 0,
+		},
+		"CAP": {
+			handler:      capHandler,
+			usablePreReg: true,
+			minParams:    1,
+		},
+		"CHANSERV": {
+			handler:   csHandler,
+			minParams: 1,
+		},
+		"CS": {
+			handler:   csHandler,
+			minParams: 1,
+		},
+		"DEBUG": {
+			handler:   debugHandler,
+			minParams: 1,
+		},
+		"DLINE": {
+			handler:   dlineHandler,
+			minParams: 1,
+			oper:      true,
+		},
+		"HELP": {
+			handler:   helpHandler,
+			minParams: 0,
+		},
+		"HELPOP": {
+			handler:   helpHandler,
+			minParams: 0,
+		},
+		"INFO": {
+			handler: infoHandler,
+		},
+		"INVITE": {
+			handler:   inviteHandler,
+			minParams: 2,
+		},
+		"ISON": {
+			handler:   isonHandler,
+			minParams: 1,
+		},
+		"JOIN": {
+			handler:   joinHandler,
+			minParams: 1,
+		},
+		"KICK": {
+			handler:   kickHandler,
+			minParams: 2,
+		},
+		"KILL": {
+			handler:   killHandler,
+			minParams: 1,
+			oper:      true,
+			capabs:    []string{"oper:local_kill"}, //TODO(dan): when we have S2S, this will be checked in the command handler itself
+		},
+		"KLINE": {
+			handler:   klineHandler,
+			minParams: 1,
+			oper:      true,
+		},
+		"LANGUAGE": {
+			handler:      languageHandler,
+			usablePreReg: true,
+			minParams:    1,
+		},
+		"LIST": {
+			handler:   listHandler,
+			minParams: 0,
+		},
+		"LUSERS": {
+			handler:   lusersHandler,
+			minParams: 0,
+		},
+		"MODE": {
+			handler:   modeHandler,
+			minParams: 1,
+		},
+		"MONITOR": {
+			handler:   monitorHandler,
+			minParams: 1,
+		},
+		"MOTD": {
+			handler:   motdHandler,
+			minParams: 0,
+		},
+		"NAMES": {
+			handler:   namesHandler,
+			minParams: 0,
+		},
+		"NICK": {
+			handler:      nickHandler,
+			usablePreReg: true,
+			minParams:    1,
+		},
+		"NICKSERV": {
+			handler:   nsHandler,
+			minParams: 1,
+		},
+		"NOTICE": {
+			handler:   noticeHandler,
+			minParams: 2,
+		},
+		"NPC": {
+			handler:   npcHandler,
+			minParams: 3,
+		},
+		"NPCA": {
+			handler:   npcaHandler,
+			minParams: 3,
+		},
+		"NS": {
+			handler:   nsHandler,
+			minParams: 1,
+		},
+		"OPER": {
+			handler:   operHandler,
+			minParams: 2,
+		},
+		"PART": {
+			handler:   partHandler,
+			minParams: 1,
+		},
+		"PASS": {
+			handler:      passHandler,
+			usablePreReg: true,
+			minParams:    1,
+		},
+		"PING": {
+			handler:           pingHandler,
+			usablePreReg:      true,
+			minParams:         1,
+			leaveClientActive: true,
+		},
+		"PONG": {
+			handler:           pongHandler,
+			usablePreReg:      true,
+			minParams:         1,
+			leaveClientActive: true,
+		},
+		"PRIVMSG": {
+			handler:   privmsgHandler,
+			minParams: 2,
+		},
+		"PROXY": {
+			handler:      proxyHandler,
+			usablePreReg: true,
+			minParams:    5,
+		},
+		"RENAME": {
+			handler:   renameHandler,
+			minParams: 2,
+		},
+		"RESUME": {
+			handler:      resumeHandler,
+			usablePreReg: true,
+			minParams:    1,
+		},
+		"SANICK": {
+			handler:   sanickHandler,
+			minParams: 2,
+			oper:      true,
+		},
+		"SAMODE": {
+			handler:   modeHandler,
+			minParams: 1,
+			capabs:    []string{"samode"},
+		},
+		"SCENE": {
+			handler:   sceneHandler,
+			minParams: 2,
+		},
+		"TAGMSG": {
+			handler:   tagmsgHandler,
+			minParams: 1,
+		},
+		"QUIT": {
+			handler:      quitHandler,
+			usablePreReg: true,
+			minParams:    0,
+		},
+		"REHASH": {
+			handler:   rehashHandler,
+			minParams: 0,
+			oper:      true,
+			capabs:    []string{"oper:rehash"},
+		},
+		"TIME": {
+			handler:   timeHandler,
+			minParams: 0,
+		},
+		"TOPIC": {
+			handler:   topicHandler,
+			minParams: 1,
+		},
+		"UNDLINE": {
+			handler:   unDLineHandler,
+			minParams: 1,
+			oper:      true,
+		},
+		"UNKLINE": {
+			handler:   unKLineHandler,
+			minParams: 1,
+			oper:      true,
+		},
+		"USER": {
+			handler:      userHandler,
+			usablePreReg: true,
+			minParams:    4,
+		},
+		"USERHOST": {
+			handler:   userhostHandler,
+			minParams: 1,
+		},
+		"VERSION": {
+			handler:   versionHandler,
+			minParams: 0,
+		},
+		"WEBIRC": {
+			handler:      webircHandler,
+			usablePreReg: true,
+			minParams:    4,
+		},
+		"WHO": {
+			handler:   whoHandler,
+			minParams: 1,
+		},
+		"WHOIS": {
+			handler:   whoisHandler,
+			minParams: 1,
+		},
+		"WHOWAS": {
+			handler:   whowasHandler,
+			minParams: 1,
+		},
+	}
 }

--- a/irc/server.go
+++ b/irc/server.go
@@ -83,7 +83,6 @@ type Server struct {
 	channelRegistry              *ChannelRegistry
 	checkIdent                   bool
 	clients                      *ClientManager
-	commands                     chan Command
 	configFilename               string
 	configurableStateMutex       sync.RWMutex // tier 1; generic protection for server state modified by rehash()
 	connectionLimiter            *connection_limits.Limiter
@@ -147,7 +146,6 @@ func NewServer(config *Config, logger *logger.Manager) (*Server, error) {
 		accounts:            make(map[string]*ClientAccount),
 		channels:            NewChannelManager(),
 		clients:             NewClientManager(),
-		commands:            make(chan Command),
 		connectionLimiter:   connection_limits.NewLimiter(),
 		connectionThrottler: connection_limits.NewThrottler(),
 		languages:           NewLanguageManager(config.Languages.Default, config.Languages.Data),


### PR DESCRIPTION
This removes `Server.commands` (unused), `ChannelRegistry.channels` (unused), and `Server.newConns` (unnecessary, since we may as well just hand new connections off to new goroutines directly).

This last change introduced an initialization loop:

````
# github.com/oragono/oragono/irc                                                                                                     
./commands.go:56:5: initialization loop:
        /home/shivaram/go/src/github.com/oragono/oragono/irc/commands.go:56:5 Commands refers to
        /home/shivaram/go/src/github.com/oragono/oragono/irc/server.go:1615:75 rehashHandler refers to
        /home/shivaram/go/src/github.com/oragono/oragono/irc/server.go:1192:6 (*Server).rehash refers to
        /home/shivaram/go/src/github.com/oragono/oragono/irc/server.go:1214:6 (*Server).applyConfig refers to
        /home/shivaram/go/src/github.com/oragono/oragono/irc/server.go:1546:6 (*Server).setupListeners refers to
        /home/shivaram/go/src/github.com/oragono/oragono/irc/server.go:337:6 (*Server).createListener refers to
        /home/shivaram/go/src/github.com/oragono/oragono/irc/server.go:355:5 (*Server).createListener.func1 refers to
        /home/shivaram/go/src/github.com/oragono/oragono/irc/server.go:268:6 (*Server).acceptClient refers to
        /home/shivaram/go/src/github.com/oragono/oragono/irc/client.go:85:60 NewClient refers to
        /home/shivaram/go/src/github.com/oragono/oragono/irc/client.go:199:6 (*Client).run refers to
        /home/shivaram/go/src/github.com/oragono/oragono/irc/commands.go:56:5 Commands
FAIL    github.com/oragono/oragono/irc [build failed]
````

which was then fixed by moving the initialization of `Commands` to an `init()` function.