### PR TITLE
fix a deadlock in CS AMODE

### DIFF
--- a/irc/modes.go
+++ b/irc/modes.go
@@ -261,6 +261,13 @@ func (channel *Channel) ProcessAccountToUmodeChange(client *Client, change modes
 		return l == r || umodeGreaterThan(l, r)
 	}
 
+	changed := false
+	defer func() {
+		if changed {
+			channel.MarkDirty(IncludeLists)
+		}
+	}()
+
 	account := client.Account()
 	isOperChange := client.HasRoleCapabs("chanreg")
 
@@ -290,14 +297,14 @@ func (channel *Channel) ProcessAccountToUmodeChange(client *Client, change modes
 	case modes.Add:
 		if targetModeNow != targetModeAfter {
 			channel.accountToUMode[change.Arg] = change.Mode
-			channel.MarkDirty(IncludeLists)
+			changed = true
 			return []modes.ModeChange{change}, nil
 		}
 		return nil, nil
 	case modes.Remove:
 		if targetModeNow == change.Mode {
 			delete(channel.accountToUMode, change.Arg)
-			channel.MarkDirty(IncludeLists)
+			changed = true
 			return []modes.ModeChange{change}, nil
 		}
 		return nil, nil


### PR DESCRIPTION
I triggered this deadlock (introduced in #446) in production just now:

````
goroutine 135568 [semacquire, 4 minutes]:
sync.runtime_SemacquireMutex(0xc000083cf4, 0x857b00)
        /usr/local/go/src/runtime/sema.go:71 +0x3d
sync.(*Mutex).Lock(0xc000083cf0)
        /usr/local/go/src/sync/mutex.go:134 +0x109
sync.(*RWMutex).Lock(0xc000083cf0)
        /usr/local/go/src/sync/rwmutex.go:93 +0x2d
github.com/oragono/oragono/irc.(*Channel).MarkDirty(0xc000083ba0, 0x8)
        /home/oragono/go/src/github.com/oragono/oragono/irc/channel.go:183 +0x3d
github.com/oragono/oragono/irc.(*Channel).ProcessAccountToUmodeChange(0xc000083ba0, 0xc000043880, 0x2b00000068, 0xc0001b43b8, 0x6, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/oragono/go/src/github.com/oragono/oragono/irc/modes.go:293 +0x567
github.com/oragono/oragono/irc.csAmodeHandler(0xc0001938c0, 0xc000043880, 0xc00002bc02, 0x5, 0xc000358ad0, 0x3, 0x3, 0xc00033ea50)
        /home/oragono/go/src/github.com/oragono/oragono/irc/chanserv.go:136 +0x25d
github.com/oragono/oragono/irc.serviceRunCommand(0xc0000803c0, 0xc0001938c0, 0xc000043880, 0xc0000a7500, 0xc00002bc02, 0x5, 0xc000358ad0, 0x3, 0x3, 0xc00033ea50)
        /home/oragono/go/src/github.com/oragono/oragono/irc/services.go:174 +0x433
github.com/oragono/oragono/irc.servicePrivmsgHandler(0xc0000803c0, 0xc0001938c0, 0xc000043880, 0xc00002bc02, 0x17, 0xc00033ea50)
        /home/oragono/go/src/github.com/oragono/oragono/irc/services.go:135 +0x159
github.com/oragono/oragono/irc.messageHandler(0xc0001938c0, 0xc000043880, 0x0, 0x0, 0xc00002bbf0, 0x7, 0xc00000ef00, 0x2, 0x2, 0x0, ...)
        /home/oragono/go/src/github.com/oragono/oragono/irc/handlers.go:1933 +0x6c0
github.com/oragono/oragono/irc.(*Command).Run(0xc00050bdf0, 0xc0001938c0, 0xc000043880, 0x0, 0x0, 0xc00002bbf0, 0x7, 0xc00000ef00, 0x2, 0x2, ...)
        /home/oragono/go/src/github.com/oragono/oragono/irc/commands.go:48 +0x1fa
github.com/oragono/oragono/irc.(*Client).run(0xc000043880)
        /home/oragono/go/src/github.com/oragono/oragono/irc/client.go:343 +0x886
github.com/oragono/oragono/irc.RunNewClient(0xc0001938c0, 0xa95480, 0xc0000100e8, 0x0)
        /home/oragono/go/src/github.com/oragono/oragono/irc/client.go:171 +0x41e
created by github.com/oragono/oragono/irc.(*Server).acceptClient
        /home/oragono/go/src/github.com/oragono/oragono/irc/server.go:265 +0x2e2
````

This is a pretty shallow deterministic issue. Processing a `CS AMODE` command acquires the read-write lock on the channel:

https://github.com/oragono/oragono/blob/8c7027c604ad7443af005dfd7ebbe5a5e5c1a7e7/irc/modes.go#L267

but then a subsequent call to `Channel.MarkDirty` attempts to acquire the same lock again:

https://github.com/oragono/oragono/blob/8c7027c604ad7443af005dfd7ebbe5a5e5c1a7e7/irc/channel.go#L183

Anyway, no big deal except that I really need to write integration tests for the channel registration stuff.