### PR TITLE
update resume support to draft/resume-0.3

### DIFF
--- a/gencapdefs.py
+++ b/gencapdefs.py
@@ -107,7 +107,7 @@ CAPDEFS = [
     ),
     CapDef(
         identifier="Resume",
-        name="draft/resume-0.2",
+        name="draft/resume-0.3",
         url="https://github.com/DanielOaks/ircv3-specifications/blob/master+resume/extensions/resume.md",
         standard="proposed IRCv3",
     ),

--- a/irc/caps/defs.go
+++ b/irc/caps/defs.go
@@ -73,7 +73,7 @@ const (
 	// https://github.com/SaberUK/ircv3-specifications/blob/rename/extensions/rename.md
 	Rename Capability = iota
 
-	// Resume is the proposed IRCv3 capability named "draft/resume-0.2":
+	// Resume is the proposed IRCv3 capability named "draft/resume-0.3":
 	// https://github.com/DanielOaks/ircv3-specifications/blob/master+resume/extensions/resume.md
 	Resume Capability = iota
 
@@ -112,7 +112,7 @@ var (
 		"draft/message-tags-0.2",
 		"multi-prefix",
 		"draft/rename",
-		"draft/resume-0.2",
+		"draft/resume-0.3",
 		"sasl",
 		"server-time",
 		"sts",

--- a/irc/commands.go
+++ b/irc/commands.go
@@ -231,7 +231,7 @@ func init() {
 		"RESUME": {
 			handler:      resumeHandler,
 			usablePreReg: true,
-			minParams:    2,
+			minParams:    1,
 		},
 		"SAJOIN": {
 			handler:   sajoinHandler,

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -109,10 +109,16 @@ func (client *Client) uniqueIdentifiers() (nickCasefolded string, skeleton strin
 	return client.nickCasefolded, client.skeleton
 }
 
-func (client *Client) ResumeToken() string {
+func (client *Client) ResumeID() string {
 	client.stateMutex.RLock()
 	defer client.stateMutex.RUnlock()
-	return client.resumeToken
+	return client.resumeID
+}
+
+func (client *Client) SetResumeID(id string) {
+	client.stateMutex.Lock()
+	defer client.stateMutex.Unlock()
+	client.resumeID = id
 }
 
 func (client *Client) Oper() *Oper {

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2273,7 +2273,7 @@ func resumeHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Re
 		if err == nil {
 			timestamp = ts
 		} else {
-			rb.Add(nil, server.name, "RESUME", "ERR", client.t("Timestamp is not in 2006-01-02T15:04:05.999Z format, ignoring it"))
+			rb.Add(nil, server.name, "RESUME", "WARN", client.t("Timestamp is not in 2006-01-02T15:04:05.999Z format, ignoring it"))
 		}
 	}
 

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -508,8 +508,8 @@ func capHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Respo
 		// if this is the first time the client is requesting a resume token,
 		// send it to them
 		if toAdd.Has(caps.Resume) {
-			token, err := client.generateResumeToken()
-			if err == nil {
+			token := server.resumeManager.GenerateToken(client)
+			if token != "" {
 				rb.Add(nil, server.name, "RESUME", "TOKEN", token)
 			}
 		}
@@ -2258,28 +2258,26 @@ func renameHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Re
 	return false
 }
 
-// RESUME <oldnick> <token> [timestamp]
+// RESUME <token> [timestamp]
 func resumeHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
-	oldnick := msg.Params[0]
-	token := msg.Params[1]
+	token := msg.Params[0]
 
 	if client.registered {
-		rb.Add(nil, server.name, ERR_CANNOT_RESUME, oldnick, client.t("Cannot resume connection, connection registration has already been completed"))
+		rb.Add(nil, server.name, "RESUME", "ERR", client.t("Cannot resume connection, connection registration has already been completed"))
 		return false
 	}
 
 	var timestamp time.Time
-	if 2 < len(msg.Params) {
-		ts, err := time.Parse(IRCv3TimestampFormat, msg.Params[2])
+	if 1 < len(msg.Params) {
+		ts, err := time.Parse(IRCv3TimestampFormat, msg.Params[1])
 		if err == nil {
 			timestamp = ts
 		} else {
-			rb.Add(nil, server.name, ERR_CANNOT_RESUME, oldnick, client.t("Timestamp is not in 2006-01-02T15:04:05.999Z format, ignoring it"))
+			rb.Add(nil, server.name, "RESUME", "ERR", client.t("Timestamp is not in 2006-01-02T15:04:05.999Z format, ignoring it"))
 		}
 	}
 
 	client.resumeDetails = &ResumeDetails{
-		OldNick:        oldnick,
 		Timestamp:      timestamp,
 		PresentedToken: token,
 	}

--- a/irc/resume.go
+++ b/irc/resume.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2019 Shivaram Lingamneni <slingamn@cs.stanford.edu>
+// released under the MIT license
+
+package irc
+
+import (
+	"sync"
+
+	"github.com/oragono/oragono/irc/utils"
+)
+
+// implements draft/resume-0.3, in particular the issuing, management, and verification
+// of resume tokens with two components: a unique ID and a secret key
+
+type resumeTokenPair struct {
+	client *Client
+	secret string
+}
+
+type ResumeManager struct {
+	sync.RWMutex // level 2
+
+	resumeIDtoCreds map[string]resumeTokenPair
+	server          *Server
+}
+
+func (rm *ResumeManager) Initialize(server *Server) {
+	rm.resumeIDtoCreds = make(map[string]resumeTokenPair)
+	rm.server = server
+}
+
+// GenerateToken generates a resume token for a client. If the client has
+// already been assigned one, it returns "".
+func (rm *ResumeManager) GenerateToken(client *Client) (token string) {
+	id := utils.GenerateSecretToken()
+	secret := utils.GenerateSecretToken()
+
+	rm.Lock()
+	defer rm.Unlock()
+
+	if client.ResumeID() != "" {
+		return
+	}
+
+	client.SetResumeID(id)
+	rm.resumeIDtoCreds[id] = resumeTokenPair{
+		client: client,
+		secret: secret,
+	}
+
+	return id + secret
+}
+
+// VerifyToken looks up the client corresponding to a resume token, returning
+// nil if there is no such client or the token is invalid.
+func (rm *ResumeManager) VerifyToken(token string) (client *Client) {
+	if len(token) != 2*utils.SecretTokenLength {
+		return
+	}
+
+	rm.RLock()
+	defer rm.RUnlock()
+
+	id := token[:utils.SecretTokenLength]
+	pair, ok := rm.resumeIDtoCreds[id]
+	if ok {
+		if utils.SecretTokensMatch(pair.secret, token[utils.SecretTokenLength:]) {
+			// disallow resume of an unregistered client; this prevents the use of
+			// resume as an auth bypass
+			if pair.client.Registered() {
+				return pair.client
+			}
+		}
+	}
+	return
+}
+
+// Delete stops tracking a client's resume token.
+func (rm *ResumeManager) Delete(client *Client) {
+	rm.Lock()
+	defer rm.Unlock()
+
+	currentID := client.ResumeID()
+	if currentID != "" {
+		delete(rm.resumeIDtoCreds, currentID)
+	}
+}

--- a/irc/server.go
+++ b/irc/server.go
@@ -88,6 +88,7 @@ type Server struct {
 	rehashMutex            sync.Mutex // tier 4
 	rehashSignal           chan os.Signal
 	pprofServer            *http.Server
+	resumeManager          ResumeManager
 	signals                chan os.Signal
 	snomasks               *SnoManager
 	store                  *buntdb.DB
@@ -129,6 +130,8 @@ func NewServer(config *Config, logger *logger.Manager) (*Server, error) {
 		stats:               NewStats(),
 		semaphores:          NewServerSemaphores(),
 	}
+
+	server.resumeManager.Initialize(server)
 
 	if err := server.applyConfig(config, true); err != nil {
 		return nil, err

--- a/irc/utils/crypto.go
+++ b/irc/utils/crypto.go
@@ -14,6 +14,10 @@ var (
 	b32encoder = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567").WithPadding(base32.NoPadding)
 )
 
+const (
+	SecretTokenLength = 26
+)
+
 // generate a secret token that cannot be brute-forced via online attacks
 func GenerateSecretToken() string {
 	// 128 bits of entropy are enough to resist any online attack:

--- a/irc/utils/crypto_test.go
+++ b/irc/utils/crypto_test.go
@@ -16,7 +16,7 @@ const (
 
 func TestGenerateSecretToken(t *testing.T) {
 	token := GenerateSecretToken()
-	if len(token) < 22 {
+	if len(token) != SecretTokenLength {
 		t.Errorf("bad token: %v", token)
 	}
 }


### PR DESCRIPTION
cc @jesopo

This implements https://github.com/DanielOaks/ircv3-specifications/blob/0844bc2cb7e906ca9dceecab5033bafdbbca48ba/extensions/resume.md

It went quite well!

By design, a successful resume bypasses all auth checks (`PASS`, sasl-required, etc.). Formerly, client lookup by nickname was enough to ensure that the old client had successfully registered (and therefore passed all the auth checks). This implementation needs to check explicitly; this may or may not be worth noting in the spec.