### PR TITLE
some tweaks to account/channel unregistration

### DIFF
--- a/oragono.yaml
+++ b/oragono.yaml
@@ -280,7 +280,7 @@ oper-classes:
         capabilities:
             - "oper:rehash"
             - "oper:die"
-            - "unregister"
+            - "accreg"
             - "sajoin"
             - "samode"
             - "vhosts"


### PR DESCRIPTION
1. The oper privilege for account unregistration is now `accreg`, not `unregister`
1. Unregistering an account requires the account name and a confirmation code
1. Persistent channel admins cannot add/remove other admins