### PR TITLE
prevents default create/open of buntdb, requires user to call initdb

### DIFF
--- a/irc/database.go
+++ b/irc/database.go
@@ -81,6 +81,10 @@ func OpenDatabase(config *Config) (*buntdb.DB, error) {
 
 // open the database, giving it at most one chance to auto-upgrade the schema
 func openDatabaseInternal(config *Config, allowAutoupgrade bool) (db *buntdb.DB, err error) {
+	_, err = os.Stat(config.Datastore.Path)
+	if os.IsNotExist(err) {
+		return
+	}
 	db, err = buntdb.Open(config.Datastore.Path)
 	if err != nil {
 		return


### PR DESCRIPTION
Resolves #302 - you will now get:
```
2018-11-19T19:11:59Z : error : startup : Could not load server: Failed to open datastore: stat ircd.db: no such file or directory
```

but (the reason I opened this issue) if you navigate to wherever ircd.db would be it won't exist (less confusion)