### PR TITLE
refactor irc.Socket

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -86,7 +86,9 @@ type Client struct {
 // NewClient returns a client with all the appropriate info setup.
 func NewClient(server *Server, conn net.Conn, isTLS bool) *Client {
 	now := time.Now()
-	socket := NewSocket(conn, server.MaxSendQBytes)
+	limits := server.Limits()
+	fullLineLenLimit := limits.LineLen.Tags + limits.LineLen.Rest
+	socket := NewSocket(conn, fullLineLenLimit*2, server.MaxSendQBytes())
 	go socket.RunSocketWriter()
 	client := &Client{
 		atime:          now,
@@ -230,7 +232,11 @@ func (client *Client) run() {
 
 		line, err = client.socket.Read()
 		if err != nil {
-			client.Quit("connection closed")
+			quitMessage := "connection closed"
+			if err == errReadQ {
+				quitMessage = "readQ exceeded"
+			}
+			client.Quit(quitMessage)
 			break
 		}
 

--- a/irc/config.go
+++ b/irc/config.go
@@ -208,7 +208,7 @@ type Config struct {
 		ProxyAllowedFrom    []string       `yaml:"proxy-allowed-from"`
 		WebIRC              []webircConfig `yaml:"webirc"`
 		MaxSendQString      string         `yaml:"max-sendq"`
-		MaxSendQBytes       uint64
+		MaxSendQBytes       int
 		ConnectionLimiter   connection_limits.LimiterConfig   `yaml:"connection-limits"`
 		ConnectionThrottler connection_limits.ThrottlerConfig `yaml:"connection-throttling"`
 	}
@@ -520,10 +520,11 @@ func LoadConfig(filename string) (config *Config, err error) {
 		}
 	}
 
-	config.Server.MaxSendQBytes, err = bytefmt.ToBytes(config.Server.MaxSendQString)
+	maxSendQBytes, err := bytefmt.ToBytes(config.Server.MaxSendQString)
 	if err != nil {
 		return nil, fmt.Errorf("Could not parse maximum SendQ size (make sure it only contains whole numbers): %s", err.Error())
 	}
+	config.Server.MaxSendQBytes = int(maxSendQBytes)
 
 	// get language files
 	config.Languages.Data = make(map[string]languages.LangData)

--- a/irc/errors.go
+++ b/irc/errors.go
@@ -40,6 +40,7 @@ var (
 var (
 	errNoPeerCerts = errors.New("Client did not provide a certificate")
 	errNotTLS      = errors.New("Not a TLS connection")
+	errReadQ       = errors.New("ReadQ Exceeded")
 )
 
 // String Errors

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -10,11 +10,11 @@ import (
 )
 
 func (server *Server) MaxSendQBytes() int {
-	return int(atomic.LoadUint64(&server.maxSendQBytes))
+	return int(atomic.LoadUint32(&server.maxSendQBytes))
 }
 
 func (server *Server) SetMaxSendQBytes(m int) {
-	atomic.StoreUint64(&server.maxSendQBytes, uint64(m))
+	atomic.StoreUint32(&server.maxSendQBytes, uint32(m))
 }
 
 func (server *Server) ISupport() *isupport.List {

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -6,7 +6,16 @@ package irc
 import (
 	"github.com/oragono/oragono/irc/isupport"
 	"github.com/oragono/oragono/irc/modes"
+	"sync/atomic"
 )
+
+func (server *Server) MaxSendQBytes() int {
+	return int(atomic.LoadUint64(&server.maxSendQBytes))
+}
+
+func (server *Server) SetMaxSendQBytes(m int) {
+	atomic.StoreUint64(&server.maxSendQBytes, uint64(m))
+}
 
 func (server *Server) ISupport() *isupport.List {
 	server.configurableStateMutex.RLock()

--- a/irc/server.go
+++ b/irc/server.go
@@ -109,7 +109,7 @@ type Server struct {
 	limits                     Limits
 	listeners                  map[string]*ListenerWrapper
 	logger                     *logger.Manager
-	maxSendQBytes              uint64
+	maxSendQBytes              uint32
 	monitorManager             *MonitorManager
 	motdLines                  []string
 	name                       string

--- a/irc/server.go
+++ b/irc/server.go
@@ -109,7 +109,7 @@ type Server struct {
 	limits                     Limits
 	listeners                  map[string]*ListenerWrapper
 	logger                     *logger.Manager
-	MaxSendQBytes              uint64
+	maxSendQBytes              uint64
 	monitorManager             *MonitorManager
 	motdLines                  []string
 	name                       string
@@ -932,16 +932,7 @@ func (server *Server) applyConfig(config *Config, initial bool) error {
 	server.configurableStateMutex.Unlock()
 
 	// set new sendqueue size
-	if config.Server.MaxSendQBytes != server.MaxSendQBytes {
-		server.configurableStateMutex.Lock()
-		server.MaxSendQBytes = config.Server.MaxSendQBytes
-		server.configurableStateMutex.Unlock()
-
-		// update on all clients
-		for _, sClient := range server.clients.AllClients() {
-			sClient.socket.MaxSendQBytes = config.Server.MaxSendQBytes
-		}
-	}
+	server.SetMaxSendQBytes(config.Server.MaxSendQBytes)
 
 	// set RPL_ISUPPORT
 	var newISupportReplies [][]string


### PR DESCRIPTION
Should be quite a bit simpler now; there's a chance that I introduced some kind of horrifying edge case too.

From what I understand, there's no need to drain channels when disposing of them, because channels and their contents are subject to normal garbage collection rules.