### PR TITLE
some small fixes

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1594,16 +1594,14 @@ func motdHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 	return false
 }
 
-// NAMES [<channel>{,<channel>}]
+// NAMES [<channel>{,<channel>} [target]]
 func namesHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
 	var channels []string
 	if len(msg.Params) > 0 {
 		channels = strings.Split(msg.Params[0], ",")
 	}
-	//var target string
-	//if len(msg.Params) > 1 {
-	//	target = msg.Params[1]
-	//}
+
+	// TODO: in a post-federation world, process `target` (server to forward request to)
 
 	if len(channels) == 0 {
 		for _, channel := range server.channels.Channels() {
@@ -1612,21 +1610,13 @@ func namesHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Res
 		return false
 	}
 
-	// limit regular users to only listing one channel
-	if !client.flags[modes.Operator] {
-		channels = channels[:1]
-	}
-
 	for _, chname := range channels {
-		casefoldedChname, err := CasefoldChannel(chname)
-		channel := server.channels.Get(casefoldedChname)
-		if err != nil || channel == nil {
-			if len(chname) > 0 {
-				rb.Add(nil, server.name, ERR_NOSUCHCHANNEL, client.nick, chname, client.t("No such channel"))
-			}
-			continue
+		channel := server.channels.Get(chname)
+		if channel != nil {
+			channel.Names(client, rb)
+		} else if chname != "" {
+			rb.Add(nil, server.name, RPL_ENDOFNAMES, client.Nick(), chname, client.t("End of NAMES list"))
 		}
-		channel.Names(client, rb)
 	}
 	return false
 }

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -79,6 +79,7 @@ server:
             password: JDJhJDA0JG9rTTVERlNRa0hpOEZpNkhjZE95SU9Da1BseFdlcWtOTEQxNEFERVlqbEZNTkdhOVlYUkMu
 
             # hosts that can use this webirc command
+            # you should also add these addresses to the connection limits and throttling exemption lists
             hosts:
                 # - localhost
                 # - "127.0.0.1"

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -100,8 +100,8 @@ server:
         # how wide the cidr should be for IPv6
         cidr-len-ipv6: 64
 
-        # maximum number of IPs per subnet (defined above by the cird length)
-        ips-per-subnet: 16
+        # maximum concurrent connections per subnet (defined above by the cidr length)
+        connections-per-subnet: 16
 
         # IPs/networks which are exempted from connection limits
         exempted:


### PR DESCRIPTION
1. `ips-per-subnet` is a confusing name; this renames it to `connections-per-subnet` while preserving backwards compatibility.
1. Add a warning to the reference config file about whitelisting `WEBIRC` gateways from the limiter and throttler.
1. Make `NAMES` behavior complaint with the RFC. (This removes the operator check, since even before this, unprivileged users could issue bare `NAMES` and see all the channels. This should probably end up being a role capability --- does the role capability system support assigning privileges to non-operators?)