### PR TITLE
minimum viable product for bouncer

### DIFF
--- a/gencapdefs.py
+++ b/gencapdefs.py
@@ -147,6 +147,18 @@ CAPDEFS = [
         url="https://ircv3.net/specs/extensions/userhost-in-names-3.2.html",
         standard="IRCv3",
     ),
+    CapDef(
+        identifier="Bouncer",
+        name="oragono.io/bnc",
+        url="https://oragono.io/bnc",
+        standard="Oragono-specific",
+    ),
+    CapDef(
+        identifier="ZNCSelfMessage",
+        name="znc.in/self-message",
+        url="https://wiki.znc.in/Query_buffers",
+        standard="ZNC vendor",
+    ),
 ]
 
 def validate_defs():

--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -1227,7 +1227,7 @@ func (am *AccountManager) Login(client *Client, account ClientAccount) {
 		return
 	}
 
-	client.nickTimer.Touch()
+	client.nickTimer.Touch(nil)
 
 	am.applyVHostInfo(client, account.VHost)
 
@@ -1313,7 +1313,7 @@ func (am *AccountManager) logoutOfAccount(client *Client) {
 	}
 
 	client.SetAccountName("")
-	go client.nickTimer.Touch()
+	go client.nickTimer.Touch(nil)
 
 	// dispatch account-notify
 	// TODO: doing the I/O here is kind of a kludge, let's move this somewhere else

--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -221,8 +221,6 @@ func (am *AccountManager) EnforcementStatus(cfnick, skeleton string) (account st
 		nickMethod := finalEnforcementMethod(nickAccount)
 		skelMethod := finalEnforcementMethod(skelAccount)
 		switch {
-		case nickMethod == NickReservationNone && skelMethod == NickReservationNone:
-			return nickAccount, NickReservationNone
 		case skelMethod == NickReservationNone:
 			return nickAccount, nickMethod
 		case nickMethod == NickReservationNone:
@@ -232,6 +230,15 @@ func (am *AccountManager) EnforcementStatus(cfnick, skeleton string) (account st
 			return "!", NickReservationStrict
 		}
 	}
+}
+
+func (am *AccountManager) BouncerAllowed(account string, session *Session) bool {
+	// TODO stub
+	config := am.server.Config()
+	if !config.Accounts.Bouncer.Enabled {
+		return false
+	}
+	return config.Accounts.Bouncer.AllowedByDefault || session.capabilities.Has(caps.Bouncer)
 }
 
 // Looks up the enforcement method stored in the database for an account
@@ -928,9 +935,9 @@ func (am *AccountManager) Unregister(account string) error {
 	}
 	for _, client := range clients {
 		if config.Accounts.RequireSasl.Enabled {
-			client.Quit(client.t("You are no longer authorized to be on this server"))
+			client.Quit(client.t("You are no longer authorized to be on this server"), nil)
 			// destroy acquires a semaphore so we can't call it while holding a lock
-			go client.destroy(false)
+			go client.destroy(false, nil)
 		} else {
 			am.logoutOfAccount(client)
 		}

--- a/irc/caps/defs.go
+++ b/irc/caps/defs.go
@@ -7,7 +7,7 @@ package caps
 
 const (
 	// number of recognized capabilities:
-	numCapabs = 22
+	numCapabs = 24
 	// length of the uint64 array that represents the bitset:
 	bitsetLen = 1
 )
@@ -100,6 +100,14 @@ const (
 	// UserhostInNames is the IRCv3 capability named "userhost-in-names":
 	// https://ircv3.net/specs/extensions/userhost-in-names-3.2.html
 	UserhostInNames Capability = iota
+
+	// Bouncer is the Oragono-specific capability named "oragono.io/bnc":
+	// https://oragono.io/bnc
+	Bouncer Capability = iota
+
+	// ZNCSelfMessage is the ZNC vendor capability named "znc.in/self-message":
+	// https://wiki.znc.in/Query_buffers
+	ZNCSelfMessage Capability = iota
 )
 
 // `capabilityNames[capab]` is the string name of the capability `capab`
@@ -127,5 +135,7 @@ var (
 		"draft/setname",
 		"sts",
 		"userhost-in-names",
+		"oragono.io/bnc",
+		"znc.in/self-message",
 	}
 )

