### PR TITLE
fix #364

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1996,6 +1996,7 @@ func operHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 	}
 	if !authorized {
 		rb.Add(nil, server.name, ERR_PASSWDMISMATCH, client.nick, client.t("Password incorrect"))
+		client.Quit(client.t("Password incorrect"))
 		return true
 	}
 
@@ -2059,7 +2060,7 @@ func passHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 	password := []byte(msg.Params[0])
 	if bcrypt.CompareHashAndPassword(serverPassword, password) != nil {
 		rb.Add(nil, server.name, ERR_PASSWDMISMATCH, client.nick, client.t("Password incorrect"))
-		rb.Add(nil, server.name, "ERROR", client.t("Password incorrect"))
+		client.Quit(client.t("Password incorrect"))
 		return true
 	}
 


### PR DESCRIPTION
````
# normal /quit
quit :my quit message
:asdf!~a@0::1 QUIT :Quit: my quit message
ERROR :Quit: my quit message

# incorrect /pass
pass wrongpassword
:oragono.test 464 * :Password incorrect
ERROR :Password incorrect

# incorrect /oper, also sends the "Password incorrect" message to friends
oper root wrongpassword
:oragono.test 464 asdf :Password incorrect
:asdf!~a@0::1 QUIT :Password incorrect
ERROR :Password incorrect

# unregistered ping timeout
ERROR :Registration timeout: 1m0s

# registered ping timeout
:asdf!~a@0::1 QUIT :Ping timeout: 2m30s
ERROR :Ping timeout: 2m30s
````