### PR TITLE
remove indirections in Fakelag and NickTimer

### DIFF
--- a/irc/fakelag_test.go
+++ b/irc/fakelag_test.go
@@ -40,13 +40,20 @@ func (mt *mockTime) lastSleep() (slept bool, duration time.Duration) {
 }
 
 func newFakelagForTesting(window time.Duration, burstLimit uint, throttleMessagesPerWindow uint, cooldown time.Duration) (*Fakelag, *mockTime) {
-	fl := NewFakelag(window, burstLimit, throttleMessagesPerWindow, cooldown)
+	fl := Fakelag{}
+	fl.config = FakelagConfig{
+		Enabled:           true,
+		Window:            window,
+		BurstLimit:        burstLimit,
+		MessagesPerWindow: throttleMessagesPerWindow,
+		Cooldown:          cooldown,
+	}
 	mt := new(mockTime)
 	mt.now, _ = time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Mon Jan 2 15:04:05 -0700 MST 2006")
 	mt.lastCheckedSleep = -1
 	fl.nowFunc = mt.Now
 	fl.sleepFunc = mt.Sleep
-	return fl, mt
+	return &fl, mt
 }
 
 func TestFakelag(t *testing.T) {

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -46,10 +46,6 @@ func (server *Server) AccountConfig() *AccountConfig {
 	return &server.Config().Accounts
 }
 
-func (server *Server) FakelagConfig() *FakelagConfig {
-	return &server.Config().Fakelag
-}
-
 func (server *Server) GetOperator(name string) (oper *Oper) {
 	name, err := CasefoldName(name)
 	if err != nil {

--- a/irc/server.go
+++ b/irc/server.go
@@ -826,6 +826,13 @@ func (server *Server) applyConfig(config *Config, initial bool) (err error) {
 			if sendRawOutputNotice {
 				sClient.Notice(sClient.t("This server is in debug mode and is logging all user I/O. If you do not wish for everything you send to be readable by the server owner(s), please disconnect."))
 			}
+
+			if !oldConfig.Accounts.NickReservation.Enabled && config.Accounts.NickReservation.Enabled {
+				sClient.nickTimer.Initialize(sClient)
+				sClient.nickTimer.Touch()
+			} else if oldConfig.Accounts.NickReservation.Enabled && !config.Accounts.NickReservation.Enabled {
+				sClient.nickTimer.Stop()
+			}
 		}
 	}
 


### PR DESCRIPTION
This is a somewhat pointless refactor (I'm not even sure it's worth the time required to review it). The goal was to put Fakelag and NickTimer directly inside the Client object (rather than storing pointers). While I was in the neighborhood, I made NickTimer more rehashable (it now behaves as one would expect if nick reservation is enabled or disabled by rehash).