### PR TITLE
implement confusables prevention (#178)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -62,6 +62,13 @@
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
+  digest = "1:7caf3ea977a13cd8b9a2e1ecef1ccaa8e38f831b4f6ffcb8bd0aa909c48afb3a"
+  name = "github.com/oragono/confusables"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d5dd03409482fae2457f0742be22782890f720c2"
+
+[[projects]]
   branch = "master"
   digest = "1:2251e6a17ea4a6eaa708882a1cda837aae3e425edbb190ef39b761ecf15a5c3d"
   name = "github.com/oragono/go-ident"
@@ -199,12 +206,14 @@
     "github.com/goshuirc/irc-go/ircmsg",
     "github.com/mattn/go-colorable",
     "github.com/mgutz/ansi",
+    "github.com/oragono/confusables",
     "github.com/oragono/go-ident",
     "github.com/tidwall/buntdb",
     "golang.org/x/crypto/bcrypt",
     "golang.org/x/crypto/sha3",
     "golang.org/x/crypto/ssh/terminal",
     "golang.org/x/text/secure/precis",
+    "golang.org/x/text/unicode/norm",
     "gopkg.in/yaml.v2",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,6 +50,10 @@
   name = "github.com/oragono/go-ident"
 
 [[constraint]]
+  revision = "d5dd03409482fae2457f0742be22782890f720c2"
+  name = "github.com/oragono/confusables"
+
+[[constraint]]
   name = "github.com/tidwall/buntdb"
   version = "1.0.0"
 

--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -52,17 +52,19 @@ type AccountManager struct {
 
 	server *Server
 	// track clients logged in to accounts
-	accountToClients map[string][]*Client
-	nickToAccount    map[string]string
-	accountToMethod  map[string]NickReservationMethod
+	accountToClients  map[string][]*Client
+	nickToAccount     map[string]string
+	skeletonToAccount map[string]string
+	accountToMethod   map[string]NickReservationMethod
 }
 
 func NewAccountManager(server *Server) *AccountManager {
 	am := AccountManager{
-		accountToClients: make(map[string][]*Client),
-		nickToAccount:    make(map[string]string),
-		accountToMethod:  make(map[string]NickReservationMethod),
-		server:           server,
+		accountToClients:  make(map[string][]*Client),
+		nickToAccount:     make(map[string]string),
+		skeletonToAccount: make(map[string]string),
+		accountToMethod:   make(map[string]NickReservationMethod),
+		server:            server,
 	}
 
 	am.buildNickToAccountIndex()
@@ -76,6 +78,7 @@ func (am *AccountManager) buildNickToAccountIndex() {
 	}
 
 	nickToAccount := make(map[string]string)
+	skeletonToAccount := make(map[string]string)
 	accountToMethod := make(map[string]NickReservationMethod)
 	existsPrefix := fmt.Sprintf(keyAccountExists, "")
 
@@ -91,11 +94,21 @@ func (am *AccountManager) buildNickToAccountIndex() {
 			account := strings.TrimPrefix(key, existsPrefix)
 			if _, err := tx.Get(fmt.Sprintf(keyAccountVerified, account)); err == nil {
 				nickToAccount[account] = account
+				accountName, err := tx.Get(fmt.Sprintf(keyAccountName, account))
+				if err != nil {
+					am.server.logger.Error("internal", "missing account name for", account)
+				} else {
+					skeleton, _ := Skeleton(accountName)
+					skeletonToAccount[skeleton] = account
+				}
 			}
 			if rawNicks, err := tx.Get(fmt.Sprintf(keyAccountAdditionalNicks, account)); err == nil {
 				additionalNicks := unmarshalReservedNicks(rawNicks)
 				for _, nick := range additionalNicks {
-					nickToAccount[nick] = account
+					cfnick, _ := CasefoldName(nick)
+					nickToAccount[cfnick] = account
+					skeleton, _ := Skeleton(nick)
+					skeletonToAccount[skeleton] = account
 				}
 			}
 
@@ -115,6 +128,7 @@ func (am *AccountManager) buildNickToAccountIndex() {
 	} else {
 		am.Lock()
 		am.nickToAccount = nickToAccount
+		am.skeletonToAccount = skeletonToAccount
 		am.accountToMethod = accountToMethod
 		am.Unlock()
 	}
@@ -171,36 +185,55 @@ func (am *AccountManager) NickToAccount(nick string) string {
 
 // Given a nick, looks up the account that owns it and the method (none/timeout/strict)
 // used to enforce ownership.
-func (am *AccountManager) EnforcementStatus(nick string) (account string, method NickReservationMethod) {
-	cfnick, err := CasefoldName(nick)
-	if err != nil {
-		return
-	}
-
+func (am *AccountManager) EnforcementStatus(cfnick, skeleton string) (account string, method NickReservationMethod) {
 	config := am.server.Config()
 	if !config.Accounts.NickReservation.Enabled {
-		method = NickReservationNone
-		return
+		return "", NickReservationNone
 	}
 
 	am.RLock()
 	defer am.RUnlock()
 
-	account = am.nickToAccount[cfnick]
-	if account == "" {
-		method = NickReservationNone
+	// given an account, combine stored enforcement method with the config settings
+	// to compute the actual enforcement method
+	finalEnforcementMethod := func(account_ string) (result NickReservationMethod) {
+		result = am.accountToMethod[account_]
+		// if they don't have a custom setting, or customization is disabled, use the default
+		if result == NickReservationOptional || !config.Accounts.NickReservation.AllowCustomEnforcement {
+			result = config.Accounts.NickReservation.Method
+		}
+		if result == NickReservationOptional {
+			// enforcement was explicitly enabled neither in the config or by the user
+			result = NickReservationNone
+		}
 		return
 	}
-	method = am.accountToMethod[account]
-	// if they don't have a custom setting, or customization is disabled, use the default
-	if method == NickReservationOptional || !config.Accounts.NickReservation.AllowCustomEnforcement {
-		method = config.Accounts.NickReservation.Method
+
+	nickAccount := am.nickToAccount[cfnick]
+	skelAccount := am.skeletonToAccount[skeleton]
+	if nickAccount == "" && skelAccount == "" {
+		return "", NickReservationNone
+	} else if nickAccount != "" && skelAccount != "" && nickAccount != skelAccount {
+		// two people have competing claims on (this casefolding of) this nick!
+		nickMethod := finalEnforcementMethod(nickAccount)
+		skelMethod := finalEnforcementMethod(skelAccount)
+		switch {
+		case nickMethod == NickReservationNone && skelMethod == NickReservationNone:
+			return "", NickReservationNone
+		case skelMethod == NickReservationNone:
+			return nickAccount, nickMethod
+		case nickMethod == NickReservationNone:
+			return skelAccount, skelMethod
+		default:
+			// nobody can use this nick
+			return "!", NickReservationStrict
+		}
+	} else if nickAccount == "" && skelAccount != "" {
+		// skeleton owner is the only owner; fall through to normal case
+		nickAccount = skelAccount
 	}
-	if method == NickReservationOptional {
-		// enforcement was explicitly enabled neither in the config or by the user
-		method = NickReservationNone
-	}
-	return
+	// else: nickAccount != "" && skelAccount == "", nickAccount is the only owner
+	return nickAccount, finalEnforcementMethod(nickAccount)
 }
 
 // Looks up the enforcement method stored in the database for an account
@@ -264,8 +297,13 @@ func (am *AccountManager) AccountToClients(account string) (result []*Client) {
 
 func (am *AccountManager) Register(client *Client, account string, callbackNamespace string, callbackValue string, passphrase string, certfp string) error {
 	casefoldedAccount, err := CasefoldName(account)
-	if err != nil || account == "" || account == "*" {
+	skeleton, skerr := Skeleton(account)
+	if err != nil || skerr != nil || account == "" || account == "*" {
 		return errAccountCreation
+	}
+
+	if restrictedNicknames[casefoldedAccount] || restrictedNicknames[skeleton] {
+		return errAccountAlreadyRegistered
 	}
 
 	// can't register a guest nickname
@@ -535,8 +573,10 @@ func (am *AccountManager) Verify(client *Client, account string, code string) er
 		})
 
 		if err == nil {
+			skeleton, _ := Skeleton(raw.Name)
 			am.Lock()
 			am.nickToAccount[casefoldedAccount] = casefoldedAccount
+			am.skeletonToAccount[skeleton] = casefoldedAccount
 			am.Unlock()
 		}
 	}()
@@ -567,9 +607,10 @@ func unmarshalReservedNicks(nicks string) (result []string) {
 
 func (am *AccountManager) SetNickReserved(client *Client, nick string, saUnreserve bool, reserve bool) error {
 	cfnick, err := CasefoldName(nick)
+	skeleton, skerr := Skeleton(nick)
 	// garbage nick, or garbage options, or disabled
 	nrconfig := am.server.AccountConfig().NickReservation
-	if err != nil || cfnick == "" || (reserve && saUnreserve) || !nrconfig.Enabled {
+	if err != nil || skerr != nil || cfnick == "" || (reserve && saUnreserve) || !nrconfig.Enabled {
 		return errAccountNickReservationFailed
 	}
 
@@ -591,8 +632,15 @@ func (am *AccountManager) SetNickReserved(client *Client, nick string, saUnreser
 		return errAccountNotLoggedIn
 	}
 
-	accountForNick := am.NickToAccount(cfnick)
-	if reserve && accountForNick != "" {
+	am.Lock()
+	accountForNick := am.nickToAccount[cfnick]
+	var accountForSkeleton string
+	if reserve {
+		accountForSkeleton = am.skeletonToAccount[skeleton]
+	}
+	am.Unlock()
+
+	if reserve && (accountForNick != "" || accountForSkeleton != "") {
 		return errNicknameReserved
 	} else if !reserve && !saUnreserve && accountForNick != account {
 		return errNicknameReserved
@@ -623,12 +671,18 @@ func (am *AccountManager) SetNickReserved(client *Client, nick string, saUnreser
 			if len(nicks) >= nrconfig.AdditionalNickLimit {
 				return errAccountTooManyNicks
 			}
-			nicks = append(nicks, cfnick)
+			nicks = append(nicks, nick)
 		} else {
+			// compute (original reserved nicks) minus cfnick
 			var newNicks []string
 			for _, reservedNick := range nicks {
-				if reservedNick != cfnick {
+				cfreservednick, _ := CasefoldName(reservedNick)
+				if cfreservednick != cfnick {
 					newNicks = append(newNicks, reservedNick)
+				} else {
+					// found the original, unfolded version of the nick we're dropping;
+					// recompute the true skeleton from it
+					skeleton, _ = Skeleton(reservedNick)
 				}
 			}
 			nicks = newNicks
@@ -650,8 +704,10 @@ func (am *AccountManager) SetNickReserved(client *Client, nick string, saUnreser
 	defer am.Unlock()
 	if reserve {
 		am.nickToAccount[cfnick] = account
+		am.skeletonToAccount[skeleton] = account
 	} else {
 		delete(am.nickToAccount, cfnick)
+		delete(am.skeletonToAccount, skeleton)
 	}
 	return nil
 }
@@ -787,8 +843,10 @@ func (am *AccountManager) Unregister(account string) error {
 	am.serialCacheUpdateMutex.Lock()
 	defer am.serialCacheUpdateMutex.Unlock()
 
+	var accountName string
 	am.server.store.Update(func(tx *buntdb.Tx) error {
 		tx.Delete(accountKey)
+		accountName, _ = tx.Get(accountNameKey)
 		tx.Delete(accountNameKey)
 		tx.Delete(verifiedKey)
 		tx.Delete(registeredTimeKey)
@@ -817,6 +875,7 @@ func (am *AccountManager) Unregister(account string) error {
 		}
 	}
 
+	skeleton, _ := Skeleton(accountName)
 	additionalNicks := unmarshalReservedNicks(rawNicks)
 
 	am.Lock()
@@ -825,8 +884,11 @@ func (am *AccountManager) Unregister(account string) error {
 	clients = am.accountToClients[casefoldedAccount]
 	delete(am.accountToClients, casefoldedAccount)
 	delete(am.nickToAccount, casefoldedAccount)
+	delete(am.skeletonToAccount, skeleton)
 	for _, nick := range additionalNicks {
 		delete(am.nickToAccount, nick)
+		additionalSkel, _ := Skeleton(nick)
+		delete(am.skeletonToAccount, additionalSkel)
 	}
 	for _, client := range clients {
 		am.logoutOfAccount(client)

--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -213,13 +213,18 @@ func (am *AccountManager) EnforcementStatus(cfnick, skeleton string) (account st
 	skelAccount := am.skeletonToAccount[skeleton]
 	if nickAccount == "" && skelAccount == "" {
 		return "", NickReservationNone
-	} else if nickAccount != "" && skelAccount != "" && nickAccount != skelAccount {
+	} else if nickAccount != "" && (skelAccount == nickAccount || skelAccount == "") {
+		return nickAccount, finalEnforcementMethod(nickAccount)
+	} else if skelAccount != "" && nickAccount == "" {
+		return skelAccount, finalEnforcementMethod(skelAccount)
+	} else {
+		// nickAccount != skelAccount and both are nonempty:
 		// two people have competing claims on (this casefolding of) this nick!
 		nickMethod := finalEnforcementMethod(nickAccount)
 		skelMethod := finalEnforcementMethod(skelAccount)
 		switch {
 		case nickMethod == NickReservationNone && skelMethod == NickReservationNone:
-			return "", NickReservationNone
+			return nickAccount, NickReservationNone
 		case skelMethod == NickReservationNone:
 			return nickAccount, nickMethod
 		case nickMethod == NickReservationNone:
@@ -228,12 +233,7 @@ func (am *AccountManager) EnforcementStatus(cfnick, skeleton string) (account st
 			// nobody can use this nick
 			return "!", NickReservationStrict
 		}
-	} else if nickAccount == "" && skelAccount != "" {
-		// skeleton owner is the only owner; fall through to normal case
-		nickAccount = skelAccount
 	}
-	// else: nickAccount != "" && skelAccount == "", nickAccount is the only owner
-	return nickAccount, finalEnforcementMethod(nickAccount)
 }
 
 // Looks up the enforcement method stored in the database for an account

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -108,6 +108,15 @@ func (client *Client) Realname() string {
 	return client.realname
 }
 
+// uniqueIdentifiers returns the strings for which the server enforces per-client
+// uniqueness/ownership; no two clients can have colliding casefolded nicks or
+// skeletons.
+func (client *Client) uniqueIdentifiers() (nickCasefolded string, skeleton string) {
+	client.stateMutex.RLock()
+	defer client.stateMutex.RUnlock()
+	return client.nickCasefolded, client.skeleton
+}
+
 func (client *Client) ResumeToken() string {
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()
@@ -118,12 +127,6 @@ func (client *Client) Oper() *Oper {
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()
 	return client.oper
-}
-
-func (client *Client) SetOper(oper *Oper) {
-	client.stateMutex.Lock()
-	defer client.stateMutex.Unlock()
-	client.oper = oper
 }
 
 func (client *Client) Registered() bool {

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1706,7 +1706,6 @@ func operHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 
 	oldNickmask := client.NickMaskString()
 	client.SetOper(oper)
-	client.updateNickMask("")
 	if client.NickMaskString() != oldNickmask {
 		client.sendChghost(oldNickmask, oper.Vhost)
 	}

--- a/irc/idletimer.go
+++ b/irc/idletimer.go
@@ -205,9 +205,9 @@ func (nt *NickTimer) Touch() {
 		return
 	}
 
-	nick := nt.client.NickCasefolded()
+	cfnick, skeleton := nt.client.uniqueIdentifiers()
 	account := nt.client.Account()
-	accountForNick, method := nt.client.server.accounts.EnforcementStatus(nick)
+	accountForNick, method := nt.client.server.accounts.EnforcementStatus(cfnick, skeleton)
 	enforceTimeout := method == NickReservationWithTimeout
 
 	var shouldWarn bool
@@ -223,7 +223,7 @@ func (nt *NickTimer) Touch() {
 		// the timer will not reset as long as the squatter is targeting the same account
 		accountChanged := accountForNick != nt.accountForNick
 		// change state
-		nt.nick = nick
+		nt.nick = cfnick
 		nt.account = account
 		nt.accountForNick = accountForNick
 		delinquent := accountForNick != "" && accountForNick != account

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -215,7 +215,7 @@ func nsGhostHandler(server *Server, client *Client, command string, params []str
 }
 
 func nsGroupHandler(server *Server, client *Client, command string, params []string, rb *ResponseBuffer) {
-	nick := client.NickCasefolded()
+	nick := client.Nick()
 	err := server.accounts.SetNickReserved(client, nick, false, true)
 	if err == nil {
 		nsNotice(rb, fmt.Sprintf(client.t("Successfully grouped nick %s with your account"), nick))

--- a/irc/strings.go
+++ b/irc/strings.go
@@ -8,21 +8,25 @@ package irc
 import (
 	"strings"
 
+	"github.com/mtibben/confusables"
 	"golang.org/x/text/secure/precis"
+	"golang.org/x/text/unicode/norm"
 )
 
 const (
 	casemappingName = "rfc8265"
 )
 
-// Casefold returns a casefolded string, without doing any name or channel character checks.
-func Casefold(str string) (string, error) {
-	var err error
-	oldStr := str
+// Each pass of PRECIS casefolding is a composition of idempotent operations,
+// but not idempotent itself. Therefore, the spec says "do it four times and hope
+// it converges" (lolwtf). Golang's PRECIS implementation has a "repeat" option,
+// which provides this functionality, but unfortunately it's not exposed publicly.
+func iterateFolding(profile *precis.Profile, oldStr string) (str string, err error) {
+	str = oldStr
 	// follow the stabilizing rules laid out here:
 	// https://tools.ietf.org/html/draft-ietf-precis-7564bis-10.html#section-7
 	for i := 0; i < 4; i++ {
-		str, err = precis.UsernameCaseMapped.CompareKey(str)
+		str, err = profile.CompareKey(str)
 		if err != nil {
 			return "", err
 		}
@@ -35,6 +39,11 @@ func Casefold(str string) (string, error) {
 		return "", errCouldNotStabilize
 	}
 	return str, nil
+}
+
+// Casefold returns a casefolded string, without doing any name or channel character checks.
+func Casefold(str string) (string, error) {
+	return iterateFolding(precis.UsernameCaseMapped, str)
 }
 
 // CasefoldChannel returns a casefolded version of a channel name.
@@ -95,4 +104,47 @@ func CasefoldName(name string) (string, error) {
 	}
 
 	return lowered, err
+}
+
+// "boring" names are exempt from skeletonization.
+// this is because confusables.txt considers various pure ASCII alphanumeric
+// strings confusable: 0 and O, 1 and l, m and rn. IMO this causes more problems
+// than it solves.
+func isBoring(name string) bool {
+	for i := 0; i < len(name); i += 1 {
+		chr := name[i]
+		if (chr >= 'a' && chr <= 'z') || (chr >= 'A' && chr <= 'Z') || (chr >= '0' && chr <= '9') {
+			continue // alphanumerics
+		}
+		switch chr {
+		case '$', '%', '^', '&', '(', ')', '{', '}', '[', ']', '<', '>', '=':
+			continue // benign printable ascii characters
+		default:
+			return false // potentially confusable ascii like | ' `, non-ascii
+		}
+	}
+	return true
+}
+
+var skeletonCasefolder = precis.NewIdentifier(precis.FoldWidth, precis.LowerCase(), precis.Norm(norm.NFC))
+
+// similar to Casefold, but exempts the bidi rule, because skeletons may
+// mix scripts strangely
+func casefoldSkeleton(str string) (string, error) {
+	return iterateFolding(skeletonCasefolder, str)
+}
+
+// Skeleton produces a canonicalized identifier that tries to catch
+// homoglyphic / confusable identifiers. It's a tweaked version of the TR39
+// skeleton algorithm. We apply the skeleton algorithm first and only then casefold,
+// because casefolding first would lose some information about visual confusability.
+// This has the weird consequence that the skeleton is not a function of the
+// casefolded identifier --- therefore it must always be computed
+// from the original (unfolded) identifier and stored/tracked separately from the
+// casefolded identifier.
+func Skeleton(name string) (string, error) {
+	if !isBoring(name) {
+		name = confusables.Skeleton(name)
+	}
+	return casefoldSkeleton(name)
 }

--- a/irc/strings.go
+++ b/irc/strings.go
@@ -8,7 +8,7 @@ package irc
 import (
 	"strings"
 
-	"github.com/mtibben/confusables"
+	"github.com/oragono/confusables"
 	"golang.org/x/text/secure/precis"
 	"golang.org/x/text/unicode/norm"
 )

--- a/irc/strings_test.go
+++ b/irc/strings_test.go
@@ -127,3 +127,50 @@ func TestCasefoldName(t *testing.T) {
 		})
 	}
 }
+
+func TestIsBoring(t *testing.T) {
+	assertBoring := func(str string, expected bool) {
+		if isBoring(str) != expected {
+			t.Errorf("expected [%s] to have boringness [%t], but got [%t]", str, expected, !expected)
+		}
+	}
+
+	assertBoring("warning", true)
+	assertBoring("phi|ip", false)
+	assertBoring("Νικηφόρος", false)
+}
+
+func TestSkeleton(t *testing.T) {
+	skeleton := func(str string) string {
+		skel, err := Skeleton(str)
+		if err != nil {
+			t.Error(err)
+		}
+		return skel
+	}
+
+	if skeleton("warning") == skeleton("waming") {
+		t.Errorf("Oragono shouldn't consider rn confusable with m")
+	}
+
+	if skeleton("Phi|ip") != "philip" {
+		t.Errorf("but we still consider pipe confusable with l")
+	}
+
+	if skeleton("ｓｍｔ") != "smt" {
+		t.Errorf("fullwidth characters should skeletonize to plain old ascii characters")
+	}
+
+	if skeleton("ＳＭＴ") != "smt" {
+		t.Errorf("after skeletonizing, we should casefold")
+	}
+
+	if skeleton("еvan") != "evan" {
+		t.Errorf("we must protect against cyrillic homoglyph attacks")
+	}
+
+	if skeleton("РОТАТО") != "potato" {
+		t.Errorf("we must protect against cyrillic homoglyph attacks")
+	}
+
+}


### PR DESCRIPTION
This is weird and fiddly and it may have bugs. Some notes:

1. Skeleton is always maintained side-by-side with the casefolded nick; both the skeleton and the casefolded nick must be computed from the original nick (you can't get one from the other).
1. Accordingly, additional nicknames reserved with `NS GROUP` must now be stored in their original, unfolded form (and folded again when they get loaded from the database).