### PR TITLE
Correct NS REGISTER example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ oragono run
 
 ### How to register a channel
 
-1. Register your account with `/NS REGISTER <username> [<password>]`
+1. Register your account with `/NS REGISTER <username> <email> <password>`
 2. Join the channel with `/join #channel`
 3. Register the channel with `/CS REGISTER #channel`
 


### PR DESCRIPTION
I noticed when testing this server out that `/NS REGISTER nick password` didn't work; I checked the code it and looks like all three of nick, email, and password are required: https://github.com/oragono/oragono/blob/c72a84e49fb136e471c1870d246a7d7e110d6ef9/irc/nickserv.go#L247

Thanks!