### PR TITLE
implement #199

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -65,6 +65,7 @@ type Client struct {
 	nickMaskString     string // cache for nickmask string since it's used with lots of replies
 	nickTimer          *NickTimer
 	operName           string
+	preregNick         string
 	proxiedIP          net.IP // actual remote IP if using the PROXY protocol
 	quitMessage        string
 	rawHostname        string

--- a/irc/config.go
+++ b/irc/config.go
@@ -61,6 +61,7 @@ func (conf *PassConfig) PasswordBytes() []byte {
 type AccountConfig struct {
 	Registration          AccountRegistrationConfig
 	AuthenticationEnabled bool                  `yaml:"authentication-enabled"`
+	SkipServerPassword    bool                  `yaml:"skip-server-password"`
 	NickReservation       NickReservationConfig `yaml:"nick-reservation"`
 }
 

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -142,6 +142,30 @@ func (client *Client) SetAccountName(account string) (changed bool) {
 	return
 }
 
+func (client *Client) Authorized() bool {
+	client.stateMutex.RLock()
+	defer client.stateMutex.RUnlock()
+	return client.authorized
+}
+
+func (client *Client) SetAuthorized(authorized bool) {
+	client.stateMutex.Lock()
+	defer client.stateMutex.Unlock()
+	client.authorized = authorized
+}
+
+func (client *Client) PreregNick() string {
+	client.stateMutex.RLock()
+	defer client.stateMutex.RUnlock()
+	return client.preregNick
+}
+
+func (client *Client) SetPreregNick(preregNick string) {
+	client.stateMutex.Lock()
+	defer client.stateMutex.Unlock()
+	client.preregNick = preregNick
+}
+
 func (client *Client) HasMode(mode modes.Mode) bool {
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -319,6 +319,10 @@ func authenticateHandler(server *Server, client *Client, msg ircmsg.IrcMessage, 
 	// let the SASL handler do its thing
 	exiting := handler(server, client, client.saslMechanism, data, rb)
 
+	if client.LoggedIntoAccount() && server.AccountConfig().SkipServerPassword {
+		client.SetAuthorized(true)
+	}
+
 	// wait 'til SASL is done before emptying the sasl vars
 	client.saslInProgress = false
 	client.saslMechanism = ""
@@ -491,9 +495,8 @@ func capHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Respo
 		rb.Add(nil, server.name, "CAP", client.nick, "ACK", capString)
 
 	case "END":
-		if !client.registered {
+		if !client.Registered() {
 			client.capState = caps.NegotiatedState
-			server.tryRegister(client)
 		}
 
 	default:
@@ -1633,12 +1636,12 @@ func namesHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Res
 
 // NICK <nickname>
 func nickHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
-	if !client.authorized {
-		client.Quit("Bad password")
-		return true
+	if client.Registered() {
+		performNickChange(server, client, client, msg.Params[0], rb)
+	} else {
+		client.SetPreregNick(msg.Params[0])
 	}
-
-	return performNickChange(server, client, client, msg.Params[0], rb)
+	return false
 }
 
 // NOTICE <target>{,<target>} <message>
@@ -1831,14 +1834,14 @@ func partHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 
 // PASS <password>
 func passHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
-	if client.registered {
+	if client.Registered() {
 		rb.Add(nil, server.name, ERR_ALREADYREGISTRED, client.nick, client.t("You may not reregister"))
 		return false
 	}
 
 	// if no password exists, skip checking
 	if len(server.password) == 0 {
-		client.authorized = true
+		client.SetAuthorized(true)
 		return false
 	}
 
@@ -1850,7 +1853,7 @@ func passHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 		return true
 	}
 
-	client.authorized = true
+	client.SetAuthorized(true)
 	return false
 }
 
@@ -1942,7 +1945,7 @@ func privmsgHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *R
 // http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
 func proxyHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
 	// only allow unregistered clients to use this command
-	if client.registered || client.proxiedIP != nil {
+	if client.Registered() || client.proxiedIP != nil {
 		return false
 	}
 
@@ -2106,7 +2109,8 @@ func sanickHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Re
 		rb.Add(nil, server.name, ERR_NOSUCHNICK, client.nick, msg.Params[0], client.t("No such nick"))
 		return false
 	}
-	return performNickChange(server, client, target, msg.Params[1], rb)
+	performNickChange(server, client, target, msg.Params[1], rb)
+	return false
 }
 
 // SCENE <target> <message>
@@ -2320,14 +2324,9 @@ func unKLineHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *R
 
 // USER <username> * 0 <realname>
 func userHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
-	if client.registered {
+	if client.Registered() {
 		rb.Add(nil, server.name, ERR_ALREADYREGISTRED, client.nick, client.t("You may not reregister"))
 		return false
-	}
-
-	if !client.authorized {
-		client.Quit("Bad password")
-		return true
 	}
 
 	if client.username != "" && client.realname != "" {
@@ -2349,8 +2348,6 @@ func userHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 	if client.realname == "" {
 		client.realname = msg.Params[3]
 	}
-
-	server.tryRegister(client)
 
 	return false
 }
@@ -2403,7 +2400,7 @@ func versionHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *R
 // WEBIRC <password> <gateway> <hostname> <ip> [:flag1 flag2=x flag3]
 func webircHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
 	// only allow unregistered clients to use this command
-	if client.registered || client.proxiedIP != nil {
+	if client.Registered() || client.proxiedIP != nil {
 		return false
 	}
 

--- a/irc/nickname.go
+++ b/irc/nickname.go
@@ -23,6 +23,7 @@ var (
 	}
 )
 
+// returns whether the change succeeded or failed
 func performNickChange(server *Server, client *Client, target *Client, newnick string, rb *ResponseBuffer) bool {
 	nickname := strings.TrimSpace(newnick)
 	cfnick, err := CasefoldName(nickname)
@@ -38,7 +39,7 @@ func performNickChange(server *Server, client *Client, target *Client, newnick s
 	}
 
 	if target.Nick() == nickname {
-		return false
+		return true
 	}
 
 	hadNick := target.HasNick()
@@ -49,7 +50,7 @@ func performNickChange(server *Server, client *Client, target *Client, newnick s
 		rb.Add(nil, server.name, ERR_NICKNAMEINUSE, client.nick, nickname, client.t("Nickname is already in use"))
 		return false
 	} else if err == errNicknameReserved {
-		client.Send(nil, server.name, ERR_NICKNAMEINUSE, client.nick, nickname, client.t("Nickname is reserved by a different account"))
+		rb.Add(nil, server.name, ERR_NICKNAMEINUSE, client.nick, nickname, client.t("Nickname is reserved by a different account"))
 		return false
 	} else if err != nil {
 		rb.Add(nil, server.name, ERR_UNKNOWNERROR, client.nick, "NICK", fmt.Sprintf(client.t("Could not set or change nickname: %s"), err.Error()))
@@ -67,12 +68,11 @@ func performNickChange(server *Server, client *Client, target *Client, newnick s
 		}
 	}
 
-	if target.registered {
+	if target.Registered() {
 		client.server.monitorManager.AlertAbout(target, true)
-	} else {
-		server.tryRegister(target)
 	}
-	return false
+	// else: Run() will attempt registration immediately after this
+	return true
 }
 
 func (server *Server) RandomlyRename(client *Client) {

--- a/irc/server.go
+++ b/irc/server.go
@@ -437,6 +437,7 @@ func (server *Server) tryRegister(c *Client) {
 	nickAssigned := performNickChange(server, c, c, preregNick, rb)
 	rb.Send()
 	if !nickAssigned {
+		c.SetPreregNick("")
 		return
 	}
 

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -170,6 +170,13 @@ accounts:
     # is account authentication enabled?
     authentication-enabled: true
 
+    # some clients (notably Pidgin and Hexchat) offer only a single password field,
+    # which makes it impossible to specify a separate server password (for the PASS
+    # command) and SASL password. if this option is set to true, a client that
+    # successfully authenticates with SASL will not be required to send
+    # PASS as well, so it can be configured to authenticate with SASL only.
+    skip-server-password: false
+
     # nick-reservation controls how, and whether, nicknames are linked to accounts
     nick-reservation:
         # is there any enforcement of reserved nicknames?


### PR DESCRIPTION
Implements what we talked about, more or less: you can send `NICK` and `USER` before `PASS`, but by the time registration is complete (i.e., you sent `NICK` *and* `USER`, and also` CAP END` if you're doing negotiation), you must have sent `PASS` (or authenticated with SASL, if the server is configured to accept that as an alternative).

The tradeoff is that you don't get your nickname error, e.g., `ERR_NICKNAMEINUSE` or `ERR_ERRONEUSNICKNAME`, until the final registration command (probably either `USER` or `CAP END`). But I'm guessing most clients can tolerate this OK. (Hexchat correctly switches over to the second-choice nickname, at which point it sends a new `NICK` command and registration succeeds.)

Here's what the handshake looks like with Hexchat doing SASL-only auth: https://gist.github.com/slingamn/0f0625020d6d9593efca2310