### PR TITLE
support unix domain sockets (#184)

### DIFF
--- a/irc/utils/net.go
+++ b/irc/utils/net.go
@@ -22,6 +22,9 @@ func IPString(addr net.Addr) string {
 
 // AddrLookupHostname returns the hostname (if possible) or address for the given `net.Addr`.
 func AddrLookupHostname(addr net.Addr) string {
+	if AddrIsUnix(addr) {
+		return "localhost"
+	}
 	return LookupHostname(IPString(addr))
 }
 
@@ -30,10 +33,22 @@ func AddrIsLocal(addr net.Addr) bool {
 	if tcpaddr, ok := addr.(*net.TCPAddr); ok {
 		return tcpaddr.IP.IsLoopback()
 	}
-	if _, ok := addr.(*net.UnixAddr); ok {
-		return true
+	_, ok := addr.(*net.UnixAddr)
+	return ok
+}
+
+// AddrToIP returns the IP address for a net.Addr, or nil if it's a unix domain socket.
+func AddrToIP(addr net.Addr) net.IP {
+	if tcpaddr, ok := addr.(*net.TCPAddr); ok {
+		return tcpaddr.IP
 	}
-	return false
+	return nil
+}
+
+// AddrIsUnix returns whether the address is a unix domain socket.
+func AddrIsUnix(addr net.Addr) bool {
+	_, ok := addr.(*net.UnixAddr)
+	return ok
 }
 
 // LookupHostname returns the hostname for `addr` if it has one. Otherwise, just returns `addr`.

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -16,6 +16,8 @@ server:
         - "127.0.0.1:6668"
         - "[::1]:6668"
         - ":6697" # ssl port
+        # unix domain socket for proxying:
+        # - "/tmp/oragono_sock"
 
     # tls listeners
     tls-listeners:
@@ -59,11 +61,12 @@ server:
     #motd-formatting: true
 
     # addresses/hostnames the PROXY command can be used from
-    # this should be restricted to 127.0.0.1 and localhost at most
+    # this should be restricted to 127.0.0.1/8 and localhost at most
     # you should also add these addresses to the connection limits and throttling exemption lists
     proxy-allowed-from:
         # - localhost
         # - "127.0.0.1"
+        # - "127.0.0.1/8"
 
     # controls the use of the WEBIRC command (by IRC<->web interfaces, bouncers and similar)
     webirc:
@@ -79,6 +82,7 @@ server:
             hosts:
                 # - localhost
                 # - "127.0.0.1"
+                # - "127.0.0.1/8"
                 # - "0::1"
 
     # maximum length of clients' sendQ in bytes


### PR DESCRIPTION
This change:

1. adds a fair amount of implementation complexity
1. is very silly
1. is (I think) kind of awesome

Some behavior changes:

1. You can no longer specify hostnames (other than `localhost`) as allowed for PROXY or WEBIRC. (This avoids trusting the DNS.)
1. You can now specify CIDRs instead.
1. To allow PROXY or WEBIRC from a UNIX domain socket, add `localhost` to the relevant allowed-hosts section of the config.
1. In the rare edge cases where a client may be connected via UNIX domain socket without having (yet) issued PROXY or WEBIRC, we pretend its IP address is `127.0.0.1` for the purpose of hostmasks etc.