### PR TITLE
configurable file mode for unix socket listeners

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-    - "1.10.x"
+    - "1.11.x"
 
 install: make deps
 

--- a/irc/config.go
+++ b/irc/config.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -212,6 +213,7 @@ type Config struct {
 		Name                string
 		nameCasefolded      string
 		Listen              []string
+		UnixBindMode        os.FileMode                 `yaml:"unix-bind-mode"`
 		TLSListeners        map[string]*TLSListenConfig `yaml:"tls-listeners"`
 		STS                 STSConfig
 		CheckIdent          bool `yaml:"check-ident"`
@@ -240,9 +242,9 @@ type Config struct {
 	Accounts AccountConfig
 
 	Channels struct {
-		RawDefaultModes *string `yaml:"default-modes"`
-		defaultModes    modes.Modes
-		Registration    ChannelRegistrationConfig
+		DefaultModes *string `yaml:"default-modes"`
+		defaultModes modes.Modes
+		Registration ChannelRegistrationConfig
 	}
 
 	OperClasses map[string]*OperClassConfig `yaml:"oper-classes"`
@@ -697,7 +699,7 @@ func LoadConfig(filename string) (config *Config, err error) {
 	config.operators = opers
 
 	// parse default channel modes
-	config.Channels.defaultModes = ParseDefaultChannelModes(config.Channels.RawDefaultModes)
+	config.Channels.defaultModes = ParseDefaultChannelModes(config.Channels.DefaultModes)
 
 	if config.Server.Password != "" {
 		config.Server.passwordBytes, err = decodeLegacyPasswordHash(config.Server.Password)

--- a/irc/database.go
+++ b/irc/database.go
@@ -255,7 +255,7 @@ func schemaChangeV2ToV3(config *Config, tx *buntdb.Tx) error {
 	}
 
 	// explicitly store the channel modes
-	defaultModes := ParseDefaultChannelModes(config.Channels.RawDefaultModes)
+	defaultModes := config.Channels.defaultModes
 	modeStrings := make([]string, len(defaultModes))
 	for i, mode := range defaultModes {
 		modeStrings[i] = string(mode)

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2411,6 +2411,11 @@ func webircHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Re
 				}
 
 				proxiedIP := msg.Params[3]
+				// see #211; websocket gateways will wrap ipv6 addresses in square brackets
+				// because IRC parameters can't start with :
+				if strings.HasPrefix(proxiedIP, "[") && strings.HasSuffix(proxiedIP, "]") {
+					proxiedIP = proxiedIP[1 : len(proxiedIP)-1]
+				}
 				return client.ApplyProxiedIP(proxiedIP, secure)
 			}
 		}

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -16,8 +16,13 @@ server:
         - "127.0.0.1:6668"
         - "[::1]:6668"
         - ":6697" # ssl port
-        # unix domain socket for proxying:
+        # Unix domain socket for proxying:
         # - "/tmp/oragono_sock"
+
+    # permissions for Unix listen sockets. the default of 0755 is only accessible
+    # by the user that owns the oragono process. change to 0777 for behavior like
+    # a regular TCP socket (processes owned by any user can connect to oragono):
+    # unix-bind-mode: 0755
 
     # tls listeners
     tls-listeners:

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -19,10 +19,11 @@ server:
         # Unix domain socket for proxying:
         # - "/tmp/oragono_sock"
 
-    # permissions for Unix listen sockets. the default of 0755 is only accessible
-    # by the user that owns the oragono process. change to 0777 for behavior like
-    # a regular TCP socket (processes owned by any user can connect to oragono):
-    # unix-bind-mode: 0755
+    # sets the permissions for Unix listen sockets. on a typical Linux system,
+    # the default is 0775 or 0755, which prevents other users/groups from connecting
+    # to the socket. With 0777, it behaves like a normal TCP socket
+    # where anyone can connect.
+    unix-bind-mode: 0777
 
     # tls listeners
     tls-listeners:


### PR DESCRIPTION
I'm trying to set things up with full separation between oragono and its proxies (stunnel4 and webircgateway). In order to run them as separate users, oragono's unix domain socket must be mode `0777` (otherwise they can't connect).

I threw in a fix for #211.