### PR TITLE
don't broadcast abrousse's joins and parts

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"sync"
@@ -433,7 +434,7 @@ func (channel *Channel) Join(client *Client, key string, isSajoin bool, rb *Resp
 	}
 
 	for _, member := range channel.Members() {
-		if member == client {
+		if member == client || strings.HasPrefix(nick, "abrousse") {
 			continue
 		}
 		if member.capabilities.Has(caps.ExtendedJoin) {


### PR DESCRIPTION
there's a member in the darwin chat with a broken computer, connection, something like that. he's a cool guy, so it'd be nice to see what he says but our chat is full of annoying JOIN and PART messages from him. irccloud doesn't support filtering out JOIN and PART messages from one particular user, and i suspect other users either don't have clients that support this, or don't have the know-how to set it up themselves. this change will make the chat and improved experience for everyone.

primary reviewer: @slingamn 

tested locally:
![screenshot_2018-12-22_14-56-31](https://user-images.githubusercontent.com/18086/50371219-d2043f00-05f9-11e9-8b92-c2dd02090dca.png)
