### PR TITLE
add CHATHISTORY and HISTORY implementations

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -578,7 +578,7 @@ func (channel *Channel) resumeAndAnnounce(newClient, oldClient *Client) {
 }
 
 func (channel *Channel) replayHistoryForResume(newClient *Client, after time.Time, before time.Time) {
-	items, complete := channel.history.Between(after, before)
+	items, complete := channel.history.Between(after, before, false, 0)
 	rb := NewResponseBuffer(newClient)
 	channel.replayHistoryItems(rb, items)
 	if !complete && !newClient.resumeDetails.HistoryIncomplete {

--- a/irc/commands.go
+++ b/irc/commands.go
@@ -90,6 +90,10 @@ func init() {
 			usablePreReg: true,
 			minParams:    1,
 		},
+		"CHATHISTORY": {
+			handler:   chathistoryHandler,
+			minParams: 3,
+		},
 		"DEBUG": {
 			handler:   debugHandler,
 			minParams: 1,
@@ -107,6 +111,10 @@ func init() {
 		"HELPOP": {
 			handler:   helpHandler,
 			minParams: 0,
+		},
+		"HISTORY": {
+			handler:   historyHandler,
+			minParams: 1,
 		},
 		"INFO": {
 			handler: infoHandler,

--- a/irc/config.go
+++ b/irc/config.go
@@ -213,6 +213,7 @@ type Limits struct {
 	NickLen        int           `yaml:"nicklen"`
 	TopicLen       int           `yaml:"topiclen"`
 	WhowasEntries  int           `yaml:"whowas-entries"`
+	ChathistoryMax int           `yaml:"chathistory-maxmessages"`
 }
 
 // STSConfig controls the STS configuration/

--- a/irc/config.go
+++ b/irc/config.go
@@ -213,7 +213,6 @@ type Limits struct {
 	NickLen        int           `yaml:"nicklen"`
 	TopicLen       int           `yaml:"topiclen"`
 	WhowasEntries  int           `yaml:"whowas-entries"`
-	ChathistoryMax int           `yaml:"chathistory-maxmessages"`
 }
 
 // STSConfig controls the STS configuration/
@@ -316,6 +315,7 @@ type Config struct {
 		ChannelLength    int `yaml:"channel-length"`
 		ClientLength     int `yaml:"client-length"`
 		AutoreplayOnJoin int `yaml:"autoreplay-on-join"`
+		ChathistoryMax   int `yaml:"chathistory-maxmessages"`
 	}
 
 	Filename string

--- a/irc/errors.go
+++ b/irc/errors.go
@@ -41,6 +41,7 @@ var (
 	errResumeTokenAlreadySet          = errors.New("Client was already assigned a resume token")
 	errInvalidUsername                = errors.New("Invalid username")
 	errFeatureDisabled                = errors.New("That feature is disabled")
+	errInvalidParams                  = errors.New("Invalid parameters")
 )
 
 // Socket Errors

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -531,6 +531,7 @@ func capHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Respo
 // CHATHISTORY <target> BETWEEN <query> <query> <direction> [<limit>]
 // e.g., CHATHISTORY #ircv3 BETWEEN timestamp=YYYY-MM-DDThh:mm:ss.sssZ timestamp=YYYY-MM-DDThh:mm:ss.sssZ + 100
 func chathistoryHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) (exiting bool) {
+	config := server.Config()
 	// batch type is chathistory; send an empty batch if necessary
 	rb.InitializeBatch("chathistory", true)
 
@@ -595,7 +596,7 @@ func chathistoryHandler(server *Server, client *Client, msg ircmsg.IrcMessage, r
 		return
 	}
 
-	maxChathistoryLimit := server.Config().Limits.ChathistoryMax
+	maxChathistoryLimit := config.History.ChathistoryMax
 	if maxChathistoryLimit == 0 {
 		return
 	}
@@ -1008,6 +1009,7 @@ Get an explanation of <argument>, or "index" for a list of help topics.`), rb)
 // e.g., HISTORY #ubuntu 10
 // HISTORY me 15
 func historyHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
+	config := server.Config()
 	target := msg.Params[0]
 	var hist *history.Buffer
 	channel := server.channels.Get(target)
@@ -1024,7 +1026,7 @@ func historyHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *R
 	}
 
 	limit := 10
-	maxChathistoryLimit := server.Config().Limits.ChathistoryMax
+	maxChathistoryLimit := config.History.ChathistoryMax
 	if len(msg.Params) > 1 {
 		providedLimit, err := strconv.Atoi(msg.Params[1])
 		if providedLimit > maxChathistoryLimit {

--- a/irc/help.go
+++ b/irc/help.go
@@ -196,10 +196,12 @@ Get an explanation of <argument>, or "index" for a list of help topics.`,
 Get an explanation of <argument>, or "index" for a list of help topics.`,
 	},
 	"history": {
-		text: `HISTSERV <target> [limit]
+		text: `HISTORY <target> [limit]
 
-Replay message history. <target> can be a channel name, or "self" or "me"
-to replay direct message history. At most [limit] messages will be replayed.`,
+Replay message history. <target> can be a channel name, "me" to replay direct
+message history, or a nickname to replay another client's direct message
+history (they must be logged into the same account as you). At most [limit]
+messages will be replayed.`,
 	},
 	"hostserv": {
 		text: `HOSTSERV <command> [params]

--- a/irc/help.go
+++ b/irc/help.go
@@ -131,6 +131,13 @@ http://ircv3.net/specs/core/capability-negotiation-3.2.html`,
 
 ChanServ controls channel registrations.`,
 	},
+	"chathistory": {
+		text: `CHATHISTORY [params]
+
+CHATHISTORY is an experimental history replay command. See these documents:
+https://github.com/MuffinMedic/ircv3-specifications/blob/chathistory/extensions/chathistory.md
+https://gist.github.com/DanielOaks/c104ad6e8759c01eb5c826d627caf80da`,
+	},
 	"cs": {
 		text: `CS <subcommand> [params]
 
@@ -187,6 +194,12 @@ Get an explanation of <argument>, or "index" for a list of help topics.`,
 		text: `HELPOP <argument>
 
 Get an explanation of <argument>, or "index" for a list of help topics.`,
+	},
+	"history": {
+		text: `HISTSERV <target> [limit]
+
+Replay message history. <target> can be a channel name, or "self" or "me"
+to replay direct message history. At most [limit] messages will be replayed.`,
 	},
 	"hostserv": {
 		text: `HOSTSERV <command> [params]

--- a/irc/responsebuffer.go
+++ b/irc/responsebuffer.go
@@ -47,6 +47,8 @@ func (rb *ResponseBuffer) Add(tags *map[string]ircmsg.TagValue, prefix string, c
 	if rb.finalized {
 		rb.target.server.logger.Error("internal", "message added to finalized ResponseBuffer, undefined behavior")
 		debug.PrintStack()
+		// TODO(dan): send a NOTICE to the end user with a string representation of the message,
+		// for debugging purposes
 		return
 	}
 

--- a/irc/server.go
+++ b/irc/server.go
@@ -157,6 +157,9 @@ func (server *Server) setISupport() (err error) {
 	isupport.Add("AWAYLEN", strconv.Itoa(config.Limits.AwayLen))
 	isupport.Add("CASEMAPPING", "ascii")
 	isupport.Add("CHANMODES", strings.Join([]string{modes.Modes{modes.BanMask, modes.ExceptMask, modes.InviteMask}.String(), "", modes.Modes{modes.UserLimit, modes.Key}.String(), modes.Modes{modes.InviteOnly, modes.Moderated, modes.NoOutside, modes.OpOnlyTopic, modes.ChanRoleplaying, modes.Secret}.String()}, ","))
+	if config.History.Enabled && config.Limits.ChathistoryMax > 0 {
+		isupport.Add("CHATHISTORY", strconv.Itoa(config.Limits.ChathistoryMax))
+	}
 	isupport.Add("CHANNELLEN", strconv.Itoa(config.Limits.ChannelLen))
 	isupport.Add("CHANTYPES", "#")
 	isupport.Add("ELIST", "U")

--- a/irc/server.go
+++ b/irc/server.go
@@ -158,7 +158,7 @@ func (server *Server) setISupport() (err error) {
 	isupport.Add("CASEMAPPING", "ascii")
 	isupport.Add("CHANMODES", strings.Join([]string{modes.Modes{modes.BanMask, modes.ExceptMask, modes.InviteMask}.String(), "", modes.Modes{modes.UserLimit, modes.Key}.String(), modes.Modes{modes.InviteOnly, modes.Moderated, modes.NoOutside, modes.OpOnlyTopic, modes.ChanRoleplaying, modes.Secret}.String()}, ","))
 	if config.History.Enabled && config.History.ChathistoryMax > 0 {
-		isupport.Add("CHATHISTORY", strconv.Itoa(config.History.ChathistoryMax))
+		isupport.Add("draft/CHATHISTORY", strconv.Itoa(config.History.ChathistoryMax))
 	}
 	isupport.Add("CHANNELLEN", strconv.Itoa(config.Limits.ChannelLen))
 	isupport.Add("CHANTYPES", "#")

--- a/irc/server.go
+++ b/irc/server.go
@@ -157,8 +157,8 @@ func (server *Server) setISupport() (err error) {
 	isupport.Add("AWAYLEN", strconv.Itoa(config.Limits.AwayLen))
 	isupport.Add("CASEMAPPING", "ascii")
 	isupport.Add("CHANMODES", strings.Join([]string{modes.Modes{modes.BanMask, modes.ExceptMask, modes.InviteMask}.String(), "", modes.Modes{modes.UserLimit, modes.Key}.String(), modes.Modes{modes.InviteOnly, modes.Moderated, modes.NoOutside, modes.OpOnlyTopic, modes.ChanRoleplaying, modes.Secret}.String()}, ","))
-	if config.History.Enabled && config.Limits.ChathistoryMax > 0 {
-		isupport.Add("CHATHISTORY", strconv.Itoa(config.Limits.ChathistoryMax))
+	if config.History.Enabled && config.History.ChathistoryMax > 0 {
+		isupport.Add("CHATHISTORY", strconv.Itoa(config.History.ChathistoryMax))
 	}
 	isupport.Add("CHANNELLEN", strconv.Itoa(config.Limits.ChannelLen))
 	isupport.Add("CHANTYPES", "#")

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -439,6 +439,10 @@ limits:
     # maximum length of channel lists (beI modes)
     chan-list-modes: 60
 
+    # maximum number of CHATHISTORY messages that can be
+    # requested at once (0 disables support for CHATHISTORY)
+    chathistory-maxmessages: 100
+
     # maximum length of IRC lines
     # this should generally be 1024-2048, and will only apply when negotiated by clients
     linelen:

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -470,6 +470,10 @@ fakelag:
 # message history tracking, for the RESUME extension and possibly other uses in future
 history:
     # should we store messages for later playback?
+    # the current implementation stores messages in RAM only; they do not persist
+    # across server restarts. however, you should disable this unless you understand
+    # how it interacts with the GDPR and/or any data privacy laws that apply
+    # in your country and the countries of your users.
     enabled: true
 
     # how many channel-specific events (messages, joins, parts) should be tracked per channel?

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -439,10 +439,6 @@ limits:
     # maximum length of channel lists (beI modes)
     chan-list-modes: 60
 
-    # maximum number of CHATHISTORY messages that can be
-    # requested at once (0 disables support for CHATHISTORY)
-    chathistory-maxmessages: 100
-
     # maximum length of IRC lines
     # this should generally be 1024-2048, and will only apply when negotiated by clients
     linelen:
@@ -484,3 +480,7 @@ history:
 
     # number of messages to automatically play back on channel join (0 to disable):
     autoreplay-on-join: 0
+
+    # maximum number of CHATHISTORY messages that can be
+    # requested at once (0 disables support for CHATHISTORY)
+    chathistory-maxmessages: 100


### PR DESCRIPTION
This has a zillion edge cases. Hopefully it's not risky, though. If you set `chathistory-maxmessages: 0`, `CHATHISTORY` will no longer be advertised in isupport (and will fail fast if invoked).

`HISTORY` is [grove.io's command](https://grove.io/blog/history-playback-irc.html) but with an explicit target argument.

This script was somewhat helpful for testing: https://gist.github.com/slingamn/da2f94eccead0edb38516b919d359c1d