### PR TITLE
fix PROXY protocol support for IPv6

### DIFF
--- a/irc/commands.go
+++ b/irc/commands.go
@@ -215,11 +215,6 @@ func init() {
 			handler:   privmsgHandler,
 			minParams: 2,
 		},
-		"PROXY": {
-			handler:      proxyHandler,
-			usablePreReg: true,
-			minParams:    5,
-		},
 		"RENAME": {
 			handler:   renameHandler,
 			minParams: 2,

--- a/irc/help.go
+++ b/irc/help.go
@@ -386,13 +386,6 @@ Replies to a PING. Used to check link connectivity.`,
 
 Sends the text to the given targets as a PRIVMSG.`,
 	},
-	"proxy": {
-		oper: true, // not really, but it's restricted anyways
-		text: `PROXY TCP4/6 <sourceip> <destip> <sourceport> <destport>
-
-Used by haproxy's PROXY v1 protocol, to allow for alternate TLS support:
-http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt`,
-	},
 	"rename": {
 		text: `RENAME <channel> <newname> [<reason>]
 


### PR DESCRIPTION
I'm trying to deploy dual stack to darwin.network. I ran into some compatibility issues with stunnel4. Specifically, stunnel4's method of doing dual stack is to listen on `::` (i.e., all IPv6 addresses); the Linux default is that this also listens on all IPv4 addresses, then uses the [v6 mapping scheme](https://en.wikipedia.org/wiki/IPv6#IPv4-mapped_IPv6_addresses) to represent v4 clients as having v6 addresses. This broke PROXY handling for two reasons, both of which are fixed here:

1. Handle PROXY lines with IPv6 addresses starting with :: (similar to WEBIRC in issue #211)
2. Strip v6 mapping from v4 addresses (i.e., turn `::ffff:192.0.2.128` back into `192.0.2.128`) when handling proxied IPs.