### PR TITLE
Read incoming data in a buffered way, killing clients appropriately

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -85,7 +85,8 @@ type Client struct {
 // NewClient returns a client with all the appropriate info setup.
 func NewClient(server *Server, conn net.Conn, isTLS bool) *Client {
 	now := time.Now()
-	socket := NewSocket(conn, server.MaxSendQBytes)
+	fullLineLenLimit := server.limits.LineLen.Tags + server.limits.LineLen.Rest
+	socket := NewSocket(conn, fullLineLenLimit*2, server.MaxSendQBytes)
 	go socket.RunSocketWriter()
 	client := &Client{
 		atime:          now,

--- a/irc/errors.go
+++ b/irc/errors.go
@@ -36,6 +36,7 @@ var (
 var (
 	errNoPeerCerts = errors.New("Client did not provide a certificate")
 	errNotTLS      = errors.New("Not a TLS connection")
+	errReadQ       = errors.New("ReadQ Exceeded")
 )
 
 // String Errors


### PR DESCRIPTION
Hmm... So we had the issue where someone could send a bunch of data into the server without a newline and Oragono would just read it forever into memory. This is bad when it reads a whole lot into memory.

This change makes the server instead read into a buffer byte-by-byte and check the maximum read length (2 x max linelen). If it's too much it kills the client.

The SetFinalData change is to make sure the client doesn't stomp over our ReadQ exceeded message.