### PR TITLE
more lenient casefolding for skeletons

### DIFF
--- a/irc/strings_test.go
+++ b/irc/strings_test.go
@@ -173,4 +173,6 @@ func TestSkeleton(t *testing.T) {
 		t.Errorf("we must protect against cyrillic homoglyph attacks")
 	}
 
+	// should not raise an error:
+	skeleton("けらんぐ")
 }


### PR DESCRIPTION
`けらんぐ` was failing skeletonization, because one of the runes in its skeleton was disallowed by PRECIS:

````
:irc.darwin.network 400 * NICK :Could not set or change nickname: precis: disallowed rune encountered
````

All identifiers must independently pass PRECIS, so there's no real reason skeletonization should also use PRECIS. This switches the postprocessing of the skeleton to just do a pass of width normalization and then a pass of lowercasing (imitating the library calls used by PRECIS itself). (We are no longer iterating these operations four times --- but that seems like it's probably OK?)