### PR TITLE
add sasl-only config option

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -456,7 +456,7 @@ func (am *AccountManager) setPassword(account string, password string) (err erro
 }
 
 func (am *AccountManager) dispatchCallback(client *Client, casefoldedAccount string, callbackNamespace string, callbackValue string) (string, error) {
-	if callbackNamespace == "*" || callbackNamespace == "none" {
+	if callbackNamespace == "*" || callbackNamespace == "none" || callbackNamespace == "admin" {
 		return "", nil
 	} else if callbackNamespace == "mailto" {
 		return am.dispatchMailtoCallback(client, casefoldedAccount, callbackValue)
@@ -590,7 +590,9 @@ func (am *AccountManager) Verify(client *Client, account string, code string) er
 	if err != nil {
 		return err
 	}
-	am.Login(client, clientAccount)
+	if client != nil {
+		am.Login(client, clientAccount)
+	}
 	return nil
 }
 

--- a/irc/client.go
+++ b/irc/client.go
@@ -32,10 +32,6 @@ const (
 	IRCv3TimestampFormat = "2006-01-02T15:04:05.000Z"
 )
 
-var (
-	LoopbackIP = net.ParseIP("127.0.0.1")
-)
-
 // ResumeDetails is a place to stash data at various stages of
 // the resume process: when handling the RESUME command itself,
 // when completing the registration, and when rejoining channels.
@@ -55,7 +51,6 @@ type Client struct {
 	account            string
 	accountName        string // display name of the account: uncasefolded, '*' if not logged in
 	atime              time.Time
-	authorized         bool
 	awayMessage        string
 	capabilities       *caps.Set
 	capState           caps.State
@@ -88,12 +83,14 @@ type Client struct {
 	quitMessage        string
 	rawHostname        string
 	realname           string
+	realIP             net.IP
 	registered         bool
 	resumeDetails      *ResumeDetails
 	resumeToken        string
 	saslInProgress     bool
 	saslMechanism      string
 	saslValue          string
+	sentPassCommand    bool
 	server             *Server
 	skeleton           string
 	socket             *Socket
@@ -131,7 +128,6 @@ func NewClient(server *Server, conn net.Conn, isTLS bool) {
 	socket := NewSocket(conn, fullLineLenLimit*2, config.Server.MaxSendQBytes)
 	client := &Client{
 		atime:        now,
-		authorized:   server.Password() == nil,
 		capabilities: caps.NewSet(),
 		capState:     caps.NoneState,
 		capVersion:   caps.Cap301,
@@ -152,6 +148,12 @@ func NewClient(server *Server, conn net.Conn, isTLS bool) {
 	}
 	client.languages = server.languages.Default()
 
+	remoteAddr := conn.RemoteAddr()
+	client.realIP = utils.AddrToIP(remoteAddr)
+	if client.realIP == nil {
+		server.logger.Error("internal", "bad remote address", remoteAddr.String())
+		return
+	}
 	client.recomputeMaxlens()
 	if isTLS {
 		client.SetMode(modes.TLS, true)
@@ -159,7 +161,7 @@ func NewClient(server *Server, conn net.Conn, isTLS bool) {
 		// error is not useful to us here anyways so we can ignore it
 		client.certfp, _ = client.socket.CertFP()
 	}
-	if config.Server.CheckIdent && !utils.AddrIsUnix(conn.RemoteAddr()) {
+	if config.Server.CheckIdent && !utils.AddrIsUnix(remoteAddr) {
 		_, serverPortString, err := net.SplitHostPort(conn.LocalAddr().String())
 		if err != nil {
 			server.logger.Error("internal", "bad server address", err.Error())
@@ -196,6 +198,16 @@ func NewClient(server *Server, conn net.Conn, isTLS bool) {
 	go client.run()
 }
 
+func (client *Client) isAuthorized(config *Config) bool {
+	saslSent := client.account != ""
+	passRequirementMet := (config.Server.passwordBytes == nil) || client.sentPassCommand || (config.Accounts.SkipServerPassword && saslSent)
+	if !passRequirementMet {
+		return false
+	}
+	saslRequirementMet := !config.Accounts.RequireSasl.Enabled || saslSent || utils.IPInNets(client.IP(), config.Accounts.RequireSasl.exemptedNets)
+	return saslRequirementMet
+}
+
 func (client *Client) resetFakelag() {
 	fakelag := func() *Fakelag {
 		if client.HasRoleCapabs("nofakelag") {
@@ -218,14 +230,13 @@ func (client *Client) resetFakelag() {
 
 // IP returns the IP address of this client.
 func (client *Client) IP() net.IP {
+	client.stateMutex.RLock()
+	defer client.stateMutex.RUnlock()
+
 	if client.proxiedIP != nil {
 		return client.proxiedIP
 	}
-	if ip := utils.AddrToIP(client.socket.conn.RemoteAddr()); ip != nil {
-		return ip
-	}
-	// unix domain socket that hasn't issued PROXY/WEBIRC yet. YOLO
-	return LoopbackIP
+	return client.realIP
 }
 
 // IPString returns the IP address of this client as a string.
@@ -296,7 +307,7 @@ func (client *Client) run() {
 
 	// Set the hostname for this client
 	// (may be overridden by a later PROXY command from stunnel)
-	client.rawHostname = utils.AddrLookupHostname(client.socket.conn.RemoteAddr())
+	client.rawHostname = utils.LookupHostname(client.realIP.String())
 
 	firstLine := true
 

--- a/irc/commands.go
+++ b/irc/commands.go
@@ -54,7 +54,9 @@ func (cmd *Command) Run(server *Server, client *Client, msg ircmsg.IrcMessage) b
 	}
 
 	// most servers do this only for PING/PONG, but we'll do it for any command:
-	client.idletimer.Touch()
+	if client.registered {
+		client.idletimer.Touch()
+	}
 
 	if !cmd.leaveClientIdle {
 		client.Active()

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -32,14 +32,6 @@ func (server *Server) RecoverFromErrors() bool {
 	return *server.Config().Debug.RecoverFromErrors
 }
 
-func (server *Server) ProxyAllowedFrom() []string {
-	return server.Config().Server.ProxyAllowedFrom
-}
-
-func (server *Server) WebIRCConfig() []webircConfig {
-	return server.Config().Server.WebIRC
-}
-
 func (server *Server) DefaultChannelModes() modes.Modes {
 	return server.Config().Channels.defaultModes
 }
@@ -168,18 +160,6 @@ func (client *Client) SetAccountName(account string) (changed bool) {
 	client.account = casefoldedAccount
 	client.accountName = account
 	return
-}
-
-func (client *Client) Authorized() bool {
-	client.stateMutex.RLock()
-	defer client.stateMutex.RUnlock()
-	return client.authorized
-}
-
-func (client *Client) SetAuthorized(authorized bool) {
-	client.stateMutex.Lock()
-	defer client.stateMutex.Unlock()
-	client.authorized = authorized
 }
 
 func (client *Client) HasMode(mode modes.Mode) bool {

--- a/irc/idletimer.go
+++ b/irc/idletimer.go
@@ -83,11 +83,6 @@ func (it *IdleTimer) Start() {
 }
 
 func (it *IdleTimer) Touch() {
-	// ignore touches from unregistered clients
-	if !it.client.Registered() {
-		return
-	}
-
 	it.updateIdleDuration()
 
 	it.Lock()

--- a/irc/server.go
+++ b/irc/server.go
@@ -381,7 +381,7 @@ func (server *Server) generateMessageID() string {
 //
 
 func (server *Server) tryRegister(c *Client) {
-	if c.Registered() {
+	if c.registered {
 		return
 	}
 
@@ -389,9 +389,10 @@ func (server *Server) tryRegister(c *Client) {
 		return
 	}
 
-	// client MUST send PASS (or AUTHENTICATE, if skip-server-password is set)
+	// client MUST send PASS if necessary, or authenticate with SASL if necessary,
 	// before completing the other registration commands
-	if !c.Authorized() {
+	config := server.Config()
+	if !c.isAuthorized(config) {
 		c.Quit(c.t("Bad password"))
 		c.destroy(false)
 		return

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -198,10 +198,13 @@ accounts:
     # PASS as well, so it can be configured to authenticate with SASL only.
     skip-server-password: false
 
+    # require-sasl controls whether clients are required to have accounts
+    # (and sign into them using SASL) to connect to the server
     require-sasl:
-        # if this is enabled, all clients must authenticate with SASL:
+        # if this is enabled, all clients must authenticate with SASL while connecting
         enabled: false
-        # the following IPs/CIDRs are exempted from this requirement:
+
+        # IPs/CIDRs which are exempted from the account requirement
         exempted:
             - "localhost"
             # - '127.0.0.2'

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -67,8 +67,8 @@ server:
     # if this is true, the motd is escaped using formatting codes like $c, $b, and $i
     motd-formatting: true
 
-    # addresses/hostnames the PROXY command can be used from
-    # this should be restricted to 127.0.0.1/8 and localhost at most
+    # addresses/CIDRs the PROXY command can be used from
+    # this should be restricted to 127.0.0.1/8 and ::1/128 (unless you have a good reason)
     # you should also add these addresses to the connection limits and throttling exemption lists
     proxy-allowed-from:
         # - localhost
@@ -85,7 +85,7 @@ server:
             # password the gateway uses to connect, made with  oragono genpasswd
             password: "$2a$04$sLEFDpIOyUp55e6gTMKbOeroT6tMXTjPFvA0eGvwvImVR9pkwv7ee"
 
-            # hosts that can use this webirc command
+            # addresses/CIDRs that can use this webirc command
             # you should also add these addresses to the connection limits and throttling exemption lists
             hosts:
                 # - localhost
@@ -117,9 +117,9 @@ server:
 
         # IPs/networks which are exempted from connection limits
         exempted:
-            - "127.0.0.1"
-            - "127.0.0.1/8"
-            - "::1/128"
+            - "localhost"
+            # - "192.168.1.1"
+            # - "2001:0db8::/32"
 
     # automated connection throttling
     connection-throttling:
@@ -145,9 +145,9 @@ server:
 
         # IPs/networks which are exempted from connection limits
         exempted:
-            - "127.0.0.1"
-            - "127.0.0.1/8"
-            - "::1/128"
+            - "localhost"
+            # - "192.168.1.1"
+            # - "2001:0db8::/32"
 
 # account options
 accounts:
@@ -197,6 +197,15 @@ accounts:
     # successfully authenticates with SASL will not be required to send
     # PASS as well, so it can be configured to authenticate with SASL only.
     skip-server-password: false
+
+    require-sasl:
+        # if this is enabled, all clients must authenticate with SASL:
+        enabled: false
+        # the following IPs/CIDRs are exempted from this requirement:
+        exempted:
+            - "localhost"
+            # - '127.0.0.2'
+            # - '10.10.0.0/16'
 
     # nick-reservation controls how, and whether, nicknames are linked to accounts
     nick-reservation:


### PR DESCRIPTION
Implements the last-mentioned idea on #288.

This got into a lot of yak shaving because of the tangential connection to IPs. In short:

* All configurable lists of IPs/nets are normalized to a list of ipv6 CIDRs, using the utils from #329
* All IPs are normalized to v6, using the 4-to-6 mapping. (I explicitly stripped this mapping in #294, but it was a misdiagnosis; stunnel over ipv4 works fine with oragono without it.)
* To the maximum extent possible, we pretend unix domain sockets are actually 127.0.0.1
* "localhost" is an alias for both loopback CIDRs (127.0.0.0/8 and ::1/128), hence also for unix domain sockets

I tested this a bunch in my stage (genuine remote connections over both ipv4 and ipv6, direct and proxied through stunnel). I didn't test WEBIRC end-to-end with a real webircgateway instance, but I spoofed WEBIRC lines with ircdog and they were processed correctly. I'll do a final test in prod after this is merged.