### PR TITLE
fix #268

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 
+go:
+    - "1.10.x"
+
 install: make deps
 
 script:
@@ -7,4 +10,3 @@ script:
 - tar -xzf goreleaser_Linux_x86_64.tar.gz -C $GOPATH/bin
 - make
 - make test
-- ./.check-gofmt.sh

--- a/irc/modes/modes.go
+++ b/irc/modes/modes.go
@@ -366,6 +366,10 @@ func (set *ModeSet) SetMode(mode Mode, on bool) (applied bool) {
 
 // return the modes in the set as a slice
 func (set *ModeSet) AllModes() (result []Mode) {
+	if set == nil {
+		return
+	}
+
 	set.RLock()
 	defer set.RUnlock()
 
@@ -376,22 +380,27 @@ func (set *ModeSet) AllModes() (result []Mode) {
 }
 
 // String returns the modes in this set.
-func (set *ModeSet) String() string {
+func (set *ModeSet) String() (result string) {
+	if set == nil {
+		return
+	}
+
 	set.RLock()
 	defer set.RUnlock()
 
-	if len(set.modes) == 0 {
-		return ""
-	}
-	var result []byte
+	var buf strings.Builder
 	for mode := range set.modes {
-		result = append(result, mode.String()...)
+		buf.WriteRune(rune(mode))
 	}
-	return string(result)
+	return buf.String()
 }
 
 // Prefixes returns a list of prefixes for the given set of channel modes.
 func (set *ModeSet) Prefixes(isMultiPrefix bool) (prefixes string) {
+	if set == nil {
+		return
+	}
+
 	set.RLock()
 	defer set.RUnlock()
 

--- a/irc/modes/modes.go
+++ b/irc/modes/modes.go
@@ -340,6 +340,10 @@ func NewModeSet() *ModeSet {
 
 // test whether `mode` is set
 func (set *ModeSet) HasMode(mode Mode) bool {
+	if set == nil {
+		return false
+	}
+
 	set.RLock()
 	defer set.RUnlock()
 	return set.modes[mode]

--- a/irc/modes/modes_test.go
+++ b/irc/modes/modes_test.go
@@ -35,3 +35,16 @@ func TestSetMode(t *testing.T) {
 		t.Errorf("unexpected modestring: %s", modeString)
 	}
 }
+
+func TestNilReceivers(t *testing.T) {
+	var set ModeSet
+
+	if set.HasMode(Invisible) {
+		t.Errorf("nil ModeSet should not have any modes")
+	}
+
+	str := set.String()
+	if str != "" {
+		t.Errorf("nil Modeset should have empty String(), got %v instead", str)
+	}
+}


### PR DESCRIPTION
Basically what's happening on #268 is that although SAMODE is respected (i.e., a client issuing a valid SAMODE does not require channel permissions), a check of channel permissions happens first as an implementation detail, and this check was crashing in the case that the client is not joined to the channel. 

This makes it not crash. The other option is adding a nil check to the client:

````diff
diff --git a/irc/channel.go b/irc/channel.go
index a48e7d8..178901f 100644
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -231,6 +231,9 @@ func (channel *Channel) ClientIsAtLeast(client *Client, permission modes.Mode) b
 	defer channel.stateMutex.RUnlock()
 
 	clientModes := channel.members[client]
+	if clientModes == nil {
+		return false
+	}
 
 	// get voice, since it's not a part of ChannelPrivModes
 	if clientModes.HasMode(permission) {
````

but this seemed about as clean.