--- a/irc/caps/set.go
+++ b/irc/caps/set.go
@@ -20,6 +20,16 @@ func NewSet(capabs ...Capability) *Set {
 	return &newSet
 }
 
+// NewCompleteSet returns a new Set, with all defined capabilities enabled.
+func NewCompleteSet() *Set {
+	var newSet Set
+	asSlice := newSet[:]
+	for i := 0; i < numCapabs; i += 1 {
+		utils.BitsetSet(asSlice, uint(i), true)
+	}
+	return &newSet
+}
+
 // Enable enables the given capabilities.
 func (s *Set) Enable(capabs ...Capability) {
 	asSlice := s[:]
@@ -51,6 +61,16 @@ func (s *Set) Remove(capabs ...Capability) {
 // Has returns true if this set has the given capability.
 func (s *Set) Has(capab Capability) bool {
 	return utils.BitsetGet(s[:], uint(capab))
+}
+
+// HasAll returns true if the set has all the given capabilities.
+func (s *Set) HasAll(capabs ...Capability) bool {
+	for _, capab := range capabs {
+		if !s.Has(capab) {
+			return false
+		}
+	}
+	return true
 }
 
 // Union adds all the capabilities of another set to this set.
@@ -93,4 +113,10 @@ func (s *Set) String(version Version, values *Values) string {
 	sort.Sort(strs)
 
 	return strings.Join(strs, " ")
+}
+
+// returns whether we should send `znc.in/self-message`-style echo messages
+// to sessions other than that which originated the message
+func (capabs *Set) SelfMessagesEnabled() bool {
+	return capabs.Has(EchoMessage) || capabs.Has(ZNCSelfMessage)
 }

--- a/irc/client.go
+++ b/irc/client.go
@@ -451,7 +451,7 @@ func (client *Client) tryResume() (success bool) {
 	// this is a bit racey
 	client.resumeDetails.ResumedAt = time.Now()
 
-	client.nickTimer.Touch()
+	client.nickTimer.Touch(nil)
 
 	// resume successful, proceed to copy client state (nickname, flags, etc.)
 	// after this, the server thinks that `newClient` owns the nickname

--- a/irc/client_lookup_set.go
+++ b/irc/client_lookup_set.go
@@ -160,7 +160,9 @@ func (clients *ClientManager) SetNick(client *Client, session *Session, newNick 
 		if !currentClient.AddSession(session) {
 			return errNicknameInUse
 		}
-		// successful reattach:
+		// successful reattach. temporarily assign them the nick they'll have going forward
+		// (the current `client` will be discarded at the end of command execution)
+		client.updateNick(currentClient.Nick(), newcfnick, newSkeleton)
 		return nil
 	}
 	// analogous checks for skeletons

--- a/irc/config.go
+++ b/irc/config.go
@@ -66,7 +66,11 @@ type AccountConfig struct {
 	} `yaml:"login-throttling"`
 	SkipServerPassword bool                  `yaml:"skip-server-password"`
 	NickReservation    NickReservationConfig `yaml:"nick-reservation"`
-	VHosts             VHostConfig
+	Bouncer            struct {
+		Enabled          bool
+		AllowedByDefault bool `yaml:"allowed-by-default"`
+	}
+	VHosts VHostConfig
 }
 
 // AccountRegistrationConfig controls account registration.

--- a/irc/idletimer.go
+++ b/irc/idletimer.go
@@ -45,7 +45,7 @@ type IdleTimer struct {
 
 	// immutable after construction
 	registerTimeout time.Duration
-	client          *Client
+	session         *Session
 
 	// mutable
 	idleTimeout time.Duration
@@ -56,14 +56,19 @@ type IdleTimer struct {
 
 // Initialize sets up an IdleTimer and starts counting idle time;
 // if there is no activity from the client, it will eventually be stopped.
-func (it *IdleTimer) Initialize(client *Client) {
-	it.client = client
+func (it *IdleTimer) Initialize(session *Session) {
+	it.session = session
 	it.registerTimeout = RegisterTimeout
 	it.idleTimeout, it.quitTimeout = it.recomputeDurations()
+	registered := session.client.Registered()
 
 	it.Lock()
 	defer it.Unlock()
-	it.state = TimerUnregistered
+	if registered {
+		it.state = TimerActive
+	} else {
+		it.state = TimerUnregistered
+	}
 	it.resetTimeout()
 }
 
@@ -72,12 +77,12 @@ func (it *IdleTimer) recomputeDurations() (idleTimeout, quitTimeout time.Duratio
 	totalTimeout := DefaultTotalTimeout
 	// if they have the resume cap, wait longer before pinging them out
 	// to give them a chance to resume their connection
-	if it.client.capabilities.Has(caps.Resume) {
+	if it.session.capabilities.Has(caps.Resume) {
 		totalTimeout = ResumeableTotalTimeout
 	}
 
 	idleTimeout = DefaultIdleTimeout
-	if it.client.isTor {
+	if it.session.client.isTor {
 		idleTimeout = TorIdleTimeout
 	}
 
@@ -118,10 +123,10 @@ func (it *IdleTimer) processTimeout() {
 	}()
 
 	if previousState == TimerActive {
-		it.client.Ping()
+		it.session.Ping()
 	} else {
-		it.client.Quit(it.quitMessage(previousState))
-		it.client.destroy(false)
+		it.session.client.Quit(it.quitMessage(previousState), it.session)
+		it.session.client.destroy(false, it.session)
 	}
 }
 

--- a/irc/nickname.go
+++ b/irc/nickname.go
@@ -57,8 +57,6 @@ func performNickChange(server *Server, client *Client, target *Client, session *
 		return false
 	}
 
-	target.nickTimer.Touch()
-
 	client.server.logger.Debug("nick", fmt.Sprintf("%s changed nickname to %s [%s]", origNickMask, nickname, cfnick))
 	if hadNick {
 		target.server.snomasks.Send(sno.LocalNicks, fmt.Sprintf(ircfmt.Unescape("$%s$r changed nickname to %s"), whowas.nick, nickname))
@@ -70,6 +68,8 @@ func performNickChange(server *Server, client *Client, target *Client, session *
 			}
 		}
 	}
+
+	target.nickTimer.Touch(rb)
 
 	if target.Registered() {
 		client.server.monitorManager.AlertAbout(target, true)

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -31,7 +31,7 @@ var (
 	// 1. sent with prefix `nickserv`
 	// 2. contains the string "identify"
 	// 3. contains at least one of several other magic strings ("msg" works)
-	nsTimeoutNotice = `This nickname is reserved. Please login within %v (using $b/msg NickServ IDENTIFY <password>$b or SASL)`
+	nsTimeoutNotice = `This nickname is reserved. Please login within %v (using $b/msg NickServ IDENTIFY <password>$b or SASL), or switch to a different nickname.`
 )
 
 const nickservHelp = `NickServ lets you register and login to an account.

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -229,8 +229,8 @@ func nsGhostHandler(server *Server, client *Client, command string, params []str
 		return
 	}
 
-	ghost.Quit(fmt.Sprintf(ghost.t("GHOSTed by %s"), client.Nick()))
-	ghost.destroy(false)
+	ghost.Quit(fmt.Sprintf(ghost.t("GHOSTed by %s"), client.Nick()), nil)
+	ghost.destroy(false, nil)
 }
 
 func nsGroupHandler(server *Server, client *Client, command string, params []string, rb *ResponseBuffer) {

--- a/irc/server.go
+++ b/irc/server.go
@@ -816,7 +816,7 @@ func (server *Server) applyConfig(config *Config, initial bool) (err error) {
 
 			if !oldConfig.Accounts.NickReservation.Enabled && config.Accounts.NickReservation.Enabled {
 				sClient.nickTimer.Initialize(sClient)
-				sClient.nickTimer.Touch()
+				sClient.nickTimer.Touch(nil)
 			} else if oldConfig.Accounts.NickReservation.Enabled && !config.Accounts.NickReservation.Enabled {
 				sClient.nickTimer.Stop()
 			}

--- a/irc/server.go
+++ b/irc/server.go
@@ -41,8 +41,8 @@ var (
 	supportedChannelModesString = modes.SupportedChannelModes.String()
 
 	// SupportedCapabilities are the caps we advertise.
-	// MaxLine, SASL and STS are set during server startup.
-	SupportedCapabilities = caps.NewSet(caps.Acc, caps.AccountTag, caps.AccountNotify, caps.AwayNotify, caps.Batch, caps.CapNotify, caps.ChgHost, caps.EchoMessage, caps.ExtendedJoin, caps.InviteNotify, caps.LabeledResponse, caps.Languages, caps.MessageTags, caps.MultiPrefix, caps.Rename, caps.Resume, caps.ServerTime, caps.SetName, caps.UserhostInNames)
+	// MaxLine, SASL and STS may be unset during server startup / rehash.
+	SupportedCapabilities = caps.NewCompleteSet()
 
 	// CapValues are the actual values we advertise to v3.2 clients.
 	// actual values are set during server startup.
@@ -374,7 +374,7 @@ func (server *Server) createListener(addr string, tlsConfig *tls.Config, isTor b
 // server functionality
 //
 
-func (server *Server) tryRegister(c *Client) {
+func (server *Server) tryRegister(c *Client, session *Session) {
 	resumed := false
 	// try to complete registration, either via RESUME token or normally
 	if c.resumeDetails != nil {
@@ -383,7 +383,7 @@ func (server *Server) tryRegister(c *Client) {
 		}
 		resumed = true
 	} else {
-		if c.preregNick == "" || !c.HasUsername() || c.capState == caps.NegotiatingState {
+		if c.preregNick == "" || !c.HasUsername() || session.capState == caps.NegotiatingState {
 			return
 		}
 
@@ -391,13 +391,13 @@ func (server *Server) tryRegister(c *Client) {
 		// before completing the other registration commands
 		config := server.Config()
 		if !c.isAuthorized(config) {
-			c.Quit(c.t("Bad password"))
-			c.destroy(false)
+			c.Quit(c.t("Bad password"), nil)
+			c.destroy(false, nil)
 			return
 		}
 
-		rb := NewResponseBuffer(c)
-		nickAssigned := performNickChange(server, c, c, c.preregNick, rb)
+		rb := NewResponseBuffer(session)
+		nickAssigned := performNickChange(server, c, c, session, c.preregNick, rb)
 		rb.Send(true)
 		if !nickAssigned {
 			c.preregNick = ""
@@ -407,20 +407,24 @@ func (server *Server) tryRegister(c *Client) {
 		// check KLINEs
 		isBanned, info := server.klines.CheckMasks(c.AllNickmasks()...)
 		if isBanned {
-			c.Quit(info.BanMessage(c.t("You are banned from this server (%s)")))
-			c.destroy(false)
+			c.Quit(info.BanMessage(c.t("You are banned from this server (%s)")), nil)
+			c.destroy(false, nil)
 			return
 		}
 	}
 
-	// registration has succeeded:
-	c.SetRegistered()
+	reattached := session.client != c
 
-	// count new user in statistics
-	server.stats.ChangeTotal(1)
+	if !reattached {
+		// registration has succeeded:
+		c.SetRegistered()
 
-	if !resumed {
-		server.monitorManager.AlertAbout(c, true)
+		// count new user in statistics
+		server.stats.ChangeTotal(1)
+
+		if !resumed {
+			server.monitorManager.AlertAbout(c, true)
+		}
 	}
 
 	// continue registration
@@ -436,7 +440,7 @@ func (server *Server) tryRegister(c *Client) {
 	//TODO(dan): Look at adding last optional [<channel modes with a parameter>] parameter
 	c.Send(nil, server.name, RPL_MYINFO, c.nick, server.name, Ver, supportedUserModesString, supportedChannelModesString)
 
-	rb := NewResponseBuffer(c)
+	rb := NewResponseBuffer(session)
 	c.RplISupport(rb)
 	server.MOTD(c, rb)
 	rb.Send(true)
@@ -480,8 +484,7 @@ func (server *Server) MOTD(client *Client, rb *ResponseBuffer) {
 }
 
 // WhoisChannelsNames returns the common channel names between two users.
-func (client *Client) WhoisChannelsNames(target *Client) []string {
-	isMultiPrefix := client.capabilities.Has(caps.MultiPrefix)
+func (client *Client) WhoisChannelsNames(target *Client, multiPrefix bool) []string {
 	var chstrs []string
 	for _, channel := range target.Channels() {
 		// channel is secret and the target can't see it
@@ -490,7 +493,7 @@ func (client *Client) WhoisChannelsNames(target *Client) []string {
 				continue
 			}
 		}
-		chstrs = append(chstrs, channel.ClientPrefixes(target, isMultiPrefix)+channel.name)
+		chstrs = append(chstrs, channel.ClientPrefixes(target, multiPrefix)+channel.name)
 	}
 	return chstrs
 }
@@ -501,7 +504,7 @@ func (client *Client) getWhoisOf(target *Client, rb *ResponseBuffer) {
 	rb.Add(nil, client.server.name, RPL_WHOISUSER, cnick, targetInfo.nick, targetInfo.username, targetInfo.hostname, "*", targetInfo.realname)
 	tnick := targetInfo.nick
 
-	whoischannels := client.WhoisChannelsNames(target)
+	whoischannels := client.WhoisChannelsNames(target, rb.session.capabilities.Has(caps.MultiPrefix))
 	if whoischannels != nil {
 		rb.Add(nil, client.server.name, RPL_WHOISCHANNELS, cnick, tnick, strings.Join(whoischannels, " "))
 	}
@@ -555,18 +558,12 @@ func (target *Client) rplWhoReply(channel *Channel, client *Client, rb *Response
 	}
 
 	if channel != nil {
-		flags += channel.ClientPrefixes(client, target.capabilities.Has(caps.MultiPrefix))
+		// TODO is this right?
+		flags += channel.ClientPrefixes(client, rb.session.capabilities.Has(caps.MultiPrefix))
 		channelName = channel.name
 	}
-	rb.Add(nil, target.server.name, RPL_WHOREPLY, target.nick, channelName, client.Username(), client.Hostname(), client.server.name, client.Nick(), flags, strconv.Itoa(client.hops)+" "+client.Realname())
-}
-
-func whoChannel(client *Client, channel *Channel, friends ClientSet, rb *ResponseBuffer) {
-	for _, member := range channel.Members() {
-		if !client.HasMode(modes.Invisible) || friends[client] {
-			client.rplWhoReply(channel, member, rb)
-		}
-	}
+	// hardcode a hopcount of 0 for now
+	rb.Add(nil, target.server.name, RPL_WHOREPLY, target.nick, channelName, client.Username(), client.Hostname(), client.server.name, client.Nick(), flags, "0 "+client.Realname())
 }
 
 // rehash reloads the config and applies the changes from the config file.
@@ -691,6 +688,8 @@ func (server *Server) applyConfig(config *Config, initial bool) (err error) {
 		SupportedCapabilities.Enable(caps.MaxLine)
 		value := fmt.Sprintf("%d", config.Limits.LineLen.Rest)
 		CapValues.Set(caps.MaxLine, value)
+	} else {
+		SupportedCapabilities.Disable(caps.MaxLine)
 	}
 
 	// STS
@@ -699,20 +698,24 @@ func (server *Server) applyConfig(config *Config, initial bool) (err error) {
 	stsDisabledByRehash := false
 	stsCurrentCapValue, _ := CapValues.Get(caps.STS)
 	server.logger.Debug("server", "STS Vals", stsCurrentCapValue, stsValue, fmt.Sprintf("server[%v] config[%v]", stsPreviouslyEnabled, config.Server.STS.Enabled))
-	if config.Server.STS.Enabled && !stsPreviouslyEnabled {
+	if config.Server.STS.Enabled {
 		// enabling STS
 		SupportedCapabilities.Enable(caps.STS)
-		addedCaps.Add(caps.STS)
-		CapValues.Set(caps.STS, stsValue)
-	} else if !config.Server.STS.Enabled && stsPreviouslyEnabled {
+		if !stsPreviouslyEnabled {
+			addedCaps.Add(caps.STS)
+			CapValues.Set(caps.STS, stsValue)
+		} else if stsValue != stsCurrentCapValue {
+			// STS policy updated
+			CapValues.Set(caps.STS, stsValue)
+			updatedCaps.Add(caps.STS)
+		}
+	} else {
 		// disabling STS
 		SupportedCapabilities.Disable(caps.STS)
-		removedCaps.Add(caps.STS)
-		stsDisabledByRehash = true
-	} else if config.Server.STS.Enabled && stsPreviouslyEnabled && stsValue != stsCurrentCapValue {
-		// STS policy updated
-		CapValues.Set(caps.STS, stsValue)
-		updatedCaps.Add(caps.STS)
+		if stsPreviouslyEnabled {
+			removedCaps.Add(caps.STS)
+			stsDisabledByRehash = true
+		}
 	}
 
 	// resize history buffers as needed
@@ -730,7 +733,7 @@ func (server *Server) applyConfig(config *Config, initial bool) (err error) {
 	}
 
 	// burst new and removed caps
-	var capBurstClients ClientSet
+	var capBurstSessions []*Session
 	added := make(map[caps.Version]string)
 	var removed string
 
@@ -741,7 +744,7 @@ func (server *Server) applyConfig(config *Config, initial bool) (err error) {
 	removedCaps.Union(updatedCaps)
 
 	if !addedCaps.Empty() || !removedCaps.Empty() {
-		capBurstClients = server.clients.AllWithCaps(caps.CapNotify)
+		capBurstSessions = server.clients.AllWithCaps(caps.CapNotify)
 
 		added[caps.Cap301] = addedCaps.String(caps.Cap301, CapValues)
 		added[caps.Cap302] = addedCaps.String(caps.Cap302, CapValues)
@@ -749,7 +752,7 @@ func (server *Server) applyConfig(config *Config, initial bool) (err error) {
 		removed = removedCaps.String(caps.Cap301, CapValues)
 	}
 
-	for sClient := range capBurstClients {
+	for _, sSession := range capBurstSessions {
 		if stsDisabledByRehash {
 			// remove STS policy
 			//TODO(dan): this is an ugly hack. we can write this better.
@@ -763,10 +766,10 @@ func (server *Server) applyConfig(config *Config, initial bool) (err error) {
 		}
 		// DEL caps and then send NEW ones so that updated caps get removed/added correctly
 		if !removedCaps.Empty() {
-			sClient.Send(nil, server.name, "CAP", sClient.nick, "DEL", removed)
+			sSession.Send(nil, server.name, "CAP", sSession.client.Nick(), "DEL", removed)
 		}
 		if !addedCaps.Empty() {
-			sClient.Send(nil, server.name, "CAP", sClient.nick, "NEW", added[sClient.capVersion])
+			sSession.Send(nil, server.name, "CAP", sSession.client.Nick(), "NEW", added[sSession.capVersion])
 		}
 	}
 

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -262,6 +262,19 @@ accounts:
         # rename-prefix - this is the prefix to use when renaming clients (e.g. Guest-AB54U31)
         rename-prefix: Guest-
 
+    # bouncer controls whether oragono can act as a bouncer, i.e., allowing
+    # multiple connections to attach to the same client/nickname identity
+    bouncer:
+        # when disabled, each connection must use a separate nickname (as is the
+        # typical behavior of IRC servers). when enabled, a new connection that
+        # has authenticated with SASL can associate itself with an existing
+        # client
+        enabled: true
+
+        # clients can opt in to bouncer functionality using the cap system, or
+        # via nickserv. if this is enabled, then they have to opt out instead
+        allowed-by-default: false
+
     # vhosts controls the assignment of vhosts (strings displayed in place of the user's
     # hostname/IP) by the HostServ service
     vhosts:


### PR DESCRIPTION
This is an unusually dangerous change. Here are the active ingredients:

1. `Client` now has a field `sessions` of type `[]*Session`
1. A `Session` holds a `Socket` and other data that is local to an individual TCP connection, in particular the cap set
1. `Client.sessions` is effectively a refcount system for the client; if its length drops to `0`, the client is destroyed
1. `ResponseBuffer` now targets a single `*Session`. Any state changes in the response have to be manually forwarded to other connected sessions (i.e., `ResponseBuffer` doesn't attempt to automatically cc them).
1. If allowed by default in the server config, or the client negotiates the cap `oragono.io/bnc` (to be drafted), `ClientLookupSet.SetNick` will allow the client to reattach to an existing session
1. If `Client.run` detects a reattach (i.e., the session has been attached to a new client), it spins off a new goroutine corresponding to the new client-session pair, then exits (triggering a destroy of the old client)
1. I stubbed out but didn't implement a system that would allow account holders to opt their account in and out of the bouncer system (i.e., via NickServ), without having to negotiate the cap

This needs a bunch of testing. It passes `irctest` and handled the cases I produced manually (various orderings of channel join, reattach, message sending, and quitting). Probably the most likely category of bug is state changes that are not correctly broadcast to other attached sessions.

I threw a fix for #449 on top.