### PR TITLE
frontend for persistent account modes in channels

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -232,13 +232,7 @@ func (channel *Channel) ClientIsAtLeast(client *Client, permission modes.Mode) b
 
 	clientModes := channel.members[client]
 
-	// get voice, since it's not a part of ChannelPrivModes
-	if clientModes.HasMode(permission) {
-		return true
-	}
-
-	// check regular modes
-	for _, mode := range modes.ChannelPrivModes {
+	for _, mode := range modes.ChannelUserModes {
 		if clientModes.HasMode(mode) {
 			return true
 		}

--- a/irc/errors.go
+++ b/irc/errors.go
@@ -34,6 +34,7 @@ var (
 	errNoExistingBan                  = errors.New("Ban does not exist")
 	errNoSuchChannel                  = errors.New("No such channel")
 	errRenamePrivsNeeded              = errors.New("Only chanops can rename channels")
+	errInsufficientPrivs              = errors.New("Insufficient privileges")
 	errSaslFail                       = errors.New("SASL failed")
 )
 

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -303,37 +303,3 @@ func (channel *Channel) Founder() string {
 	defer channel.stateMutex.RUnlock()
 	return channel.registeredFounder
 }
-
-func (channel *Channel) AccountToUmode() (result []modes.ModeChange) {
-	channel.stateMutex.RLock()
-	defer channel.stateMutex.RUnlock()
-	for account, mode := range channel.accountToUMode {
-		result = append(result, modes.ModeChange{
-			Mode: mode,
-			Arg:  account,
-			Op:   modes.Add,
-		})
-	}
-
-	return
-}
-
-func (channel *Channel) ApplyAccountToUmodeChange(change modes.ModeChange) (applied bool) {
-	channel.stateMutex.Lock()
-	defer channel.stateMutex.Unlock()
-
-	current := channel.accountToUMode[change.Arg]
-	switch change.Op {
-	case modes.Add:
-		applied = (current != change.Mode)
-		if applied {
-			channel.accountToUMode[change.Arg] = change.Mode
-		}
-	case modes.Remove:
-		applied = (current == change.Mode)
-		if applied {
-			delete(channel.accountToUMode, change.Arg)
-		}
-	}
-	return
-}

--- a/irc/modes/modes.go
+++ b/irc/modes/modes.go
@@ -147,6 +147,12 @@ var (
 		ChannelFounder, ChannelAdmin, ChannelOperator, Halfop,
 	}
 
+	// ChannelUserModes holds the list of all modes that can be applied to a user in a channel,
+	// including Voice, in descending order of precedence
+	ChannelUserModes = Modes{
+		ChannelFounder, ChannelAdmin, ChannelOperator, Halfop, Voice,
+	}
+
 	ChannelModePrefixes = map[Mode]string{
 		ChannelFounder:  "~",
 		ChannelAdmin:    "&",
@@ -176,20 +182,13 @@ func SplitChannelMembershipPrefixes(target string) (prefixes string, name string
 }
 
 // GetLowestChannelModePrefix returns the lowest channel prefix mode out of the given prefixes.
-func GetLowestChannelModePrefix(prefixes string) *Mode {
-	var lowest *Mode
-
-	if strings.Contains(prefixes, "+") {
-		lowest = &Voice
-	} else {
-		for i, mode := range ChannelPrivModes {
-			if strings.Contains(prefixes, ChannelModePrefixes[mode]) {
-				lowest = &ChannelPrivModes[i]
-			}
+func GetLowestChannelModePrefix(prefixes string) (lowest *Mode) {
+	for i, mode := range ChannelUserModes {
+		if strings.Contains(prefixes, ChannelModePrefixes[mode]) {
+			lowest = &ChannelPrivModes[i]
 		}
 	}
-
-	return lowest
+	return
 }
 
 //
@@ -304,14 +303,11 @@ func ParseChannelModeChanges(params ...string) (ModeChanges, map[rune]bool) {
 					break
 				}
 			}
-			for _, supportedMode := range ChannelPrivModes {
+			for _, supportedMode := range ChannelUserModes {
 				if rune(supportedMode) == mode {
 					isKnown = true
 					break
 				}
-			}
-			if mode == rune(Voice) {
-				isKnown = true
 			}
 			if !isKnown {
 				unknown[mode] = true
@@ -392,13 +388,10 @@ func (set *ModeSet) Prefixes(isMultiPrefix bool) (prefixes string) {
 	defer set.RUnlock()
 
 	// add prefixes in order from highest to lowest privs
-	for _, mode := range ChannelPrivModes {
+	for _, mode := range ChannelUserModes {
 		if set.modes[mode] {
 			prefixes += ChannelModePrefixes[mode]
 		}
-	}
-	if set.modes[Voice] {
-		prefixes += ChannelModePrefixes[Voice]
 	}
 
 	if !isMultiPrefix && len(prefixes) > 1 {

--- a/irc/modes/modes_test.go
+++ b/irc/modes/modes_test.go
@@ -8,6 +8,47 @@ import (
 	"testing"
 )
 
+func TestParseChannelModeChanges(t *testing.T) {
+	modes, unknown := ParseChannelModeChanges("+h", "wrmsr")
+	if len(unknown) > 0 {
+		t.Errorf("unexpected unknown mode change: %v", unknown)
+	}
+	expected := ModeChange{
+		Op:   Add,
+		Mode: Halfop,
+		Arg:  "wrmsr",
+	}
+	if len(modes) != 1 || modes[0] != expected {
+		t.Errorf("unexpected mode change: %v", modes)
+	}
+
+	modes, unknown = ParseChannelModeChanges("-v", "shivaram")
+	if len(unknown) > 0 {
+		t.Errorf("unexpected unknown mode change: %v", unknown)
+	}
+	expected = ModeChange{
+		Op:   Remove,
+		Mode: Voice,
+		Arg:  "shivaram",
+	}
+	if len(modes) != 1 || modes[0] != expected {
+		t.Errorf("unexpected mode change: %v", modes)
+	}
+
+	modes, unknown = ParseChannelModeChanges("+tx")
+	if len(unknown) != 1 || !unknown['x'] {
+		t.Errorf("expected that x is an unknown mode, instead: %v", unknown)
+	}
+	expected = ModeChange{
+		Op:   Add,
+		Mode: OpOnlyTopic,
+		Arg:  "",
+	}
+	if len(modes) != 1 || modes[0] != expected {
+		t.Errorf("unexpected mode change: %v", modes)
+	}
+}
+
 func TestSetMode(t *testing.T) {
 	set := NewModeSet()
 

--- a/irc/modes_test.go
+++ b/irc/modes_test.go
@@ -36,3 +36,17 @@ func TestParseDefaultChannelModes(t *testing.T) {
 		}
 	}
 }
+
+func TestUmodeGreaterThan(t *testing.T) {
+	if !umodeGreaterThan(modes.Halfop, modes.Voice) {
+		t.Errorf("expected Halfop > Voice")
+	}
+
+	if !umodeGreaterThan(modes.Voice, modes.Mode(0)) {
+		t.Errorf("expected Voice > 0 (the zero value of modes.Mode)")
+	}
+
+	if umodeGreaterThan(modes.ChannelAdmin, modes.ChannelAdmin) {
+		t.Errorf("modes should not be greater than themselves")
+	}
+}

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -283,6 +283,7 @@ oper-classes:
             - "unregister"
             - "samode"
             - "vhosts"
+            - "chanreg"
 
 # ircd operators
 opers:


### PR DESCRIPTION
I called it `AMODE` to emphasize the connection with accounts, as opposed to nicks. Maybe `AUMODE` would be better? Or something else entirely? The syntax looks like a `MODE` command, e.g., `/msg ChanServ AMODE #channel +h accountname`.