### PR TITLE
refactor [dk]lines

### DIFF
--- a/irc/database.go
+++ b/irc/database.go
@@ -22,7 +22,7 @@ const (
 	// 'version' of the database schema
 	keySchemaVersion = "db.version"
 	// latest schema of the db
-	latestDbSchema = "3"
+	latestDbSchema = "4"
 )
 
 type SchemaChanger func(*Config, *buntdb.Tx) error
@@ -278,6 +278,118 @@ func schemaChangeV2ToV3(config *Config, tx *buntdb.Tx) error {
 	return nil
 }
 
+// 1. ban info format changed (from `legacyBanInfo` below to `IPBanInfo`)
+// 2. dlines against individual IPs are normalized into dlines against the appropriate /128 network
+func schemaChangeV3ToV4(config *Config, tx *buntdb.Tx) error {
+	type ipRestrictTime struct {
+		Duration time.Duration
+		Expires  time.Time
+	}
+	type legacyBanInfo struct {
+		Reason     string          `json:"reason"`
+		OperReason string          `json:"oper_reason"`
+		OperName   string          `json:"oper_name"`
+		Time       *ipRestrictTime `json:"time"`
+	}
+
+	now := time.Now()
+	legacyToNewInfo := func(old legacyBanInfo) (new_ IPBanInfo) {
+		new_.Reason = old.Reason
+		new_.OperReason = old.OperReason
+		new_.OperName = old.OperName
+
+		if old.Time == nil {
+			new_.TimeCreated = now
+			new_.Duration = 0
+		} else {
+			new_.TimeCreated = old.Time.Expires.Add(-1 * old.Time.Duration)
+			new_.Duration = old.Time.Duration
+		}
+		return
+	}
+
+	var keysToDelete []string
+
+	prefix := "bans.dline "
+	dlines := make(map[string]IPBanInfo)
+	tx.AscendGreaterOrEqual("", prefix, func(key, value string) bool {
+		if !strings.HasPrefix(key, prefix) {
+			return false
+		}
+		keysToDelete = append(keysToDelete, key)
+
+		var lbinfo legacyBanInfo
+		id := strings.TrimPrefix(key, prefix)
+		err := json.Unmarshal([]byte(value), &lbinfo)
+		if err != nil {
+			log.Printf("error unmarshaling legacy dline: %v\n", err)
+			return true
+		}
+		// legacy keys can be either an IP or a CIDR
+		hostNet, err := utils.NormalizedNetFromString(id)
+		if err != nil {
+			log.Printf("error unmarshaling legacy dline network: %v\n", err)
+			return true
+		}
+		dlines[utils.NetToNormalizedString(hostNet)] = legacyToNewInfo(lbinfo)
+
+		return true
+	})
+
+	setOptions := func(info IPBanInfo) *buntdb.SetOptions {
+		if info.Duration == 0 {
+			return nil
+		}
+		ttl := info.TimeCreated.Add(info.Duration).Sub(now)
+		return &buntdb.SetOptions{Expires: true, TTL: ttl}
+	}
+
+	// store the new dlines
+	for id, info := range dlines {
+		b, err := json.Marshal(info)
+		if err != nil {
+			log.Printf("error marshaling migrated dline: %v\n", err)
+			continue
+		}
+		tx.Set(fmt.Sprintf("bans.dlinev2 %s", id), string(b), setOptions(info))
+	}
+
+	// same operations against klines
+	prefix = "bans.kline "
+	klines := make(map[string]IPBanInfo)
+	tx.AscendGreaterOrEqual("", prefix, func(key, value string) bool {
+		if !strings.HasPrefix(key, prefix) {
+			return false
+		}
+		keysToDelete = append(keysToDelete, key)
+		mask := strings.TrimPrefix(key, prefix)
+		var lbinfo legacyBanInfo
+		err := json.Unmarshal([]byte(value), &lbinfo)
+		if err != nil {
+			log.Printf("error unmarshaling legacy kline: %v\n", err)
+			return true
+		}
+		klines[mask] = legacyToNewInfo(lbinfo)
+		return true
+	})
+
+	for mask, info := range klines {
+		b, err := json.Marshal(info)
+		if err != nil {
+			log.Printf("error marshaling migrated kline: %v\n", err)
+			continue
+		}
+		tx.Set(fmt.Sprintf("bans.klinev2 %s", mask), string(b), setOptions(info))
+	}
+
+	// clean up all the old entries
+	for _, key := range keysToDelete {
+		tx.Delete(key)
+	}
+
+	return nil
+}
+
 func init() {
 	allChanges := []SchemaChange{
 		{
@@ -289,6 +401,11 @@ func init() {
 			InitialVersion: "2",
 			TargetVersion:  "3",
 			Changer:        schemaChangeV2ToV3,
+		},
+		{
+			InitialVersion: "3",
+			TargetVersion:  "4",
+			Changer:        schemaChangeV3ToV4,
 		},
 	}
 

--- a/irc/database.go
+++ b/irc/database.go
@@ -190,7 +190,7 @@ func UpgradeDB(config *Config) (err error) {
 	})
 
 	if err != nil {
-		log.Println("database upgrade failed and was rolled back")
+		log.Printf("database upgrade failed and was rolled back: %v\n", err)
 	}
 	return err
 }

