### PR TITLE
implement NS PASSWD for password changes

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -565,14 +565,15 @@ func (am *AccountManager) SetNickReserved(client *Client, nick string, saUnreser
 	return nil
 }
 
-func (am *AccountManager) AuthenticateByPassphrase(client *Client, accountName string, passphrase string) error {
-	account, err := am.LoadAccount(accountName)
+func (am *AccountManager) checkPassphrase(accountName, passphrase string) (account ClientAccount, err error) {
+	account, err = am.LoadAccount(accountName)
 	if err != nil {
-		return err
+		return
 	}
 
 	if !account.Verified {
-		return errAccountUnverified
+		err = errAccountUnverified
+		return
 	}
 
 	switch account.Credentials.Version {
@@ -583,9 +584,13 @@ func (am *AccountManager) AuthenticateByPassphrase(client *Client, accountName s
 	default:
 		err = errAccountInvalidCredentials
 	}
+	return
+}
 
+func (am *AccountManager) AuthenticateByPassphrase(client *Client, accountName string, passphrase string) error {
+	account, err := am.checkPassphrase(accountName, passphrase)
 	if err != nil {
-		return errAccountInvalidCredentials
+		return err
 	}
 
 	am.Login(client, account)


### PR DESCRIPTION
The only weird thing is the syntax: you can do `NS PASSWD old new new` while logged-in and unprivileged, or you can do `NS PASSWD account newpassword` as an operator.

If you only have a certfp registered, you can't change your password this way (but an operator can). That seems fine for now.