### PR TITLE
two nickname reservation fixes

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -354,9 +354,6 @@ func (am *AccountManager) LoadAccount(casefoldedAccount string) (result ClientAc
 	var raw rawClientAccount
 	am.server.store.View(func(tx *buntdb.Tx) error {
 		raw, err = am.loadRawAccount(tx, casefoldedAccount)
-		if err == buntdb.ErrNotFound {
-			err = errAccountDoesNotExist
-		}
 		return nil
 	})
 	if err != nil {

--- a/irc/client.go
+++ b/irc/client.go
@@ -686,9 +686,8 @@ func (client *Client) destroy(beingResumed bool) {
 	}
 
 	// clean up self
-	if client.idletimer != nil {
-		client.idletimer.Stop()
-	}
+	client.idletimer.Stop()
+	client.nickTimer.Stop()
 
 	client.server.accounts.Logout(client)
 

--- a/irc/idletimer.go
+++ b/irc/idletimer.go
@@ -127,6 +127,10 @@ func (it *IdleTimer) processTimeout() {
 
 // Stop stops counting idle time.
 func (it *IdleTimer) Stop() {
+	if it == nil {
+		return
+	}
+
 	it.Lock()
 	defer it.Unlock()
 	it.state = TimerDead
@@ -229,6 +233,20 @@ func (nt *NickTimer) Touch() {
 
 	if shouldWarn {
 		nt.sendWarning()
+	}
+}
+
+// Stop stops counting time and cleans up the timer
+func (nt *NickTimer) Stop() {
+	if nt == nil {
+		return
+	}
+
+	nt.Lock()
+	defer nt.Unlock()
+	if nt.timer != nil {
+		nt.timer.Stop()
+		nt.timer = nil
 	}
 }
 

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -146,8 +146,7 @@ accounts:
         enabled: true
 
         # length of time a user has to verify their account before it can be re-registered
-        # default is 120 hours, or 5 days
-        verify-timeout: "120h"
+        verify-timeout: "32h"
 
         # callbacks to allow
         enabled-callbacks:


### PR DESCRIPTION
Two changes:

1. Bug fix: we didn't stop the `NickTimer` on client quit. This caused really weird stuff to happen if a client disconnected while the timer was running.
1. Allow re-registration of unverified accounts. I'm not sure if this is the right thing to do, but it handles cases where someone tries to sign up with the wrong email address, or the email doesn't get delivered correctly.