### PR TITLE
fix #322

### DIFF
--- a/README
+++ b/README
@@ -34,7 +34,6 @@ To generate passwords for opers and connect passwords, you can use this command:
 
 Run these commands in order -- these will setup each section of the server:
 
-    $ oragono initdb
     $ oragono mkcerts
     $ oragono run
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Extract it into a folder, then run the following commands:
 ```sh
 cp oragono.yaml ircd.yaml
 vim ircd.yaml  # modify the config file to your liking
-oragono initdb
 oragono mkcerts
 ```
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -78,12 +78,11 @@ In this section, we'll explain how to install and use the Oragono IRC server.
 To get started with Oragono on Windows:
 
 1. Make sure you have the [latest release](https://github.com/oragono/oragono/releases/latest) downloaded.
-2. Extract the zip file to a folder.
-3. Copy and rename `oragono.yaml` to `ircd.yaml`.
-4. Open up `ircd.yaml` using any text editor, and then save it once you're happy.
-5. Open up a `cmd.exe` window, then `cd` to where you have Oragono extracted.
-6. Run `oragono.exe initdb` (this creates the database).
-7. Run `oragono.exe mkcerts` if you want to generate new self-signed SSL/TLS certificates (note that you can't enable STS if you use self-signed certs).
+1. Extract the zip file to a folder.
+1. Copy and rename `oragono.yaml` to `ircd.yaml`.
+1. Open up `ircd.yaml` using any text editor, and then save it once you're happy.
+1. Open up a `cmd.exe` window, then `cd` to where you have Oragono extracted.
+1. Run `oragono.exe mkcerts` if you want to generate new self-signed SSL/TLS certificates (note that you can't enable STS if you use self-signed certs).
 
 To start the server, type `oragono.exe run` and hit enter, and the server should start!
 
@@ -93,12 +92,11 @@ To start the server, type `oragono.exe run` and hit enter, and the server should
 To get started with Oragono on macOS, Linux, or on a Raspberry Pi:
 
 1. Make sure you have the [latest release](https://github.com/oragono/oragono/releases/latest) for your OS/distro downloaded.
-2. Extract the tar.gz file to a folder.
-3. Copy and rename `oragono.yaml` to `ircd.yaml`.
-4. Open up `ircd.yaml` using any text editor, and then save it once you're happy.
-5. Open up a Terminal window, then `cd` to where you have Oragono extracted.
-6. Run `./oragono initdb` (this creates the database).
-7. Run `./oragono mkcerts` if you want to generate new self-signed SSL/TLS certificates (note that you can't enable STS if you use self-signed certs).
+1. Extract the tar.gz file to a folder.
+1. Copy and rename `oragono.yaml` to `ircd.yaml`.
+1. Open up `ircd.yaml` using any text editor, and then save it once you're happy.
+1. Open up a Terminal window, then `cd` to where you have Oragono extracted.
+1. Run `./oragono mkcerts` if you want to generate new self-signed SSL/TLS certificates (note that you can't enable STS if you use self-signed certs).
 
 To start the server, type `./oragono run` and hit enter, and the server should be ready to use!
 

--- a/irc/server.go
+++ b/irc/server.go
@@ -887,7 +887,7 @@ func (server *Server) loadDatastore(config *Config) error {
 
 	_, err := os.Stat(config.Datastore.Path)
 	if os.IsNotExist(err) {
-		server.logger.Warning("startup", "database does not exist, creating it", config.Datastore.Path)
+		server.logger.Warning("rehash", "database does not exist, creating it", config.Datastore.Path)
 		err = initializeDB(config.Datastore.Path)
 		if err != nil {
 			return err
@@ -902,7 +902,7 @@ func (server *Server) loadDatastore(config *Config) error {
 	}
 
 	// load *lines (from the datastores)
-	server.logger.Debug("startup", "Loading D/Klines")
+	server.logger.Debug("rehash", "Loading D/Klines")
 	server.loadDLines()
 	server.loadKLines()
 
@@ -974,7 +974,7 @@ func (server *Server) setupListeners(config *Config) (err error) {
 	}
 
 	if len(tlsListeners) == 0 {
-		server.logger.Warning("startup", "You are not exposing an SSL/TLS listening port. You should expose at least one port (typically 6697) to accept TLS connections")
+		server.logger.Warning("rehash", "You are not exposing an SSL/TLS listening port. You should expose at least one port (typically 6697) to accept TLS connections")
 	}
 
 	var usesStandardTLSPort bool
@@ -985,7 +985,7 @@ func (server *Server) setupListeners(config *Config) (err error) {
 		}
 	}
 	if 0 < len(tlsListeners) && !usesStandardTLSPort {
-		server.logger.Warning("startup", "Port 6697 is the standard TLS port for IRC. You should (also) expose port 6697 as a TLS port to ensure clients can connect securely")
+		server.logger.Warning("rehash", "Port 6697 is the standard TLS port for IRC. You should (also) expose port 6697 as a TLS port to ensure clients can connect securely")
 	}
 
 	return

--- a/irc/server.go
+++ b/irc/server.go
@@ -885,6 +885,15 @@ func (server *Server) loadDatastore(config *Config) error {
 	// open the datastore and load server state for which it (rather than config)
 	// is the source of truth
 
+	_, err := os.Stat(config.Datastore.Path)
+	if os.IsNotExist(err) {
+		server.logger.Warning("startup", "database does not exist, creating it", config.Datastore.Path)
+		err = initializeDB(config.Datastore.Path)
+		if err != nil {
+			return err
+		}
+	}
+
 	db, err := OpenDatabase(config)
 	if err == nil {
 		server.store = db

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -340,6 +340,7 @@ logging:
         #   commands        command calling and operations
         #   opers           oper actions, authentication, etc
         #   password        password hashing and comparing
+        #   rehash          server startup and rehash events
         #   userinput       raw lines sent by users
         #   useroutput      raw lines sent to users
         type: "* -userinput -useroutput -localconnect -localconnect-ip"


### PR DESCRIPTION
This also removes the instruction to run `oragono initdb` from the documentation. That's a separate commit so we can take it out.