### PR TITLE
services refactor

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -187,6 +187,10 @@ func (am *AccountManager) EnforcementStatus(nick string) (account string, method
 	defer am.RUnlock()
 
 	account = am.nickToAccount[cfnick]
+	if account == "" {
+		method = NickReservationNone
+		return
+	}
 	method = am.accountToMethod[account]
 	// if they don't have a custom setting, or customization is disabled, use the default
 	if method == NickReservationOptional || !config.Accounts.NickReservation.AllowCustomEnforcement {

--- a/irc/chanserv.go
+++ b/irc/chanserv.go
@@ -91,7 +91,6 @@ func csNotice(rb *ResponseBuffer, text string) {
 
 func csAmodeHandler(server *Server, client *Client, command string, params []string, rb *ResponseBuffer) {
 	channelName := params[0]
-	modeChange := strings.Join(params[1:], " ")
 
 	channel := server.channels.Get(channelName)
 	if channel == nil {
@@ -102,7 +101,7 @@ func csAmodeHandler(server *Server, client *Client, command string, params []str
 		return
 	}
 
-	modeChanges, unknown := modes.ParseChannelModeChanges(strings.Fields(modeChange)...)
+	modeChanges, unknown := modes.ParseChannelModeChanges(params[1:]...)
 	var change modes.ModeChange
 	if len(modeChanges) > 1 || len(unknown) > 0 {
 		csNotice(rb, client.t("Invalid mode change"))

--- a/irc/chanserv.go
+++ b/irc/chanserv.go
@@ -15,7 +15,6 @@ import (
 	"github.com/goshuirc/irc-go/ircfmt"
 	"github.com/oragono/oragono/irc/modes"
 	"github.com/oragono/oragono/irc/sno"
-	"github.com/oragono/oragono/irc/utils"
 )
 
 const chanservHelp = `ChanServ lets you register and manage channels.
@@ -26,8 +25,8 @@ To see in-depth help for a specific ChanServ command, try:
 Here are the commands you can use:
 %s`
 
-func chanregEnabled(server *Server) bool {
-	return server.ChannelRegistrationEnabled()
+func chanregEnabled(config *Config) bool {
+	return config.Channels.Registration.Enabled
 }
 
 var (
@@ -41,6 +40,7 @@ this command if you're the founder of the channel.`,
 			helpShort:    `$bOP$b makes the given user (or yourself) a channel admin.`,
 			authRequired: true,
 			enabled:      chanregEnabled,
+			minParams:    1,
 		},
 		"register": {
 			handler: csRegisterHandler,
@@ -52,6 +52,7 @@ remembered.`,
 			helpShort:    `$bREGISTER$b lets you own a given channel.`,
 			authRequired: true,
 			enabled:      chanregEnabled,
+			minParams:    1,
 		},
 		"unregister": {
 			handler: csUnregisterHandler,
@@ -62,6 +63,7 @@ To prevent accidental unregistrations, a verification code is required;
 invoking the command without a code will display the necessary code.`,
 			helpShort: `$bUNREGISTER$b deletes a channel registration.`,
 			enabled:   chanregEnabled,
+			minParams: 1,
 		},
 		"drop": {
 			aliasOf: "unregister",
@@ -77,6 +79,7 @@ accounts and modes, use $bAMODE #channel$b. Note that users are always
 referenced by their registered account names, not their nicknames.`,
 			helpShort: `$bAMODE$b modifies persistent mode settings for channel members.`,
 			enabled:   chanregEnabled,
+			minParams: 1,
 		},
 	}
 )
@@ -86,8 +89,9 @@ func csNotice(rb *ResponseBuffer, text string) {
 	rb.Add(nil, "ChanServ", "NOTICE", rb.target.Nick(), text)
 }
 
-func csAmodeHandler(server *Server, client *Client, command, params string, rb *ResponseBuffer) {
-	channelName, modeChange := utils.ExtractParam(params)
+func csAmodeHandler(server *Server, client *Client, command string, params []string, rb *ResponseBuffer) {
+	channelName := params[0]
+	modeChange := strings.Join(params[1:], " ")
 
 	channel := server.channels.Get(channelName)
 	if channel == nil {
@@ -159,27 +163,13 @@ func csAmodeHandler(server *Server, client *Client, command, params string, rb *
 	}
 }
 
-func csOpHandler(server *Server, client *Client, command, params string, rb *ResponseBuffer) {
-	channelName, clientToOp := utils.ExtractParam(params)
-
-	if channelName == "" {
-		csNotice(rb, ircfmt.Unescape(client.t("Syntax: $bOP #channel [nickname]$b")))
-		return
-	}
-
-	clientToOp = strings.TrimSpace(clientToOp)
-
-	channelKey, err := CasefoldChannel(channelName)
-	if err != nil {
-		csNotice(rb, client.t("Channel name is not valid"))
-		return
-	}
-
-	channelInfo := server.channels.Get(channelKey)
+func csOpHandler(server *Server, client *Client, command string, params []string, rb *ResponseBuffer) {
+	channelInfo := server.channels.Get(params[0])
 	if channelInfo == nil {
 		csNotice(rb, client.t("Channel does not exist"))
 		return
 	}
+	channelName := channelInfo.Name()
 
 	clientAccount := client.Account()
 	if clientAccount == "" || clientAccount != channelInfo.Founder() {
@@ -188,10 +178,9 @@ func csOpHandler(server *Server, client *Client, command, params string, rb *Res
 	}
 
 	var target *Client
-	if clientToOp != "" {
-		casefoldedNickname, err := CasefoldName(clientToOp)
-		target = server.clients.Get(casefoldedNickname)
-		if err != nil || target == nil {
+	if len(params) > 1 {
+		target = server.clients.Get(params[1])
+		if target == nil {
 			csNotice(rb, client.t("Could not find given client"))
 			return
 		}
@@ -216,16 +205,13 @@ func csOpHandler(server *Server, client *Client, command, params string, rb *Res
 
 	csNotice(rb, fmt.Sprintf(client.t("Successfully op'd in channel %s"), channelName))
 
-	server.logger.Info("chanserv", fmt.Sprintf("Client %s op'd [%s] in channel %s", client.nick, clientToOp, channelName))
-	server.snomasks.Send(sno.LocalChannels, fmt.Sprintf(ircfmt.Unescape("Client $c[grey][$r%s$c[grey]] CS OP'd $c[grey][$r%s$c[grey]] in channel $c[grey][$r%s$c[grey]]"), client.nickMaskString, clientToOp, channelName))
+	tnick := target.Nick()
+	server.logger.Info("services", fmt.Sprintf("Client %s op'd [%s] in channel %s", client.Nick(), tnick, channelName))
+	server.snomasks.Send(sno.LocalChannels, fmt.Sprintf(ircfmt.Unescape("Client $c[grey][$r%s$c[grey]] CS OP'd $c[grey][$r%s$c[grey]] in channel $c[grey][$r%s$c[grey]]"), client.NickMaskString(), tnick, channelName))
 }
 
-func csRegisterHandler(server *Server, client *Client, command, params string, rb *ResponseBuffer) {
-	channelName := strings.TrimSpace(params)
-	if channelName == "" {
-		csNotice(rb, ircfmt.Unescape(client.t("Syntax: $bREGISTER #channel$b")))
-		return
-	}
+func csRegisterHandler(server *Server, client *Client, command string, params []string, rb *ResponseBuffer) {
+	channelName := params[0]
 
 	channelKey, err := CasefoldChannel(channelName)
 	if err != nil {
@@ -251,7 +237,7 @@ func csRegisterHandler(server *Server, client *Client, command, params string, r
 
 	csNotice(rb, fmt.Sprintf(client.t("Channel %s successfully registered"), channelName))
 
-	server.logger.Info("chanserv", fmt.Sprintf("Client %s registered channel %s", client.nick, channelName))
+	server.logger.Info("services", fmt.Sprintf("Client %s registered channel %s", client.nick, channelName))
 	server.snomasks.Send(sno.LocalChannels, fmt.Sprintf(ircfmt.Unescape("Channel registered $c[grey][$r%s$c[grey]] by $c[grey][$r%s$c[grey]]"), channelName, client.nickMaskString))
 
 	// give them founder privs
@@ -266,8 +252,13 @@ func csRegisterHandler(server *Server, client *Client, command, params string, r
 	}
 }
 
-func csUnregisterHandler(server *Server, client *Client, command, params string, rb *ResponseBuffer) {
-	channelName, verificationCode := utils.ExtractParam(params)
+func csUnregisterHandler(server *Server, client *Client, command string, params []string, rb *ResponseBuffer) {
+	channelName := params[0]
+	var verificationCode string
+	if len(params) > 1 {
+		verificationCode = params[1]
+	}
+
 	channelKey, err := CasefoldChannel(channelName)
 	if channelKey == "" || err != nil {
 		csNotice(rb, client.t("Channel name is not valid"))

--- a/irc/client_lookup_set.go
+++ b/irc/client_lookup_set.go
@@ -129,7 +129,7 @@ func (clients *ClientManager) SetNick(client *Client, newNick string) error {
 	if currentNewEntry != nil && currentNewEntry != client {
 		return errNicknameInUse
 	}
-	if method == NickReservationStrict && reservedAccount != client.Account() {
+	if method == NickReservationStrict && reservedAccount != "" && reservedAccount != client.Account() {
 		return errNicknameReserved
 	}
 	clients.removeInternal(client)

--- a/irc/hostserv.go
+++ b/irc/hostserv.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strings"
 	"time"
 )
 
@@ -125,6 +124,7 @@ for the rejection.`,
 			capabs:    []string{"vhosts"},
 			enabled:   hostservEnabled,
 			minParams: 1,
+			maxParams: 2,
 		},
 	}
 )
@@ -296,7 +296,7 @@ func hsRejectHandler(server *Server, client *Client, command string, params []st
 	var reason string
 	user := params[0]
 	if len(params) > 1 {
-		reason = strings.Join(params[1:], " ")
+		reason = params[1]
 	}
 
 	vhostInfo, err := server.accounts.VHostReject(user, reason)

--- a/irc/nickname.go
+++ b/irc/nickname.go
@@ -15,9 +15,10 @@ import (
 )
 
 var (
+	// anything added here MUST be casefolded:
 	restrictedNicknames = map[string]bool{
 		"=scene=":  true, // used for rp commands
-		"HistServ": true, // TODO(slingamn) this should become a real service
+		"histserv": true, // TODO(slingamn) this should become a real service
 	}
 )
 

--- a/irc/utils/args.go
+++ b/irc/utils/args.go
@@ -3,19 +3,6 @@
 
 package utils
 
-import "strings"
-
-// ExtractParam extracts a parameter from the given string, returning the param and the rest of the string.
-func ExtractParam(line string) (string, string) {
-	rawParams := strings.SplitN(strings.TrimSpace(line), " ", 2)
-	param0 := rawParams[0]
-	var param1 string
-	if 1 < len(rawParams) {
-		param1 = strings.TrimSpace(rawParams[1])
-	}
-	return param0, param1
-}
-
 // ArgsToStrings takes the arguments and splits them into a series of strings,
 // each argument separated by delim and each string bounded by maxLength.
 func ArgsToStrings(maxLength int, arguments []string, delim string) []string {

--- a/irc/utils/fieldsn.go
+++ b/irc/utils/fieldsn.go
@@ -1,0 +1,52 @@
+package utils
+
+// Copyright (c) 2014 Kevin Wallace <kevin@pentabarf.net>
+// Found here: https://github.com/kevinwallace/fieldsn
+// Released under the MIT license
+// XXX this implementation treats negative n as "return nil",
+// unlike stdlib SplitN and friends, which treat it as "no limit"
+
+// Original source code below:
+
+// Package fieldsn implements FieldsN and FieldsFuncN,
+// which are conspicuously missing from the strings package.
+
+import (
+	"unicode"
+)
+
+// FieldsN is like strings.Fields, but returns at most n fields,
+// and the nth field includes any whitespace at the end of the string.
+func FieldsN(s string, n int) []string {
+	return FieldsFuncN(s, unicode.IsSpace, n)
+}
+
+// FieldsFuncN is like strings.FieldsFunc, but returns at most n fields,
+// and the nth field includes any runes at the end of the string normally excluded by f.
+func FieldsFuncN(s string, f func(rune) bool, n int) []string {
+	if n <= 0 {
+		return nil
+	}
+
+	a := make([]string, 0, n)
+	na := 0
+	fieldStart := -1
+	for i, rune := range s {
+		if f(rune) {
+			if fieldStart >= 0 {
+				a = append(a, s[fieldStart:i])
+				na++
+				fieldStart = -1
+			}
+		} else if fieldStart == -1 {
+			fieldStart = i
+			if na+1 == n {
+				break
+			}
+		}
+	}
+	if fieldStart >= 0 {
+		a = append(a, s[fieldStart:])
+	}
+	return a
+}


### PR DESCRIPTION
This is a low-priority refactor of the service framework. Two main changes:

1. Parameters now get parsed up front with `strings.Fields()` and passed to handlers as `[]string`, eliminating the use of `ExtractParam`.
1. `enabled` callbacks now take `*Config` instead of `*Server`

I also fixed a few cases where the behavior was incorrect or differed from the documentation.

The second commit is a fix for a dumb edge case in nickname reservation: if the server default was strict enforcement, and you were authed, then you couldn't change to a nickname that wasn't already reserved to your account (even if nobody owned it).