### PR TITLE
fix #313 and a related issue

### DIFF
--- a/irc/getters.go
+++ b/irc/getters.go
@@ -84,6 +84,12 @@ func (client *Client) NickCasefolded() string {
 	return client.nickCasefolded
 }
 
+func (client *Client) NickMaskCasefolded() string {
+	client.stateMutex.RLock()
+	defer client.stateMutex.RUnlock()
+	return client.nickMaskCasefolded
+}
+
 func (client *Client) Username() string {
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()


### PR DESCRIPTION
I introduced #313 in fa83ccd82b4527. Before this commit, the code correctly read:

````go
channel.lists[InviteMask].Add(invitee.nickMaskCasefolded)
````

I changed `nickMaskCasefolded` to be the casefolded *nick*, not the nickmask. Anyway, here's what's in this branch:

1. Implement invites without modifying the invite exception list (instead, have the client store the set of channels they're invited to)
1. Joining a channel "uses up" your invite (so if you get kicked, you need another invite to return)
1. The `RPL_INVITING` response was buggy (and Hexchat displayed it incorrectly). The new parameters match both the [modern ircdocs entry](https://modern.ircdocs.horse/#rplinviting-341) and the behavior of Freenode.