### PR TITLE
fix fakelag double-rate issue

### DIFF
--- a/irc/fakelag.go
+++ b/irc/fakelag.go
@@ -85,9 +85,10 @@ func (fl *Fakelag) Touch() {
 		}
 		// space them out by at least window/messagesperwindow
 		sleepDuration := time.Duration((int64(fl.window) / int64(fl.throttleMessagesPerWindow)) - int64(elapsed))
-		if sleepDuration < 0 {
-			sleepDuration = 0
+		if sleepDuration > 0 {
+			fl.sleepFunc(sleepDuration)
+			// the touch time should take into account the time we slept
+			fl.lastTouch = fl.nowFunc()
 		}
-		fl.sleepFunc(sleepDuration)
 	}
 }

--- a/irc/fakelag_test.go
+++ b/irc/fakelag_test.go
@@ -83,13 +83,15 @@ func TestFakelag(t *testing.T) {
 		t.Fatalf("incorrect sleep time: %v != %v", expected, duration)
 	}
 
+	// send another message without a pause; we should have to sleep for 500 msec
 	fl.Touch()
 	if fl.state != FakelagThrottled {
 		t.Fatalf("should be throttled")
 	}
 	slept, duration = mt.lastSleep()
-	if duration != interval {
-		t.Fatalf("incorrect sleep time: %v != %v", interval, duration)
+	expected, _ = time.ParseDuration("500ms")
+	if duration != expected {
+		t.Fatalf("incorrect sleep time: %v != %v", duration, expected)
 	}
 
 	mt.pause(interval * 6)


### PR DESCRIPTION
Commit message with the official explanation:

Basically, fakelag was counting the time imposed by its own sleeps as though
the user had themselves paused for that amount of time. Therefore, if a user
sent a large number of consecutive commands, every other command would pause
for the expected throttle interval, but the subsequent command would be
processed instantly (you'd get two back-to-back commands). This resulted in
throttled users being able to send at double the expected rate.

Unofficial explanation:

(a) I somehow miscounted the messages during manual testing (b) apparently in the unit test, I just wrote in whatever numbers would make it pass. (So the unit test is still valuable for ascertaining that future refactors preserve the correctness of the code. But as originally written, the code and the test were equally incorrect.)