### PR TITLE
four small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can use the `--conf` parameter when launching Oragono to control where it lo
 
 ### Logs
 
-By default, logs are stored in the file `ircd.log`. The configuration format of logs is designed to be easily pluggable, and is inspired by the logging config provided by InspIRCd.
+By default, logs go to stderr only. They can be configured to go to a file, or you can use systemd to direct the stderr to the system journal (see the manual for details). The configuration format of logs is designed to be easily pluggable, and is inspired by the logging config provided by InspIRCd.
 
 ### Passwords
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -103,9 +103,16 @@ To get started with Oragono on macOS, Linux, or on a Raspberry Pi:
 
 To start the server, type `./oragono run` and hit enter, and the server should be ready to use!
 
-If you're using Arch Linux, you can also install the [`oragono` package](https://aur.archlinux.org/packages/oragono/) from the AUR. This lets you bypass the above process and bundles a systemd service file for easily starting the server.
+If you're using Arch Linux, you can also install the [`oragono` package](https://aur.archlinux.org/packages/oragono/) from the AUR.
 
-If you're rolling your own deployment, here's another [example](https://github.com/darwin-network/slash/blob/master/etc/systemd/system/ircd.service) of a systemd unit file that can be used to run Oragono as an unprivileged role user.
+
+## Running oragono as a service on Linux
+
+The recommended way to operate oragono as a service on Linux is via systemd. This provides a standard interface for starting, stopping, and rehashing (via `systemctl reload`) the service. It also captures oragono's loglines (sent to stderr in the default configuration) and writes them to the system journal.
+
+If you're using Arch, the abovementioned AUR package bundles a systemd file for starting and stopping the server. If you're rolling your own deployment, here's an [example](https://github.com/darwin-network/slash/blob/master/etc/systemd/system/ircd.service) of a systemd unit file that can be used to run Oragono as an unprivileged role user.
+
+On a non-systemd system, oragono can be configured to log to a file and used [logrotate(8)](https://linux.die.net/man/8/logrotate), since it will reopen its log files (as well as rehashing the config file) upon receiving a SIGHUP.
 
 
 --------------------------------------------------------------------------------------------

--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -311,7 +311,7 @@ func (am *AccountManager) Register(client *Client, account string, callbackNames
 	// as an account; this prevents "land-grab" situations where someone else
 	// registers your nick out from under you and then NS GHOSTs you
 	// n.b. client is nil during a SAREGISTER:
-	if config.NickReservation.Enabled && client != nil && client.Nick() != account {
+	if config.NickReservation.Enabled && client != nil && client.NickCasefolded() != casefoldedAccount {
 		return errAccountMustHoldNick
 	}
 

--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -593,6 +593,11 @@ func (am *AccountManager) Verify(client *Client, account string, code string) er
 		return err
 	}
 
+	nick := "[server admin]"
+	if client != nil {
+		nick = client.Nick()
+	}
+	am.server.logger.Info("accounts", "client", nick, "registered account", casefoldedAccount)
 	raw.Verified = true
 	clientAccount, err := am.deserializeRawAccount(raw)
 	if err != nil {

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -256,9 +256,18 @@ func nsIdentifyHandler(server *Server, client *Client, command string, params []
 
 	loginSuccessful := false
 
-	username := params[0]
-	var passphrase string
-	if len(params) > 1 {
+	var username, passphrase string
+	if len(params) == 1 {
+		if client.certfp != "" {
+			username = params[0]
+		} else {
+			// XXX undocumented compatibility mode with other nickservs, allowing
+			// /msg NickServ identify passphrase
+			username = client.NickCasefolded()
+			passphrase = params[0]
+		}
+	} else {
+		username = params[0]
 		passphrase = params[1]
 	}
 

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -463,6 +463,7 @@ func nsUnregisterHandler(server *Server, client *Client, command string, params 
 		nsNotice(rb, client.t("Error while unregistering account"))
 	} else {
 		nsNotice(rb, fmt.Sprintf(client.t("Successfully unregistered account %s"), cfname))
+		server.logger.Info("accounts", "client", client.Nick(), "unregistered account", cfname)
 	}
 }
 

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -372,7 +372,8 @@ logging:
         #   channels        channel creation and operations
         #   commands        command calling and operations
         #   opers           oper actions, authentication, etc
-        #   password        password hashing and comparing
+        #   services        actions related to NickServ, ChanServ, etc.
+        #   internal        unexpected runtime behavior, including potential bugs
         #   userinput       raw lines sent by users
         #   useroutput      raw lines sent to users
         type: "* -userinput -useroutput"


### PR DESCRIPTION
1. Someone was having problems with ZNC's nickserv module (given that ZNC's SASL is broken) and I realized that it expects a different command format by default. Let's support this in the case where the client doesn't have a certfp (so they can't mean `/ns register $account`, meaning their certfp as the credential)
1. Most of the log categories mentioned in oragono.yaml don't actually exist! I added some loglines for the `accounts` category.
1. Updated the readme and the manual with some documentation changes that were missing from 
1. Make the land-grab check case insensitive