--- a/irc/dline.go
+++ b/irc/dline.go
@@ -158,6 +158,7 @@ func (dm *DLineManager) addNetworkInternal(network net.IPNet, info IPBanInfo) (i
 		if ok && netBan.Info.TimeCreated.Equal(timeCreated) {
 			delete(dm.networks, id)
 			// TODO(slingamn) here's where we'd remove it from the radix tree
+			delete(dm.expirationTimers, id)
 		}
 	}
 	dm.expirationTimers[id] = time.AfterFunc(timeLeft, processExpiration)

--- a/irc/kline.go
+++ b/irc/kline.go
@@ -113,6 +113,7 @@ func (km *KLineManager) addMaskInternal(mask string, info IPBanInfo) {
 		maskBan, ok := km.entries[mask]
 		if ok && maskBan.Info.TimeCreated.Equal(timeCreated) {
 			delete(km.entries, mask)
+			delete(km.expirationTimers, mask)
 		}
 	}
 	km.expirationTimers[mask] = time.AfterFunc(timeLeft, processExpiration)

--- a/irc/utils/net_test.go
+++ b/irc/utils/net_test.go
@@ -4,7 +4,15 @@
 
 package utils
 
+import "net"
+import "reflect"
 import "testing"
+
+func assertEqual(supplied, expected interface{}, t *testing.T) {
+	if !reflect.DeepEqual(supplied, expected) {
+		t.Errorf("expected %v but got %v", expected, supplied)
+	}
+}
 
 // hostnames from https://github.com/DanielOaks/irc-parser-tests
 var (
@@ -46,4 +54,95 @@ func TestIsHostname(t *testing.T) {
 			)
 		}
 	}
