### PR TITLE
fix #389

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -1157,7 +1157,7 @@ func (am *AccountManager) applyVHostInfo(client *Client, info VHostInfo) {
 	updated := client.SetVHost(vhost)
 	if updated {
 		// TODO: doing I/O here is kind of a kludge
-		go client.sendChghost(oldNickmask, vhost)
+		go client.sendChghost(oldNickmask, client.Hostname())
 	}
 }
 

--- a/irc/client.go
+++ b/irc/client.go
@@ -749,13 +749,6 @@ func (client *Client) updateNick(nick, nickCasefolded, skeleton string) {
 	client.updateNickMaskNoMutex()
 }
 
-// updateNickMask updates the nickmask.
-func (client *Client) updateNickMask() {
-	client.stateMutex.Lock()
-	defer client.stateMutex.Unlock()
-	client.updateNickMaskNoMutex()
-}
-
 // updateNickMaskNoMutex updates the casefolded nickname and nickmask, not acquiring any mutexes.
 func (client *Client) updateNickMaskNoMutex() {
 	client.hostname = client.getVHostNoMutex()


### PR DESCRIPTION
@csmith want to review this?

Context: `Hostname()` returns the effective hostname, whether that's a hostserv vhost, an oper vhost, or a raw hostname.

https://github.com/oragono/oragono/blob/355491d4e1abb29bde3551c1a147f079e253faca/irc/client.go#L761