### PR TITLE
clean up stopEvent (requires go v1.10)

### DIFF
--- a/irc/server.go
+++ b/irc/server.go
@@ -79,8 +79,6 @@ type ListenerWrapper struct {
 	listener   net.Listener
 	tlsConfig  *tls.Config
 	shouldStop bool
-	// lets the ListenerWrapper inform the server that it has stopped:
-	stopEvent chan bool
 	// protects atomic update of tlsConfig and shouldStop:
 	configMutex sync.Mutex // tier 1
 }
@@ -363,7 +361,6 @@ func (server *Server) createListener(addr string, tlsConfig *tls.Config) *Listen
 		listener:   listener,
 		tlsConfig:  tlsConfig,
 		shouldStop: false,
-		stopEvent:  make(chan bool, 1),
 	}
 
 	var shouldStop bool
@@ -394,7 +391,6 @@ func (server *Server) createListener(addr string, tlsConfig *tls.Config) *Listen
 
 			if shouldStop {
 				listener.Close()
-				wrapper.stopEvent <- true
 				return
 			}
 		}
@@ -1079,8 +1075,6 @@ func (server *Server) setupListeners(config *Config) {
 		} else {
 			// tell the listener it should stop by interrupting its Accept() call:
 			currentListener.listener.Close()
-			// TODO(golang1.10) delete stopEvent once issue #21856 is released
-			<-currentListener.stopEvent
 			delete(server.listeners, addr)
 			server.logger.Info("listeners", fmt.Sprintf("stopped listening on %s.", addr))
 		}


### PR DESCRIPTION
Go v1.10 is out, including the release of our listener-closing proposal! We can now dispense with `stopEvent`.