### PR TITLE
track channel registrations per account

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -165,10 +165,13 @@ func (channel *Channel) SetRegistered(founder string) error {
 }
 
 // SetUnregistered deletes the channel's registration information.
-func (channel *Channel) SetUnregistered() {
+func (channel *Channel) SetUnregistered(expectedFounder string) {
 	channel.stateMutex.Lock()
 	defer channel.stateMutex.Unlock()
 
+	if channel.registeredFounder != expectedFounder {
+		return
+	}
 	channel.registeredFounder = ""
 	var zeroTime time.Time
 	channel.registeredTime = zeroTime

--- a/irc/channelreg.go
+++ b/irc/channelreg.go
@@ -215,17 +215,6 @@ func (reg *ChannelRegistry) Delete(casefoldedName string, info RegisteredChannel
 	})
 }
 
-// deleteByAccount is a helper to delete all channel registrations corresponding to a user account.
-func (reg *ChannelRegistry) deleteByAccount(cfaccount string, cfchannels []string) {
-	for _, cfchannel := range cfchannels {
-		info := reg.LoadChannel(cfchannel)
-		if info == nil || info.Founder != cfaccount {
-			continue
-		}
-		reg.Delete(cfchannel, *info)
-	}
-}
-
 // Rename handles the persistence part of a channel rename: the channel is
 // persisted under its new name, and the old name is cleaned up if necessary.
 func (reg *ChannelRegistry) Rename(channel *Channel, casefoldedOldName string) {

--- a/irc/chanserv.go
+++ b/irc/chanserv.go
@@ -277,11 +277,13 @@ func csUnregisterHandler(server *Server, client *Client, command string, params 
 		return
 	}
 
-	hasPrivs := client.HasRoleCapabs("chanreg")
-	if !hasPrivs {
-		founder := channel.Founder()
-		hasPrivs = founder != "" && founder == client.Account()
+	founder := channel.Founder()
+	if founder == "" {
+		csNotice(rb, client.t("That channel is not registered"))
+		return
 	}
+
+	hasPrivs := client.HasRoleCapabs("chanreg") || founder == client.Account()
 	if !hasPrivs {
 		csNotice(rb, client.t("Insufficient privileges"))
 		return
@@ -295,8 +297,8 @@ func csUnregisterHandler(server *Server, client *Client, command string, params 
 		return
 	}
 
-	channel.SetUnregistered()
-	go server.channelRegistry.Delete(channelKey, info)
+	channel.SetUnregistered(founder)
+	server.channelRegistry.Delete(channelKey, info)
 	csNotice(rb, fmt.Sprintf(client.t("Channel %s is now unregistered"), channelKey))
 }
 

--- a/irc/chanserv.go
+++ b/irc/chanserv.go
@@ -224,6 +224,13 @@ func csRegisterHandler(server *Server, client *Client, command string, params []
 		return
 	}
 
+	account := client.Account()
+	channelsAlreadyRegistered := server.accounts.ChannelsForAccount(account)
+	if server.Config().Channels.Registration.MaxChannelsPerAccount <= len(channelsAlreadyRegistered) {
+		csNotice(rb, client.t("You have already registered the maximum number of channels; try dropping some with /CS UNREGISTER"))
+		return
+	}
+
 	// this provides the synchronization that allows exactly one registration of the channel:
 	err = channelInfo.SetRegistered(client.Account())
 	if err != nil {

--- a/irc/chanserv.go
+++ b/irc/chanserv.go
@@ -232,7 +232,7 @@ func csRegisterHandler(server *Server, client *Client, command string, params []
 	}
 
 	// this provides the synchronization that allows exactly one registration of the channel:
-	err = channelInfo.SetRegistered(client.Account())
+	err = channelInfo.SetRegistered(account)
 	if err != nil {
 		csNotice(rb, err.Error())
 		return

--- a/irc/config.go
+++ b/irc/config.go
@@ -294,9 +294,10 @@ type Config struct {
 	Accounts AccountConfig
 
 	Channels struct {
-		DefaultModes *string `yaml:"default-modes"`
-		defaultModes modes.Modes
-		Registration ChannelRegistrationConfig
+		DefaultModes         *string `yaml:"default-modes"`
+		defaultModes         modes.Modes
+		MaxChannelsPerClient int `yaml:"max-channels-per-client"`
+		Registration         ChannelRegistrationConfig
 	}
 
 	OperClasses map[string]*OperClassConfig `yaml:"oper-classes"`
@@ -790,6 +791,9 @@ func LoadConfig(filename string) (config *Config, err error) {
 		config.Accounts.Registration.BcryptCost = passwd.DefaultCost
 	}
 
+	if config.Channels.MaxChannelsPerClient == 0 {
+		config.Channels.MaxChannelsPerClient = 100
+	}
 	if config.Channels.Registration.MaxChannelsPerAccount == 0 {
 		config.Channels.Registration.MaxChannelsPerAccount = 10
 	}

--- a/irc/config.go
+++ b/irc/config.go
@@ -795,7 +795,7 @@ func LoadConfig(filename string) (config *Config, err error) {
 		config.Channels.MaxChannelsPerClient = 100
 	}
 	if config.Channels.Registration.MaxChannelsPerAccount == 0 {
-		config.Channels.Registration.MaxChannelsPerAccount = 10
+		config.Channels.Registration.MaxChannelsPerAccount = 15
 	}
 
 	// in the current implementation, we disable history by creating a history buffer

--- a/irc/config.go
+++ b/irc/config.go
@@ -181,7 +181,8 @@ type NickReservationConfig struct {
 
 // ChannelRegistrationConfig controls channel registration.
 type ChannelRegistrationConfig struct {
-	Enabled bool
+	Enabled               bool
+	MaxChannelsPerAccount int `yaml:"max-channels-per-account"`
 }
 
 // OperClassConfig defines a specific operator class.
@@ -787,6 +788,10 @@ func LoadConfig(filename string) (config *Config, err error) {
 
 	if config.Accounts.Registration.BcryptCost == 0 {
 		config.Accounts.Registration.BcryptCost = passwd.DefaultCost
+	}
+
+	if config.Channels.Registration.MaxChannelsPerAccount == 0 {
+		config.Channels.Registration.MaxChannelsPerAccount = 10
 	}
 
 	// in the current implementation, we disable history by creating a history buffer

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -184,6 +184,12 @@ func (client *Client) Channels() (result []*Channel) {
 	return
 }
 
+func (client *Client) NumChannels() int {
+	client.stateMutex.RLock()
+	defer client.stateMutex.RUnlock()
+	return len(client.channels)
+}
+
 func (client *Client) WhoWas() (result WhoWas) {
 	return client.Details().WhoWas
 }

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1152,7 +1152,7 @@ func joinHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 	oper := client.Oper()
 	for i, name := range channels {
 		if config.Channels.MaxChannelsPerClient <= client.NumChannels() && oper == nil {
-			rb.Add(nil, server.name, ERR_UNKNOWNERROR, client.Nick(), name, client.t("You have joined too many channels already"))
+			rb.Add(nil, server.name, ERR_TOOMANYCHANNELS, client.Nick(), name, client.t("You have joined too many channels"))
 			return false
 		}
 		var key string

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1148,7 +1148,13 @@ func joinHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 		keys = strings.Split(msg.Params[1], ",")
 	}
 
+	config := server.Config()
+	oper := client.Oper()
 	for i, name := range channels {
+		if config.Channels.MaxChannelsPerClient <= client.NumChannels() && oper == nil {
+			rb.Add(nil, server.name, ERR_UNKNOWNERROR, client.Nick(), name, client.t("You have joined too many channels already"))
+			return false
+		}
 		var key string
 		if len(keys) > i {
 			key = keys[i]

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -318,6 +318,9 @@ func nsInfoHandler(server *Server, client *Client, command string, params []stri
 	for _, nick := range account.AdditionalNicks {
 		nsNotice(rb, fmt.Sprintf(client.t("Additional grouped nick: %s"), nick))
 	}
+	for _, channel := range server.accounts.ChannelsForAccount(accountName) {
+		nsNotice(rb, fmt.Sprintf(client.t("Registered channel: %s"), channel))
+	}
 }
 
 func nsRegisterHandler(server *Server, client *Client, command string, params []string, rb *ResponseBuffer) {

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -280,6 +280,9 @@ channels:
         # can users register new channels?
         enabled: true
 
+        # how many channels can each account register?
+        max-channels-per-account: 10
+
 # operator classes
 oper-classes:
     # local operator

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -275,6 +275,9 @@ channels:
     # see  /QUOTE HELP cmodes  for more channel modes
     default-modes: +nt
 
+    # how many channels can a client be in at once?
+    max-channels-per-client: 100
+
     # channel registration - requires an account
     registration:
         # can users register new channels?

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -284,7 +284,7 @@ channels:
         enabled: true
 
         # how many channels can each account register?
-        max-channels-per-account: 10
+        max-channels-per-account: 15
 
 # operator classes
 oper-classes:


### PR DESCRIPTION
* limit the total number of registrations per account (#280)
* when an account is unregistered, unregister all its channels (#221)

This is actually somewhat risky, and we can definitely hold it over for v0.14. But looking over the list of changes, this one seemed like it was...missing.

The default channels-per-account limit is 10, in homage to RFC 1459 (read somewhat out of context): "a limit of ten (10) channels is recommended as being ample for both experienced and novice users"