### PR TITLE
re-add nil receiver for ModeSet.HasMode

### DIFF
--- a/irc/modes/modes.go
+++ b/irc/modes/modes.go
@@ -341,6 +341,10 @@ func NewModeSet() *ModeSet {
 
 // test whether `mode` is set
 func (set *ModeSet) HasMode(mode Mode) bool {
+	if set == nil {
+		return false
+	}
+
 	return utils.BitsetGet(set[:], uint(mode)-minMode)
 }
 

--- a/irc/modes/modes_test.go
+++ b/irc/modes/modes_test.go
@@ -78,7 +78,8 @@ func TestSetMode(t *testing.T) {
 }
 
 func TestNilReceivers(t *testing.T) {
-	var set ModeSet
+	set := NewModeSet()
+	set = nil
 
 	if set.HasMode(Invisible) {
 		t.Errorf("nil ModeSet should not have any modes")


### PR DESCRIPTION
I figured out what happened:

1. In #269, I added nil receivers to the read-only methods of `ModeSet` to fix a crash
1. In #277, I accidentally removed the nil receiver from `ModeSet.HasMode`; this was not caught by unit testing because the underlying type of `ModeSet` also changed (from a map, which can be `nil`, to an array, which can't)
1. This caused the bug fixed by #269 to reappear, so it had to be fixed again in #291 (I thought it looked familiar!)

Anyway, this adds it back and improves the associated test so that it would have caught the regression in #277.