### PR TITLE
add an option to expose a pprof http endpoint

### DIFF
--- a/irc/config.go
+++ b/irc/config.go
@@ -237,7 +237,8 @@ type Config struct {
 	Logging []logger.LoggingConfig
 
 	Debug struct {
-		RecoverFromErrors *bool `yaml:"recover-from-errors"`
+		RecoverFromErrors *bool   `yaml:"recover-from-errors"`
+		PprofListener     *string `yaml:"pprof-listener"`
 		StackImpact       StackImpactConfig
 	}
 

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -316,6 +316,12 @@ debug:
     # this to false.
     recover-from-errors: true
 
+    # optionally expose a pprof http endpoint: https://golang.org/pkg/net/http/pprof/
+    # it is strongly recommended that you don't expose this on a public interface;
+    # if you need to access it remotely, you can use an SSH tunnel.
+    # set to `null`, "", leave blank, or omit to disable
+    pprof-listener: "localhost:6060"
+
     # enabling StackImpact profiling
     stackimpact:
         # whether to use StackImpact

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -320,7 +320,7 @@ debug:
     # it is strongly recommended that you don't expose this on a public interface;
     # if you need to access it remotely, you can use an SSH tunnel.
     # set to `null`, "", leave blank, or omit to disable
-    pprof-listener: "localhost:6060"
+    # pprof-listener: "localhost:6060"
 
     # enabling StackImpact profiling
     stackimpact:


### PR DESCRIPTION
The thing where importing `net/http/pprof` modifies the global `DefaultServeMux` is really gross. But it seems like the standard practice. Anyway, down the line, if we add native websocket support again, we'll have to be careful that we don't accidentally expose the pprof endpoints over the websocket listener.