### PR TITLE
tweaks to webirc functionality

### DIFF
--- a/irc/gateways.go
+++ b/irc/gateways.go
@@ -58,9 +58,11 @@ func webircHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 				key = x
 			}
 
-			// only accept "tls" flag if the gateway's connection to us is secure as well
-			if strings.ToLower(key) == "tls" && client.flags[TLS] {
-				secure = true
+			if strings.ToLower(key) == "tls" {
+				// only accept "tls" flag if the gateway's connection to us is secure as well
+				if client.flags[TLS] || utils.AddrIsLocal(client.socket.conn.RemoteAddr()) {
+					secure = true
+				}
 			}
 		}
 	}

--- a/irc/gateways.go
+++ b/irc/gateways.go
@@ -58,7 +58,8 @@ func webircHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 				key = x
 			}
 
-			if strings.ToLower(key) == "tls" {
+			lkey := strings.ToLower(key)
+			if lkey == "tls" || lkey == "secure" {
 				// only accept "tls" flag if the gateway's connection to us is secure as well
 				if client.flags[TLS] || utils.AddrIsLocal(client.socket.conn.RemoteAddr()) {
 					secure = true

--- a/irc/gateways.go
+++ b/irc/gateways.go
@@ -41,7 +41,7 @@ func (wc *webircConfig) Populate() (err error) {
 // WEBIRC <password> <gateway> <hostname> <ip> [:flag1 flag2=x flag3]
 func webircHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 	// only allow unregistered clients to use this command
-	if client.registered {
+	if client.registered || client.proxiedIP != "" {
 		return false
 	}
 
@@ -93,7 +93,7 @@ func webircHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 // http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
 func proxyHandler(server *Server, client *Client, msg ircmsg.IrcMessage) bool {
 	// only allow unregistered clients to use this command
-	if client.registered {
+	if client.registered || client.proxiedIP != "" {
 		return false
 	}
 

--- a/irc/utils/net.go
+++ b/irc/utils/net.go
@@ -25,6 +25,17 @@ func AddrLookupHostname(addr net.Addr) string {
 	return LookupHostname(IPString(addr))
 }
 
+// AddrIsLocal returns whether the address is from a trusted local connection (loopback or unix).
+func AddrIsLocal(addr net.Addr) bool {
+	if tcpaddr, ok := addr.(*net.TCPAddr); ok {
+		return tcpaddr.IP.IsLoopback()
+	}
+	if _, ok := addr.(*net.UnixAddr); ok {
+		return true
+	}
+	return false
+}
+
 // LookupHostname returns the hostname for `addr` if it has one. Otherwise, just returns `addr`.
 func LookupHostname(addr string) string {
 	names, err := net.LookupAddr(addr)


### PR DESCRIPTION
Fixes the following issues:

1. There was a quirk where you could connect through a gateway that passes `PROXY` as the first command, then pass `WEBIRC` manually. Since `client.socket.conn.RemoteAddr()` would be something like `127.0.0.1` during processing of the `WEBIRC` command, this would allow you to bypass host checking for `WEBIRC`. (You'd still have to know the password, though.)
1.  `WEBIRC` would not set the TLS flag on the connection if the last hop (from the gateway to oragono) was plaintext, even if it was on a secure connection like loopback.
1. Kiwi's [gateway](https://github.com/kiwiirc/webircgateway/blob/457c708adc51a5fe83fead2aa1ce53f9f1e0e20e/pkg/webircgateway/clientKiwiirc.go#L56) sends the flag `secure` instead of `tls` to indicate a secure connection. (Is there a spec that covers this? The [ircv3 spec](https://ircv3.net/specs/extensions/webirc.html) does not mention flags.)