+}
+
+func TestNormalizeToNet(t *testing.T) {
+	a := net.ParseIP("8.8.8.8")
+	b := net.ParseIP("8.8.4.4")
+	if a == nil || b == nil {
+		panic("something has gone very wrong")
+	}
+
+	aNetwork := NormalizeIPToNet(a)
+	bNetwork := NormalizeIPToNet(b)
+
+	assertEqual(aNetwork.Contains(a), true, t)
+	assertEqual(bNetwork.Contains(b), true, t)
+	assertEqual(aNetwork.Contains(b), false, t)
+	assertEqual(bNetwork.Contains(a), false, t)
+
+	c := net.ParseIP("2001:4860:4860::8888")
+	d := net.ParseIP("2001:db8::1")
+	if c == nil || d == nil {
+		panic("something has gone very wrong")
+	}
+
+	cNetwork := NormalizeIPToNet(c)
+	dNetwork := NormalizeIPToNet(d)
+
+	assertEqual(cNetwork.Contains(c), true, t)
+	assertEqual(dNetwork.Contains(d), true, t)
+	assertEqual(dNetwork.Contains(c), false, t)
+	assertEqual(dNetwork.Contains(a), false, t)
+	assertEqual(cNetwork.Contains(b), false, t)
+	assertEqual(aNetwork.Contains(c), false, t)
+	assertEqual(bNetwork.Contains(c), false, t)
+
+	assertEqual(NetToNormalizedString(aNetwork), "8.8.8.8", t)
+	assertEqual(NetToNormalizedString(bNetwork), "8.8.4.4", t)
+	assertEqual(NetToNormalizedString(cNetwork), "2001:4860:4860::8888", t)
+	assertEqual(NetToNormalizedString(dNetwork), "2001:db8::1", t)
+}
+
+func TestNormalizedNetToString(t *testing.T) {
+	_, network, err := net.ParseCIDR("8.8.0.0/16")
+	if err != nil {
+		panic(err)
+	}
+	assertEqual(NetToNormalizedString(*network), "8.8.0.0/16", t)
+
+	normalized := NormalizeNet(*network)
+	assertEqual(normalized.Contains(net.ParseIP("8.8.4.4")), true, t)
+	assertEqual(normalized.Contains(net.ParseIP("1.1.1.1")), false, t)
+	assertEqual(NetToNormalizedString(normalized), "8.8.0.0/16", t)
+
+	_, network, err = net.ParseCIDR("8.8.4.4/32")
+	if err != nil {
+		panic(err)
+	}
+	assertEqual(NetToNormalizedString(*network), "8.8.4.4", t)
+
+	normalized = NormalizeNet(*network)
+	assertEqual(normalized.Contains(net.ParseIP("8.8.4.4")), true, t)
+	assertEqual(normalized.Contains(net.ParseIP("8.8.8.8")), false, t)
+	assertEqual(NetToNormalizedString(normalized), "8.8.4.4", t)
+}
+
+func TestNormalizedNet(t *testing.T) {
+	_, network, err := net.ParseCIDR("::ffff:8.8.4.4/128")
+	assertEqual(err, nil, t)
+	assertEqual(NetToNormalizedString(*network), "8.8.4.4", t)
+
+	normalizedNet := NormalizeIPToNet(net.ParseIP("8.8.4.4"))
+	assertEqual(NetToNormalizedString(normalizedNet), "8.8.4.4", t)
+
+	_, network, err = net.ParseCIDR("::ffff:8.8.0.0/112")
+	assertEqual(err, nil, t)
+	assertEqual(NetToNormalizedString(*network), "8.8.0.0/16", t)
+	_, v4Network, err := net.ParseCIDR("8.8.0.0/16")
+	assertEqual(err, nil, t)
+	normalizedNet = NormalizeNet(*v4Network)
+	assertEqual(NetToNormalizedString(normalizedNet), "8.8.0.0/16", t)
+}
+
+func TestNormalizedNetFromString(t *testing.T) {
+	network, err := NormalizedNetFromString("8.8.4.4/16")
+	assertEqual(err, nil, t)
+	assertEqual(NetToNormalizedString(network), "8.8.0.0/16", t)
+	assertEqual(network.Contains(net.ParseIP("8.8.8.8")), true, t)
+
+	network, err = NormalizedNetFromString("2001:0db8::1")
+	assertEqual(err, nil, t)
+	assertEqual(NetToNormalizedString(network), "2001:db8::1", t)
+	assertEqual(network.Contains(net.ParseIP("2001:0db8::1")), true, t)
 }


### PR DESCRIPTION
This was supposed to make things simpler. It probably made them more complicated. At any rate, it fixes some bugs: #144, plus an issue where `OperReason` wasn't being parsed correctly.

Some implementation notes:

1. Expiration of [dk]lines is now timer-based (rather than relying on query-time checks for expiration). The idea was that we could eventually use a radix tree for the queries, maybe something like kentik/patricia.
1. The address vs. network distinction for dlines is gone. Every ban gets normalized to a ban against an IPv6 CIDR --- v4 addresses/nets are mapped using the 4-in-6 prefix, then individual addresses are mapped to a /128 CIDR. The string keys that identify them strip this canonicalization for ease of use, e.g., `::ff:8.8.8.8/128` prints as `8.8.8.8` as expected.