### PR TITLE
2 small fixes

### DIFF
--- a/irc/hostserv.go
+++ b/irc/hostserv.go
@@ -206,6 +206,10 @@ func hsStatusHandler(server *Server, client *Client, command string, params []st
 		accountName = params[0]
 	} else {
 		accountName = client.Account()
+		if accountName == "" {
+			hsNotice(rb, client.t("You're not logged into an account"))
+			return
+		}
 	}
 
 	account, err := server.accounts.LoadAccount(accountName)

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -452,10 +452,6 @@ func nsUnregisterHandler(server *Server, client *Client, command string, params 
 		return
 	}
 
-	if cfname == client.Account() {
-		client.server.accounts.Logout(client)
-	}
-
 	err = server.accounts.Unregister(cfname)
 	if err == errAccountDoesNotExist {
 		nsNotice(rb, client.t(err.Error()))


### PR DESCRIPTION
1. Fix the weird `hs status` message reported by bogdomania on #382. (Since `hs status` can be used by a logged-out, opered-up user, it doesn't have the usual `authRequired` flag; we have to manually check this case.)
1. If SASL is required, account unregistration should disconnect all clients logged into the account. (In part this is just the right behavior. It also avoids weird edge cases where a client could unregister their account, which is the only way to log out of an account, then register a new one that would be unknown to the administrator, creating a back door. This is now blocked because in SASL-only mode, all remote clients are always logged in, and logged-in clients can't register accounts. I need to think more about how this case interacts with the exemption for "local" clients, which may not literally be local.)