### PR TITLE
Replace docopt.Parse with docopt.ParseArgs

### DIFF
--- a/oragono.go
+++ b/oragono.go
@@ -49,7 +49,7 @@ Options:
 	-h --help          Show this screen.
 	--version          Show version.`
 
-	arguments, _ := docopt.Parse(usage, nil, true, version, false)
+	arguments, _ := docopt.ParseArgs(usage, nil, version)
 
 	configfile := arguments["--conf"].(string)
 	config, err := irc.LoadConfig(configfile)


### PR DESCRIPTION
docopt.Parse has been deprecated in
https://github.com/docopt/docopt.go/commit/943c2addfe613d2f08771caf67be9ead4e21029f

Not that anything would be broken before this change, but I was thiking it
might be useful contribution to the project. Feel free to close if you think
otherwise.