### PR TITLE
refactor channel registration

### DIFF
--- a/irc/caps/set.go
+++ b/irc/caps/set.go
@@ -16,7 +16,6 @@ type Set [bitsetLen]uint64
 // NewSet returns a new Set, with the given capabilities enabled.
 func NewSet(capabs ...Capability) *Set {
 	var newSet Set
-	utils.BitsetInitialize(newSet[:])
 	newSet.Enable(capabs...)
 	return &newSet
 }

--- a/irc/channelmanager.go
+++ b/irc/channelmanager.go
@@ -229,6 +229,10 @@ func (cm *ChannelManager) Rename(name string, newname string) (err error) {
 	info = channel.ExportRegistration(IncludeInitial)
 	delete(cm.chans, cfname)
 	cm.chans[cfnewname] = entry
+	if cm.registeredChannels[cfname] {
+		delete(cm.registeredChannels, cfname)
+		cm.registeredChannels[cfnewname] = true
+	}
 	entry.channel.Rename(newname, cfnewname)
 	return nil
 }

--- a/irc/channelmanager.go
+++ b/irc/channelmanager.go
@@ -218,7 +218,7 @@ func (cm *ChannelManager) Rename(name string, newname string) (err error) {
 	cm.Lock()
 	defer cm.Unlock()
 
-	if cm.chans[cfnewname] != nil {
+	if cm.chans[cfnewname] != nil || cm.registeredChannels[cfnewname] {
 		return errChannelNameInUse
 	}
 	entry := cm.chans[cfname]

--- a/irc/channelmanager.go
+++ b/irc/channelmanager.go
@@ -19,25 +19,38 @@ type channelManagerEntry struct {
 // providing synchronization for creation of new channels on first join,
 // cleanup of empty channels on last part, and renames.
 type ChannelManager struct {
-	sync.RWMutex // tier 2
-	chans        map[string]*channelManagerEntry
+	sync.RWMutex       // tier 2
+	chans              map[string]*channelManagerEntry
+	registeredChannels map[string]bool
+	server             *Server
 }
 
 // NewChannelManager returns a new ChannelManager.
-func NewChannelManager() *ChannelManager {
-	return &ChannelManager{
-		chans: make(map[string]*channelManagerEntry),
+func (cm *ChannelManager) Initialize(server *Server) {
+	cm.chans = make(map[string]*channelManagerEntry)
+	cm.server = server
+
+	if server.Config().Channels.Registration.Enabled {
+		cm.loadRegisteredChannels()
 	}
 }
 
+func (cm *ChannelManager) loadRegisteredChannels() {
+	registeredChannels := cm.server.channelRegistry.AllChannels()
+	cm.Lock()
+	defer cm.Unlock()
+	cm.registeredChannels = registeredChannels
+}
+
 // Get returns an existing channel with name equivalent to `name`, or nil
-func (cm *ChannelManager) Get(name string) *Channel {
+func (cm *ChannelManager) Get(name string) (channel *Channel) {
 	name, err := CasefoldChannel(name)
 	if err == nil {
 		cm.RLock()
 		defer cm.RUnlock()
 		entry := cm.chans[name]
-		if entry != nil {
+		// if the channel is still loading, pretend we don't have it
+		if entry != nil && entry.channel.IsLoaded() {
 			return entry.channel
 		}
 	}
@@ -55,28 +68,21 @@ func (cm *ChannelManager) Join(client *Client, name string, key string, isSajoin
 	cm.Lock()
 	entry := cm.chans[casefoldedName]
 	if entry == nil {
-		// XXX give up the lock to check for a registration, then check again
-		// to see if we need to create the channel. we could solve this by doing LoadChannel
-		// outside the lock initially on every join, so this is best thought of as an
-		// optimization to avoid that.
-		cm.Unlock()
-		info := client.server.channelRegistry.LoadChannel(casefoldedName)
-		cm.Lock()
-		entry = cm.chans[casefoldedName]
-		if entry == nil {
-			entry = &channelManagerEntry{
-				channel:      NewChannel(server, name, info),
-				pendingJoins: 0,
-			}
-			cm.chans[casefoldedName] = entry
+		registered := cm.registeredChannels[casefoldedName]
+		entry = &channelManagerEntry{
+			channel:      NewChannel(server, name, registered),
+			pendingJoins: 0,
 		}
+		cm.chans[casefoldedName] = entry
 	}
 	entry.pendingJoins += 1
+	channel := entry.channel
 	cm.Unlock()
 
-	entry.channel.Join(client, key, isSajoin, rb)
+	channel.EnsureLoaded()
+	channel.Join(client, key, isSajoin, rb)
 
-	cm.maybeCleanup(entry.channel, true)
+	cm.maybeCleanup(channel, true)
 
 	return nil
 }
@@ -85,7 +91,8 @@ func (cm *ChannelManager) maybeCleanup(channel *Channel, afterJoin bool) {
 	cm.Lock()
 	defer cm.Unlock()
 
-	entry := cm.chans[channel.NameCasefolded()]
+	nameCasefolded := channel.NameCasefolded()
+	entry := cm.chans[nameCasefolded]
 	if entry == nil || entry.channel != channel {
 		return
 	}
@@ -93,23 +100,15 @@ func (cm *ChannelManager) maybeCleanup(channel *Channel, afterJoin bool) {
 	if afterJoin {
 		entry.pendingJoins -= 1
 	}
-	// TODO(slingamn) right now, registered channels cannot be cleaned up.
-	// this is because once ChannelManager becomes the source of truth about a channel,
-	// we can't move the source of truth back to the database unless we do an ACID
-	// store while holding the ChannelManager's Lock(). This is pending more decisions
-	// about where the database transaction lock fits into the overall lock model.
-	if !entry.channel.IsRegistered() && entry.channel.IsEmpty() && entry.pendingJoins == 0 {
-		// reread the name, handling the case where the channel was renamed
-		casefoldedName := entry.channel.NameCasefolded()
-		delete(cm.chans, casefoldedName)
-		// invalidate the entry (otherwise, a subsequent cleanup attempt could delete
-		// a valid, distinct entry under casefoldedName):
-		entry.channel = nil
+	if entry.pendingJoins == 0 && entry.channel.IsClean() {
+		delete(cm.chans, nameCasefolded)
 	}
 }
 
 // Part parts `client` from the channel named `name`, deleting it if it's empty.
 func (cm *ChannelManager) Part(client *Client, name string, message string, rb *ResponseBuffer) error {
+	var channel *Channel
+
 	casefoldedName, err := CasefoldChannel(name)
 	if err != nil {
 		return errNoSuchChannel
@@ -117,12 +116,15 @@ func (cm *ChannelManager) Part(client *Client, name string, message string, rb *
 
 	cm.RLock()
 	entry := cm.chans[casefoldedName]
+	if entry != nil {
+		channel = entry.channel
+	}
 	cm.RUnlock()
 
-	if entry == nil {
+	if channel == nil {
 		return errNoSuchChannel
 	}
-	entry.channel.Part(client, message, rb)
+	channel.Part(client, message, rb)
 	return nil
 }
 
@@ -130,8 +132,68 @@ func (cm *ChannelManager) Cleanup(channel *Channel) {
 	cm.maybeCleanup(channel, false)
 }
 
+func (cm *ChannelManager) SetRegistered(channelName string, account string) (err error) {
+	var channel *Channel
+	cfname, err := CasefoldChannel(channelName)
+	if err != nil {
+		return err
+	}
+
+	var entry *channelManagerEntry
+
+	defer func() {
+		if err == nil && channel != nil {
+			// registration was successful: make the database reflect it
+			err = channel.Store(IncludeAllChannelAttrs)
+		}
+	}()
+
+	cm.Lock()
+	defer cm.Unlock()
+	entry = cm.chans[cfname]
+	if entry == nil {
+		return errNoSuchChannel
+	}
+	channel = entry.channel
+	err = channel.SetRegistered(account)
+	if err != nil {
+		return err
+	}
+	cm.registeredChannels[cfname] = true
+	return nil
+}
+
+func (cm *ChannelManager) SetUnregistered(channelName string, account string) (err error) {
+	cfname, err := CasefoldChannel(channelName)
+	if err != nil {
+		return err
+	}
+
+	var info RegisteredChannel
+
+	defer func() {
+		if err == nil {
+			err = cm.server.channelRegistry.Delete(info)
+		}
+	}()
+
+	cm.Lock()
+	defer cm.Unlock()
+	entry := cm.chans[cfname]
+	if entry == nil {
+		return errNoSuchChannel
+	}
+	info = entry.channel.ExportRegistration(0)
+	if info.Founder != account {
+		return errChannelNotOwnedByAccount
+	}
+	entry.channel.SetUnregistered(account)
+	delete(cm.registeredChannels, cfname)
+	return nil
+}
+
 // Rename renames a channel (but does not notify the members)
-func (cm *ChannelManager) Rename(name string, newname string) error {
+func (cm *ChannelManager) Rename(name string, newname string) (err error) {
 	cfname, err := CasefoldChannel(name)
 	if err != nil {
 		return errNoSuchChannel
@@ -141,6 +203,17 @@ func (cm *ChannelManager) Rename(name string, newname string) error {
 	if err != nil {
 		return errInvalidChannelName
 	}
+
+	var channel *Channel
+	var info RegisteredChannel
+	defer func() {
+		if channel != nil && info.Founder != "" {
+			channel.Store(IncludeAllChannelAttrs)
+			// we just flushed the channel under its new name, therefore this delete
+			// cannot be overwritten by a write to the old name:
+			cm.server.channelRegistry.Delete(info)
+		}
+	}()
 
 	cm.Lock()
 	defer cm.Unlock()
@@ -152,12 +225,12 @@ func (cm *ChannelManager) Rename(name string, newname string) error {
 	if entry == nil {
 		return errNoSuchChannel
 	}
+	channel = entry.channel
+	info = channel.ExportRegistration(IncludeInitial)
 	delete(cm.chans, cfname)
 	cm.chans[cfnewname] = entry
-	entry.channel.setName(newname)
-	entry.channel.setNameCasefolded(cfnewname)
+	entry.channel.Rename(newname, cfnewname)
 	return nil
-
 }
 
 // Len returns the number of channels
@@ -171,8 +244,11 @@ func (cm *ChannelManager) Len() int {
 func (cm *ChannelManager) Channels() (result []*Channel) {
 	cm.RLock()
 	defer cm.RUnlock()
+	result = make([]*Channel, 0, len(cm.chans))
 	for _, entry := range cm.chans {
-		result = append(result, entry.channel)
+		if entry.channel.IsLoaded() {
+			result = append(result, entry.channel)
+		}
 	}
 	return
 }

--- a/irc/chanserv.go
+++ b/irc/chanserv.go
@@ -232,14 +232,11 @@ func csRegisterHandler(server *Server, client *Client, command string, params []
 	}
 
 	// this provides the synchronization that allows exactly one registration of the channel:
-	err = channelInfo.SetRegistered(account)
+	err = server.channels.SetRegistered(channelKey, account)
 	if err != nil {
 		csNotice(rb, err.Error())
 		return
 	}
-
-	// registration was successful: make the database reflect it
-	go server.channelRegistry.StoreChannel(channelInfo, IncludeAllChannelAttrs)
 
 	csNotice(rb, fmt.Sprintf(client.t("Channel %s successfully registered"), channelName))
 
@@ -297,8 +294,7 @@ func csUnregisterHandler(server *Server, client *Client, command string, params 
 		return
 	}
 
-	channel.SetUnregistered(founder)
-	server.channelRegistry.Delete(channelKey, info)
+	server.channels.SetUnregistered(channelKey, founder)
 	csNotice(rb, fmt.Sprintf(client.t("Channel %s is now unregistered"), channelKey))
 }
 

--- a/irc/client.go
+++ b/irc/client.go
@@ -50,7 +50,7 @@ type Client struct {
 	accountName        string // display name of the account: uncasefolded, '*' if not logged in
 	atime              time.Time
 	awayMessage        string
-	capabilities       *caps.Set
+	capabilities       caps.Set
 	capState           caps.State
 	capVersion         caps.Version
 	certfp             string
@@ -58,7 +58,7 @@ type Client struct {
 	ctime              time.Time
 	exitedSnomaskSent  bool
 	fakelag            Fakelag
-	flags              *modes.ModeSet
+	flags              modes.ModeSet
 	hasQuit            bool
 	hops               int
 	hostname           string
@@ -125,15 +125,13 @@ func RunNewClient(server *Server, conn clientConn) {
 	// give them 1k of grace over the limit:
 	socket := NewSocket(conn.Conn, fullLineLenLimit+1024, config.Server.MaxSendQBytes)
 	client := &Client{
-		atime:        now,
-		capabilities: caps.NewSet(),
-		capState:     caps.NoneState,
-		capVersion:   caps.Cap301,
-		channels:     make(ChannelSet),
-		ctime:        now,
-		flags:        modes.NewModeSet(),
-		isTor:        conn.IsTor,
-		languages:    server.Languages().Default(),
+		atime:      now,
+		capState:   caps.NoneState,
+		capVersion: caps.Cap301,
+		channels:   make(ChannelSet),
+		ctime:      now,
+		isTor:      conn.IsTor,
+		languages:  server.Languages().Default(),
 		loginThrottle: connection_limits.GenericThrottle{
 			Duration: config.Accounts.LoginThrottling.Duration,
 			Limit:    config.Accounts.LoginThrottling.MaxAttempts,
@@ -546,7 +544,6 @@ func (client *Client) replayPrivmsgHistory(rb *ResponseBuffer, items []history.I
 // copy applicable state from oldClient to client as part of a resume
 func (client *Client) copyResumeData(oldClient *Client) {
 	oldClient.stateMutex.RLock()
-	flags := oldClient.flags
 	history := oldClient.history
 	nick := oldClient.nick
 	nickCasefolded := oldClient.nickCasefolded
@@ -560,7 +557,7 @@ func (client *Client) copyResumeData(oldClient *Client) {
 	// resume over plaintext)
 	hasTLS := client.flags.HasMode(modes.TLS)
 	temp := modes.NewModeSet()
-	temp.Copy(flags)
+	temp.Copy(&oldClient.flags)
 	temp.SetMode(modes.TLS, hasTLS)
 	client.flags.Copy(temp)
 

--- a/irc/client_lookup_set.go
+++ b/irc/client_lookup_set.go
@@ -37,12 +37,10 @@ type ClientManager struct {
 	bySkeleton   map[string]*Client
 }
 
-// NewClientManager returns a new ClientManager.
-func NewClientManager() *ClientManager {
-	return &ClientManager{
-		byNick:     make(map[string]*Client),
-		bySkeleton: make(map[string]*Client),
-	}
+// Initialize initializes a ClientManager.
+func (clients *ClientManager) Initialize() {
+	clients.byNick = make(map[string]*Client)
+	clients.bySkeleton = make(map[string]*Client)
 }
 
 // Count returns how many clients are in the manager.

--- a/irc/errors.go
+++ b/irc/errors.go
@@ -27,6 +27,8 @@ var (
 	errAccountMustHoldNick            = errors.New(`You must hold that nickname in order to register it`)
 	errCallbackFailed                 = errors.New("Account verification could not be sent")
 	errCertfpAlreadyExists            = errors.New(`An account already exists for your certificate fingerprint`)
+	errChannelNotOwnedByAccount       = errors.New("Channel not owned by the specified account")
+	errChannelDoesNotExist            = errors.New("Channel does not exist")
 	errChannelAlreadyRegistered       = errors.New("Channel is already registered")
 	errChannelNameInUse               = errors.New(`Channel name in use`)
 	errInvalidChannelName             = errors.New(`Invalid channel name`)

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -4,6 +4,8 @@
 package irc
 
 import (
+	"time"
+
 	"github.com/oragono/oragono/irc/isupport"
 	"github.com/oragono/oragono/irc/languages"
 	"github.com/oragono/oragono/irc/modes"
@@ -267,22 +269,20 @@ func (channel *Channel) Name() string {
 	return channel.name
 }
 
-func (channel *Channel) setName(name string) {
-	channel.stateMutex.Lock()
-	defer channel.stateMutex.Unlock()
-	channel.name = name
-}
-
 func (channel *Channel) NameCasefolded() string {
 	channel.stateMutex.RLock()
 	defer channel.stateMutex.RUnlock()
 	return channel.nameCasefolded
 }
 
-func (channel *Channel) setNameCasefolded(nameCasefolded string) {
+func (channel *Channel) Rename(name, nameCasefolded string) {
 	channel.stateMutex.Lock()
-	defer channel.stateMutex.Unlock()
+	channel.name = name
 	channel.nameCasefolded = nameCasefolded
+	if channel.registeredFounder != "" {
+		channel.registeredTime = time.Now()
+	}
+	channel.stateMutex.Unlock()
 }
 
 func (channel *Channel) Members() (result []*Client) {
@@ -313,4 +313,11 @@ func (channel *Channel) Founder() string {
 	channel.stateMutex.RLock()
 	defer channel.stateMutex.RUnlock()
 	return channel.registeredFounder
+}
+
+func (channel *Channel) DirtyBits() (dirtyBits uint) {
+	channel.stateMutex.Lock()
+	dirtyBits = channel.dirtyBits
+	channel.stateMutex.Unlock()
+	return
 }

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1607,8 +1607,8 @@ func cmodeHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Res
 		}
 	}
 
-	if channel.IsRegistered() && includeFlags != 0 {
-		go server.channelRegistry.StoreChannel(channel, includeFlags)
+	if includeFlags != 0 {
+		channel.MarkDirty(includeFlags)
 	}
 
 	// send out changes
@@ -2215,7 +2215,6 @@ func renameHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Re
 		rb.Add(nil, server.name, ERR_NOSUCHCHANNEL, client.Nick(), oldName, client.t("No such channel"))
 		return false
 	}
-	casefoldedOldName := channel.NameCasefolded()
 	if !(channel.ClientIsAtLeast(client, modes.Operator) || client.HasRoleCapabs("chanreg")) {
 		rb.Add(nil, server.name, ERR_CHANOPRIVSNEEDED, client.Nick(), oldName, client.t("You're not a channel operator"))
 		return false
@@ -2239,9 +2238,6 @@ func renameHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Re
 	if err != nil {
 		return false
 	}
-
-	// rename succeeded, persist it
-	go server.channelRegistry.Rename(channel, casefoldedOldName)
 
 	// send RENAME messages
 	clientPrefix := client.NickMaskString()

--- a/irc/modes.go
+++ b/irc/modes.go
@@ -290,14 +290,14 @@ func (channel *Channel) ProcessAccountToUmodeChange(client *Client, change modes
 	case modes.Add:
 		if targetModeNow != targetModeAfter {
 			channel.accountToUMode[change.Arg] = change.Mode
-			go client.server.channelRegistry.StoreChannel(channel, IncludeLists)
+			channel.MarkDirty(IncludeLists)
 			return []modes.ModeChange{change}, nil
 		}
 		return nil, nil
 	case modes.Remove:
 		if targetModeNow == change.Mode {
 			delete(channel.accountToUMode, change.Arg)
-			go client.server.channelRegistry.StoreChannel(channel, IncludeLists)
+			channel.MarkDirty(IncludeLists)
 			return []modes.ModeChange{change}, nil
 		}
 		return nil, nil

--- a/irc/modes/modes.go
+++ b/irc/modes/modes.go
@@ -335,7 +335,6 @@ const (
 // returns a pointer to a new ModeSet
 func NewModeSet() *ModeSet {
 	var set ModeSet
-	utils.BitsetInitialize(set[:])
 	return &set
 }
 

--- a/irc/semaphores.go
+++ b/irc/semaphores.go
@@ -32,14 +32,13 @@ type ServerSemaphores struct {
 	ClientDestroy Semaphore
 }
 
-// NewServerSemaphores creates a new ServerSemaphores.
-func NewServerSemaphores() (result *ServerSemaphores) {
+// Initialize initializes a set of server semaphores.
+func (serversem *ServerSemaphores) Initialize() {
 	capacity := runtime.NumCPU()
 	if capacity > MaxServerSemaphoreCapacity {
 		capacity = MaxServerSemaphoreCapacity
 	}
-	result = new(ServerSemaphores)
-	result.ClientDestroy.Initialize(capacity)
+	serversem.ClientDestroy.Initialize(capacity)
 	return
 }
 

--- a/irc/stats.go
+++ b/irc/stats.go
@@ -13,17 +13,6 @@ type Stats struct {
 	Operators int
 }
 
-// NewStats creates a new instance of Stats
-func NewStats() *Stats {
-	serverStats := &Stats{
-		Total:     0,
-		Invisible: 0,
-		Operators: 0,
-	}
-
-	return serverStats
-}
-
 // ChangeTotal increments the total user count on server
 func (s *Stats) ChangeTotal(i int) {
 	s.Lock()

--- a/irc/utils/bitset.go
+++ b/irc/utils/bitset.go
@@ -9,17 +9,6 @@ import "sync/atomic"
 // For examples of use, see caps.Set and modes.ModeSet; the array has to be converted to a
 // slice to use these functions.
 
-// BitsetInitialize initializes a bitset.
-func BitsetInitialize(set []uint64) {
-	// XXX re-zero the bitset using atomic stores. it's unclear whether this is required,
-	// however, golang issue #5045 suggests that you shouldn't mix atomic operations
-	// with non-atomic operations (such as the runtime's automatic zero-initialization) on
-	// the same word
-	for i := 0; i < len(set); i++ {
-		atomic.StoreUint64(&set[i], 0)
-	}
-}
-
 // BitsetGet returns whether a given bit of the bitset is set.
 func BitsetGet(set []uint64, position uint) bool {
 	idx := position / 64

--- a/irc/utils/bitset_test.go
+++ b/irc/utils/bitset_test.go
@@ -10,7 +10,6 @@ type testBitset [2]uint64
 func TestSets(t *testing.T) {
 	var t1 testBitset
 	t1s := t1[:]
-	BitsetInitialize(t1s)
 
 	if BitsetGet(t1s, 0) || BitsetGet(t1s, 63) || BitsetGet(t1s, 64) || BitsetGet(t1s, 127) {
 		t.Error("no bits should be set in a newly initialized bitset")
@@ -47,7 +46,6 @@ func TestSets(t *testing.T) {
 
 	var t2 testBitset
 	t2s := t2[:]
-	BitsetInitialize(t2s)
 
 	for i = 0; i < 128; i++ {
 		if i%2 == 1 {

--- a/irc/utils/sync.go
+++ b/irc/utils/sync.go
@@ -1,0 +1,35 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package utils
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Once is a fork of sync.Once to expose a Done() method.
+type Once struct {
+	done uint32
+	m    sync.Mutex
+}
+
+func (o *Once) Do(f func()) {
+	if atomic.LoadUint32(&o.done) == 0 {
+		o.doSlow(f)
+	}
+}
+
+func (o *Once) doSlow(f func()) {
+	o.m.Lock()
+	defer o.m.Unlock()
+	if o.done == 0 {
+		defer atomic.StoreUint32(&o.done, 1)
+		f()
+	}
+}
+
+func (o *Once) Done() bool {
+	return atomic.LoadUint32(&o.done) == 1
+}

--- a/irc/whowas.go
+++ b/irc/whowas.go
@@ -23,12 +23,10 @@ type WhoWasList struct {
 }
 
 // NewWhoWasList returns a new WhoWasList
-func NewWhoWasList(size int) *WhoWasList {
-	return &WhoWasList{
-		buffer: make([]WhoWas, size),
-		start:  -1,
-		end:    -1,
-	}
+func (list *WhoWasList) Initialize(size int) {
+	list.buffer = make([]WhoWas, size)
+	list.start = -1
+	list.end = -1
 }
 
 // Append adds an entry to the WhoWasList.

--- a/irc/whowas_test.go
+++ b/irc/whowas_test.go
@@ -23,7 +23,8 @@ func makeTestWhowas(nick string) WhoWas {
 
 func TestWhoWas(t *testing.T) {
 	var results []WhoWas
-	wwl := NewWhoWasList(3)
+	var wwl WhoWasList
+	wwl.Initialize(3)
 	// test Find on empty list
 	results = wwl.Find("nobody", 10)
 	if len(results) != 0 {
@@ -88,7 +89,8 @@ func TestWhoWas(t *testing.T) {
 
 func TestEmptyWhoWas(t *testing.T) {
 	// stupid edge case; setting an empty whowas buffer should not panic
-	wwl := NewWhoWasList(0)
+	var wwl WhoWasList
+	wwl.Initialize(0)
 	results := wwl.Find("slingamn", 10)
 	if len(results) != 0 {
 		t.Fatalf("incorrect whowas results: %v", results)


### PR DESCRIPTION
This refactors a bunch of channel registration stuff, mostly to prepare for #357 when we expect the datastore to be remote and significantly higher in latency:

1. Operations should not block on the datastore unless they need to (so we shouldn't have to look in the datastore every time someone joins a new channel)
1. The datastore should not be accessed while holding any global locks
1. There shouldn't be a thundering-herd effect on channel joins (the server is restarted, everyone tries to rejoin the same channel, each join sees that the channel data isn't loaded yet and tries to load it)
1. Writes of channel data now use a system modeled after `irc/socket.go` as of #236; we maintain dirty bits for the channel, then each time the channel becomes dirty, we acquire a trylock and spin off a writeback goroutine.
1. Since we can query whether a writeback goroutine is active, we can now tell when the channel is "clean" (no members and all writes completed), so now we can delete empty registered channels (removing the strange edge case introduced in #161 where they would stick around indefinitely with no members)
1. Barring some subtleties with the account-to-registered-channels mapping (to be worked out later), this is a much simpler API for `ChannelRegistry` (load, store, and delete methods) that is a candidate for becoming an actual `interface` --- i.e., the current `ChannelRegistry` will become the buntdb-backed implementation of a channel registry, and we'll add another for a remote datastore.

Also, I asked golang-nuts and there's no need to explicitly zero-initialize memory for atomic access, so I deleted that code.