### PR TITLE
try to fix travis by pinning a goreleaser release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 install: make deps
 
 script:
-- go get github.com/goreleaser/goreleaser
+- wget https://github.com/goreleaser/goreleaser/releases/download/v0.62.2/goreleaser_Linux_x86_64.tar.gz
+- tar -xzf goreleaser_Linux_x86_64.tar.gz -C $GOPATH/bin
 - make
 - make test


### PR DESCRIPTION
(Just want to see if this will work; I wasn't able to fully test it in my fork because, e.g., the code hardcodes `github.com/oragono/oragono/irc/passwd` as the package name.)