### PR TITLE
refactor rehash to rely more on server.config

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -515,8 +515,9 @@ func (channel *Channel) SetTopic(client *Client, topic string, rb *ResponseBuffe
 		return
 	}
 
-	if len(topic) > client.server.limits.TopicLen {
-		topic = topic[:client.server.limits.TopicLen]
+	topicLimit := client.server.Limits().TopicLen
+	if len(topic) > topicLimit {
+		topic = topic[:topicLimit]
 	}
 
 	channel.stateMutex.Lock()

--- a/irc/client.go
+++ b/irc/client.go
@@ -85,9 +85,9 @@ type Client struct {
 // NewClient returns a client with all the appropriate info setup.
 func NewClient(server *Server, conn net.Conn, isTLS bool) *Client {
 	now := time.Now()
-	limits := server.Limits()
-	fullLineLenLimit := limits.LineLen.Tags + limits.LineLen.Rest
-	socket := NewSocket(conn, fullLineLenLimit*2, server.MaxSendQBytes())
+	config := server.Config()
+	fullLineLenLimit := config.Limits.LineLen.Tags + config.Limits.LineLen.Rest
+	socket := NewSocket(conn, fullLineLenLimit*2, config.Server.MaxSendQBytes)
 	client := &Client{
 		atime:          now,
 		authorized:     server.Password() == nil,
@@ -112,7 +112,7 @@ func NewClient(server *Server, conn net.Conn, isTLS bool) *Client {
 		// error is not useful to us here anyways so we can ignore it
 		client.certfp, _ = client.socket.CertFP()
 	}
-	if server.checkIdent && !utils.AddrIsUnix(conn.RemoteAddr()) {
+	if config.Server.CheckIdent && !utils.AddrIsUnix(conn.RemoteAddr()) {
 		_, serverPortString, err := net.SplitHostPort(conn.LocalAddr().String())
 		serverPort, _ := strconv.Atoi(serverPortString)
 		if err != nil {

--- a/irc/config.go
+++ b/irc/config.go
@@ -28,10 +28,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// PassConfig holds the connection password.
-type PassConfig struct {
-	Password string
-}
+// here's how this works: exported (capitalized) members of the config structs
+// are defined in the YAML file and deserialized directly from there. They may
+// be postprocessed and overwritten by LoadConfig. Unexported (lowercase) members
+// are derived from the exported members in LoadConfig.
 
 // TLSListenConfig defines configuration options for listening on TLS.
 type TLSListenConfig struct {
@@ -49,15 +49,6 @@ func (conf *TLSListenConfig) Config() (*tls.Config, error) {
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
 	}, err
-}
-
-// PasswordBytes returns the bytes represented by the password hash.
-func (conf *PassConfig) PasswordBytes() []byte {
-	bytes, err := passwd.DecodePasswordHash(conf.Password)
-	if err != nil {
-		log.Fatal("decode password error: ", err)
-	}
-	return bytes
 }
 
 type AccountConfig struct {
@@ -171,9 +162,22 @@ func (conf *OperConfig) PasswordBytes() []byte {
 }
 
 // LineLenConfig controls line lengths.
-type LineLenConfig struct {
+type LineLenLimits struct {
 	Tags int
 	Rest int
+}
+
+// Various server-enforced limits on data size.
+type Limits struct {
+	AwayLen        int           `yaml:"awaylen"`
+	ChanListModes  int           `yaml:"chan-list-modes"`
+	ChannelLen     int           `yaml:"channellen"`
+	KickLen        int           `yaml:"kicklen"`
+	MonitorEntries int           `yaml:"monitor-entries"`
+	NickLen        int           `yaml:"nicklen"`
+	TopicLen       int           `yaml:"topiclen"`
+	WhowasEntries  int           `yaml:"whowas-entries"`
+	LineLen        LineLenLimits `yaml:"linelen"`
 }
 
 // STSConfig controls the STS configuration/
@@ -219,9 +223,10 @@ type Config struct {
 	}
 
 	Server struct {
-		PassConfig
 		Password            string
+		passwordBytes       []byte
 		Name                string
+		nameCasefolded      string
 		Listen              []string
 		TLSListeners        map[string]*TLSListenConfig `yaml:"tls-listeners"`
 		STS                 STSConfig
@@ -251,13 +256,18 @@ type Config struct {
 	Accounts AccountConfig
 
 	Channels struct {
-		DefaultModes *string `yaml:"default-modes"`
-		Registration ChannelRegistrationConfig
+		RawDefaultModes *string `yaml:"default-modes"`
+		defaultModes    modes.Modes
+		Registration    ChannelRegistrationConfig
 	}
 
 	OperClasses map[string]*OperClassConfig `yaml:"oper-classes"`
 
 	Opers map[string]*OperConfig
+
+	// parsed operator definitions, unexported so they can't be defined
+	// directly in YAML:
+	operators map[string]*Oper
 
 	Logging []logger.LoggingConfig
 
@@ -267,17 +277,7 @@ type Config struct {
 		StackImpact       StackImpactConfig
 	}
 
-	Limits struct {
-		AwayLen        uint          `yaml:"awaylen"`
-		ChanListModes  uint          `yaml:"chan-list-modes"`
-		ChannelLen     uint          `yaml:"channellen"`
-		KickLen        uint          `yaml:"kicklen"`
-		MonitorEntries uint          `yaml:"monitor-entries"`
-		NickLen        uint          `yaml:"nicklen"`
-		TopicLen       uint          `yaml:"topiclen"`
-		WhowasEntries  uint          `yaml:"whowas-entries"`
-		LineLen        LineLenConfig `yaml:"linelen"`
-	}
+	Limits Limits
 
 	Fakelag FakelagConfig
 
@@ -436,11 +436,6 @@ func LoadConfig(filename string) (config *Config, err error) {
 	}
 
 	config.Filename = filename
-
-	// we need this so PasswordBytes returns the correct info
-	if config.Server.Password != "" {
-		config.Server.PassConfig.Password = config.Server.Password
-	}
 
 	if config.Network.Name == "" {
 		return nil, ErrNetworkNameMissing
@@ -689,6 +684,34 @@ func LoadConfig(filename string) (config *Config, err error) {
 		if config.Languages.Default != "en" && !exists {
 			return nil, fmt.Errorf("Cannot find default language [%s]", config.Languages.Default)
 		}
+	}
+
+	// casefold/validate server name
+	config.Server.nameCasefolded, err = Casefold(config.Server.Name)
+	if err != nil {
+		return nil, fmt.Errorf("Server name isn't valid [%s]: %s", config.Server.Name, err.Error())
+	}
+
+	// process operator definitions, store them to config.operators
+	operclasses, err := config.OperatorClasses()
+	if err != nil {
+		return nil, err
+	}
+	opers, err := config.Operators(operclasses)
+	if err != nil {
+		return nil, err
+	}
+	config.operators = opers
+
+	// parse default channel modes
+	config.Channels.defaultModes = ParseDefaultChannelModes(config.Channels.RawDefaultModes)
+
+	if config.Server.Password != "" {
+		bytes, err := passwd.DecodePasswordHash(config.Server.Password)
+		if err != nil {
+			return nil, err
+		}
+		config.Server.passwordBytes = bytes
 	}
 
 	return config, nil

--- a/irc/config.go
+++ b/irc/config.go
@@ -686,6 +686,12 @@ func LoadConfig(filename string) (config *Config, err error) {
 		}
 	}
 
+	// RecoverFromErrors defaults to true
+	if config.Debug.RecoverFromErrors == nil {
+		config.Debug.RecoverFromErrors = new(bool)
+		*config.Debug.RecoverFromErrors = true
+	}
+
 	// casefold/validate server name
 	config.Server.nameCasefolded, err = Casefold(config.Server.Name)
 	if err != nil {

--- a/irc/database.go
+++ b/irc/database.go
@@ -267,7 +267,7 @@ func schemaChangeV2ToV3(config *Config, tx *buntdb.Tx) error {
 	}
 
 	// explicitly store the channel modes
-	defaultModes := ParseDefaultChannelModes(config)
+	defaultModes := ParseDefaultChannelModes(config.Channels.RawDefaultModes)
 	modeStrings := make([]string, len(defaultModes))
 	for i, mode := range defaultModes {
 		modeStrings[i] = string(mode)

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -29,9 +29,7 @@ func (server *Server) Password() []byte {
 }
 
 func (server *Server) RecoverFromErrors() bool {
-	// default to true if unset
-	rfe := server.Config().Debug.RecoverFromErrors
-	return rfe == nil || *rfe
+	return *server.Config().Debug.RecoverFromErrors
 }
 
 func (server *Server) ProxyAllowedFrom() []string {

--- a/irc/modes.go
+++ b/irc/modes.go
@@ -87,12 +87,12 @@ func ApplyUserModeChanges(client *Client, changes modes.ModeChanges, force bool)
 }
 
 // ParseDefaultChannelModes parses the `default-modes` line of the config
-func ParseDefaultChannelModes(config *Config) modes.Modes {
-	if config.Channels.DefaultModes == nil {
+func ParseDefaultChannelModes(rawModes *string) modes.Modes {
+	if rawModes == nil {
 		// not present in config, fall back to compile-time default
 		return DefaultChannelModes
 	}
-	modeChangeStrings := strings.Split(strings.TrimSpace(*config.Channels.DefaultModes), " ")
+	modeChangeStrings := strings.Fields(*rawModes)
 	modeChanges, _ := modes.ParseChannelModeChanges(modeChangeStrings...)
 	defaultChannelModes := make(modes.Modes, 0)
 	for _, modeChange := range modeChanges {

--- a/irc/modes_test.go
+++ b/irc/modes_test.go
@@ -27,10 +27,8 @@ func TestParseDefaultChannelModes(t *testing.T) {
 		{nil, modes.Modes{modes.NoOutside, modes.OpOnlyTopic}},
 	}
 
-	var config Config
 	for _, testcase := range parseTests {
-		config.Channels.DefaultModes = testcase.raw
-		result := ParseDefaultChannelModes(&config)
+		result := ParseDefaultChannelModes(testcase.raw)
 		if !reflect.DeepEqual(result, testcase.expected) {
 			t.Errorf("expected modes %s, got %s", testcase.expected, result)
 		}

--- a/irc/utils/bitset.go
+++ b/irc/utils/bitset.go
@@ -52,11 +52,9 @@ func BitsetSet(set []uint64, position uint, on bool) (changed bool) {
 }
 
 // BitsetEmpty returns whether the bitset is empty.
-// Right now, this is technically free of race conditions because we don't
-// have a method that can simultaneously modify two bits separated by a word boundary
-// such that one of those modifications is an unset. If we did, there would be a race
-// that could produce false positives. It's probably better to assume that they are
-// already possible under concurrent modification (which is not how we're using this).
+// This has false positives under concurrent modification (i.e., it can return true
+// even though w.r.t. the sequence of atomic modifications, there was no point at
+// which the bitset was completely empty), but that's not how we're using this method.
 func BitsetEmpty(set []uint64) (empty bool) {
 	for i := 0; i < len(set); i++ {
 		if atomic.LoadUint64(&set[i]) != 0 {

--- a/irc/whowas.go
+++ b/irc/whowas.go
@@ -32,7 +32,7 @@ type WhoWas struct {
 }
 
 // NewWhoWasList returns a new WhoWasList
-func NewWhoWasList(size uint) *WhoWasList {
+func NewWhoWasList(size int) *WhoWasList {
 	return &WhoWasList{
 		buffer: make([]WhoWas, size),
 		start:  -1,


### PR DESCRIPTION
The idea is that formerly, `applyConfig` copied a lot of state out of the `Config` struct and into the `Server` struct. For some time now, the `Server` struct has retained a pointer to the latest `Config`. So the implementation can be simplified by reading these values directly from the `Config` struct, and deleting the members of `Server` that were used to copy the data.

To the greatest extent possible, preprocessing of the config data has been moved into `LoadConfig`.

This is a bit risky because of all the edge cases so it's fine if you want to hold it until after the 0.12.0 release.