### PR TITLE
allow SAREGISTER even when normal registration is fully disabled

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -179,13 +179,13 @@ The following additional configs are recommended:
 
 This mode is comparable to Slack, Mattermost, or similar products intended as internal chat servers for an organization or team. In this mode, clients cannot connect to the server unless they log in with SASL as part of the initial handshake. This allows Oragono to be deployed facing the public Internet, with fine-grained control over who can log in.
 
-In this mode, clients must have a valid account to connect, so they cannot register their own accounts. Accordingly, an operator must do the initial account creation, using the `SAREGISTER` command of NickServ. (For more details, `/msg nickserv help saregister`.) To bootstrap this process, the SASL requirement can be disabled initially so that a first account can be created. Alternately, connections from localhost are exempt (by default) from the SASL requirement. You can also exempt your internal network, e.g., `10.0.0.0/8`.
+In this mode, clients must have a valid account to connect, so they cannot register their own accounts. Accordingly, an operator must do the initial account creation, using the `SAREGISTER` command of NickServ. (For more details, `/msg nickserv help saregister`.) To bootstrap this process, you can make an initial connection from localhost, which is exempt (by default) from the requirement, or temporarily add your own IP to the exemption list. You can also use a more permissive configuration for bootstrapping, then switch to this one once you have your account. Another possibility is permanently exempting an internal network, e.g., `10.0.0.0/8`, that only trusted people can access.
 
 To enable this mode, set the following configs:
 
-* `accounts.registration.enabled = false` (`true` during remote bootstrapping)
+* `accounts.registration.enabled = false`
 * `accounts.authentication-enabled = true`
-* `accounts.require-sasl.enabled = true` (`false` during remote bootstrapping)
+* `accounts.require-sasl.enabled = true`
 * `accounts.nick-reservation.enabled = true`
 
 Additionally, the following config is recommended:

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -183,9 +183,9 @@ In this mode, clients must have a valid account to connect, so they cannot regis
 
 To enable this mode, set the following configs:
 
-* `accounts.registration.enabled = false`
+* `accounts.registration.enabled = false` (`true` during remote bootstrapping)
 * `accounts.authentication-enabled = true`
-* `accounts.require-sasl.enabled = true`
+* `accounts.require-sasl.enabled = true` (`false` during remote bootstrapping)
 * `accounts.nick-reservation.enabled = true`
 
 Additionally, the following config is recommended:

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -179,11 +179,11 @@ The following additional configs are recommended:
 
 This mode is comparable to Slack, Mattermost, or similar products intended as internal chat servers for an organization or team. In this mode, clients cannot connect to the server unless they log in with SASL as part of the initial handshake. This allows Oragono to be deployed facing the public Internet, with fine-grained control over who can log in.
 
-In this mode, clients must have a valid account to connect, so they cannot register their own accounts. Accordingly, an operator must do the initial account creation, using the `SAREGISTER` command of NickServ. (For more details, `/msg nickserv help saregister`.) To bootstrap this process, the SASL requirement can be disabled initially so that a first account can be created. Alternately, connections from localhost are exempt (by default) from the SASL requirement.
+In this mode, clients must have a valid account to connect, so they cannot register their own accounts. Accordingly, an operator must do the initial account creation, using the `SAREGISTER` command of NickServ. (For more details, `/msg nickserv help saregister`.) To bootstrap this process, the SASL requirement can be disabled initially so that a first account can be created. Alternately, connections from localhost are exempt (by default) from the SASL requirement. You can also exempt your internal network, e.g., `10.0.0.0/8`.
 
 To enable this mode, set the following configs:
 
-* `accounts.registration.enabled = true`
+* `accounts.registration.enabled = false`
 * `accounts.authentication-enabled = true`
 * `accounts.require-sasl.enabled = true`
 * `accounts.nick-reservation.enabled = true`

--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -307,6 +307,12 @@ func (am *AccountManager) Register(client *Client, account string, callbackNames
 	}
 
 	config := am.server.AccountConfig()
+
+	// final "is registration allowed" check, probably redundant:
+	if !(config.Registration.Enabled || callbackNamespace == "admin") {
+		return errFeatureDisabled
+	}
+
 	// if nick reservation is enabled, you can only register your current nickname
 	// as an account; this prevents "land-grab" situations where someone else
 	// registers your nick out from under you and then NS GHOSTs you

