### PR TITLE
rename the "startup", "rehash", and "shutdown" log types to "server"

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1886,13 +1886,13 @@ func quitHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 
 // REHASH
 func rehashHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
-	server.logger.Info("rehash", fmt.Sprintf("REHASH command used by %s", client.nick))
+	server.logger.Info("server", fmt.Sprintf("REHASH command used by %s", client.nick))
 	err := server.rehash()
 
 	if err == nil {
 		rb.Add(nil, server.name, RPL_REHASHING, client.nick, "ircd.yaml", client.t("Rehashing"))
 	} else {
-		server.logger.Error("rehash", fmt.Sprintln("Failed to rehash:", err.Error()))
+		server.logger.Error("server", fmt.Sprintln("Failed to rehash:", err.Error()))
 		rb.Add(nil, server.name, ERR_UNKNOWNERROR, client.nick, "REHASH", err.Error())
 	}
 	return false

--- a/oragono.go
+++ b/oragono.go
@@ -130,11 +130,11 @@ Options:
 		}
 	} else if arguments["run"].(bool) {
 		if !arguments["--quiet"].(bool) {
-			logman.Info("startup", fmt.Sprintf("Oragono v%s starting", irc.SemVer))
+			logman.Info("server", fmt.Sprintf("Oragono v%s starting", irc.SemVer))
 			if commit == "" {
-				logman.Debug("startup", fmt.Sprintf("Could not get current commit"))
+				logman.Debug("server", fmt.Sprintf("Could not get current commit"))
 			} else {
-				logman.Info("startup", fmt.Sprintf("Running commit %s", commit))
+				logman.Info("server", fmt.Sprintf("Running commit %s", commit))
 			}
 		}
 
@@ -146,17 +146,17 @@ Options:
 
 		// warning if running a non-final version
 		if strings.Contains(irc.SemVer, "unreleased") {
-			logman.Warning("startup", "You are currently running an unreleased beta version of Oragono that may be unstable and could corrupt your database.\nIf you are running a production network, please download the latest build from https://oragono.io/downloads.html and run that instead.")
+			logman.Warning("server", "You are currently running an unreleased beta version of Oragono that may be unstable and could corrupt your database.\nIf you are running a production network, please download the latest build from https://oragono.io/downloads.html and run that instead.")
 		}
 
 		server, err := irc.NewServer(config, logman)
 		if err != nil {
-			logman.Error("startup", fmt.Sprintf("Could not load server: %s", err.Error()))
+			logman.Error("server", fmt.Sprintf("Could not load server: %s", err.Error()))
 			return
 		}
 		if !arguments["--quiet"].(bool) {
-			logman.Info("startup", "Server running")
-			defer logman.Info("shutdown", fmt.Sprintf("Oragono v%s exiting", irc.SemVer))
+			logman.Info("server", "Server running")
+			defer logman.Info("server", fmt.Sprintf("Oragono v%s exiting", irc.SemVer))
 		}
 		server.Run()
 	}

--- a/oragono.go
+++ b/oragono.go
@@ -152,7 +152,7 @@ Options:
 		server, err := irc.NewServer(config, logman)
 		if err != nil {
 			logman.Error("server", fmt.Sprintf("Could not load server: %s", err.Error()))
-			return
+			os.Exit(1)
 		}
 		if !arguments["--quiet"].(bool) {
 			logman.Info("server", "Server running")

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -354,12 +354,12 @@ logging:
         #
         # useful types include:
         #   *               everything (usually used with exclusing some types below)
+        #   server          server startup, rehash, and shutdown events
         #   accounts        account registration and authentication
         #   channels        channel creation and operations
         #   commands        command calling and operations
         #   opers           oper actions, authentication, etc
         #   password        password hashing and comparing
-        #   rehash          server startup and rehash events
         #   userinput       raw lines sent by users
         #   useroutput      raw lines sent to users
         type: "* -userinput -useroutput -localconnect -localconnect-ip"


### PR DESCRIPTION
I was deploying #329, which had a schema change, and I had forgotten to enable database autoupgrades. So the deployment failed, which is expected. However, I ran into two problems:

1. I forgot to enable the `startup` log category, so the error message was suppressed
1. The program exited with code `0` despite the failure, which was confusing

The problem is that `startup` (and `shutdown`) are sort of vestigial at this point; almost all such messages are now associated with `Server.applyConfig`, which logs to the category `rehash`. Yet this is also incorrect terminology, since `applyConfig` runs during initial startup as well as rehash. Hence the decision to unify all these messages in the "server" category.

This change is not backwards-compatible, which we should mention in the changelog. It might be possible to canonicalize the names during config parsing, but the results might be counterintuitive.