### PR TITLE
Comment out 6668 bindings in default config

### DIFF
--- a/oragono.yaml
+++ b/oragono.yaml
@@ -13,9 +13,10 @@ server:
     # addresses to listen on
     listen:
         - ":6667"
-        - "127.0.0.1:6668"
-        - "[::1]:6668"
         - ":6697" # ssl port
+        # Binding on specific IPs:
+        # - "127.0.0.1:6668"
+        # - "[::1]:6668"
         # Unix domain socket for proxying:
         # - "/tmp/oragono_sock"
 


### PR DESCRIPTION
These are just used as examples, and prevent Oragono from starting
up if the host doesn't have an IPv6 stack (e.g. inside docker
containers).

See oragono/oragono-docker#5