--- a/irc/errors.go
+++ b/irc/errors.go
@@ -41,7 +41,7 @@ var (
 	errSaslFail                       = errors.New("SASL failed")
 	errResumeTokenAlreadySet          = errors.New("Client was already assigned a resume token")
 	errInvalidUsername                = errors.New("Invalid username")
-	errFeatureDisabled                = errors.New("That feature is disabled")
+	errFeatureDisabled                = errors.New(`That feature is disabled`)
 	errInvalidParams                  = errors.New("Invalid parameters")
 )
 

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -183,7 +183,7 @@ func registrationErrorToMessageAndCode(err error) (message, numeric string) {
 	case errAccountAlreadyRegistered, errAccountAlreadyVerified:
 		message = err.Error()
 		numeric = ERR_ACCOUNT_ALREADY_EXISTS
-	case errAccountCreation, errAccountMustHoldNick, errAccountBadPassphrase, errCertfpAlreadyExists:
+	case errAccountCreation, errAccountMustHoldNick, errAccountBadPassphrase, errCertfpAlreadyExists, errFeatureDisabled:
 		message = err.Error()
 	}
 	return

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -18,12 +18,12 @@ func servCmdRequiresAuthEnabled(config *Config) bool {
 	return config.Accounts.AuthenticationEnabled
 }
 
-func nsGroupEnabled(config *Config) bool {
+func servCmdRequiresNickRes(config *Config) bool {
 	return config.Accounts.AuthenticationEnabled && config.Accounts.NickReservation.Enabled
 }
 
 func nsEnforceEnabled(config *Config) bool {
-	return config.Accounts.NickReservation.Enabled && config.Accounts.NickReservation.AllowCustomEnforcement
+	return servCmdRequiresNickRes(config) && config.Accounts.NickReservation.AllowCustomEnforcement
 }
 
 const nickservHelp = `NickServ lets you register and login to an account.
@@ -42,7 +42,7 @@ var (
 
 DROP de-links the given (or your current) nickname from your user account.`,
 			helpShort:    `$bDROP$b de-links your current (or the given) nickname from your user account.`,
-			enabled:      servCmdRequiresAccreg,
+			enabled:      servCmdRequiresNickRes,
 			authRequired: true,
 		},
 		"enforce": {
@@ -78,7 +78,7 @@ same user account, letting you reclaim your nickname.`,
 GROUP links your current nickname with your logged-in account, preventing other
 users from changing to it (or forcing them to rename).`,
 			helpShort:    `$bGROUP$b links your current nickname to your user account.`,
-			enabled:      nsGroupEnabled,
+			enabled:      servCmdRequiresNickRes,
 			authRequired: true,
 		},
 		"identify": {
@@ -119,7 +119,7 @@ certificate (and you will need to use that certificate to login in future).`,
 SADROP forcibly de-links the given nickname from the attached user account.`,
 			helpShort: `$bSADROP$b forcibly de-links the given nickname from its user account.`,
 			capabs:    []string{"accreg"},
-			enabled:   servCmdRequiresAccreg,
+			enabled:   servCmdRequiresNickRes,
 			minParams: 1,
 		},
 		"saregister": {
@@ -130,7 +130,7 @@ SAREGISTER registers an account on someone else's behalf.
 This is for use in configurations that require SASL for all connections;
 an administrator can set use this command to set up user accounts.`,
 			helpShort: `$bSAREGISTER$b registers an account on someone else's behalf.`,
-			enabled:   servCmdRequiresAccreg,
+			enabled:   servCmdRequiresAuthEnabled,
 			capabs:    []string{"accreg"},
 			minParams: 2,
 		},
@@ -143,7 +143,7 @@ IRC operator with the correct permissions). To prevent accidental
 unregistrations, a verification code is required; invoking the command without
 a code will display the necessary code.`,
 			helpShort: `$bUNREGISTER$b lets you delete your user account.`,
-			enabled:   servCmdRequiresAccreg,
+			enabled:   servCmdRequiresAuthEnabled,
 			minParams: 1,
 		},
 		"verify": {


### PR DESCRIPTION
This is a follow-up to #385. Basically, you can now set `accounts.registration.enabled = false` and still register accounts with `SAREGISTER`; this is in keeping with the documentation of the config key as "can users register new accounts?" (If the sudoer / config file owner wants to stop operators from using SAREGISTER, it suffices to take away the `accreg` capability from their oper blocks.)

This allows people to use the ircd from an exempted network, while forbidding them to register their own accounts. The manual is updated to describe this case.