### PR TITLE
Band-aid NS REGISTER fix

### DIFF
--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -363,6 +363,13 @@ func nsRegisterHandler(server *Server, client *Client, command string, params []
 		return
 	}
 
+	// band-aid to let users know if they mix up the order of registration params
+	if email == "*" {
+		nsNotice(rb, client.t("Registering your account with no email address"))
+	} else {
+		nsNotice(rb, fmt.Sprintf(client.t("Registering your account with email address %s"), email))
+	}
+
 	config := server.AccountConfig()
 	var callbackNamespace, callbackValue string
 	noneCallbackAllowed := false


### PR DESCRIPTION
Addresses #410 in a temporary way. Honestly, this has told me that I'm not at all happy with the current NS REGISTER command, so for v1.1.0 I reeeally want to overhaul it entirely and replace it with something more standard.