### PR TITLE
Use /bin/sh rather than /bin/bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
This makes it much easier to run on alpine which ships with
only a /bin/sh by default.