### PR TITLE
Fix cap-notify

### DIFF
--- a/irc/client_lookup_set.go
+++ b/irc/client_lookup_set.go
@@ -207,6 +207,22 @@ func (clients *ClientManager) AllWithCaps(capabs ...caps.Capability) (sessions [
 	return
 }
 
+// AllWithCapsNotify returns all clients with the given capabilities, and that support cap-notify.
+func (clients *ClientManager) AllWithCapsNotify(capabs ...caps.Capability) (sessions []*Session) {
+	clients.RLock()
+	defer clients.RUnlock()
+	for _, client := range clients.byNick {
+		for _, session := range client.Sessions() {
+			capabs = append(capabs, caps.CapNotify)
+			if session.capabilities.HasAll(capabs...) || 302 <= session.capVersion {
+				sessions = append(sessions, session)
+			}
+		}
+	}
+
+	return
+}
+
 // FindAll returns all clients that match the given userhost mask.
 func (clients *ClientManager) FindAll(userhost string) (set ClientSet) {
 	set = make(ClientSet)

--- a/irc/client_lookup_set.go
+++ b/irc/client_lookup_set.go
@@ -209,11 +209,12 @@ func (clients *ClientManager) AllWithCaps(capabs ...caps.Capability) (sessions [
 
 // AllWithCapsNotify returns all clients with the given capabilities, and that support cap-notify.
 func (clients *ClientManager) AllWithCapsNotify(capabs ...caps.Capability) (sessions []*Session) {
+	capabs = append(capabs, caps.CapNotify)
 	clients.RLock()
 	defer clients.RUnlock()
 	for _, client := range clients.byNick {
 		for _, session := range client.Sessions() {
-			capabs = append(capabs, caps.CapNotify)
+			// cap-notify is implicit in cap version 302 and above
 			if session.capabilities.HasAll(capabs...) || 302 <= session.capVersion {
 				sessions = append(sessions, session)
 			}

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -535,8 +535,12 @@ func capHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Respo
 		if !client.registered {
 			rb.session.capState = caps.NegotiatingState
 		}
-		if len(msg.Params) > 1 && msg.Params[1] == "302" {
-			rb.session.capVersion = 302
+		if 1 < len(msg.Params) {
+			num, err := strconv.Atoi(msg.Params[1])
+			newVersion := caps.Version(num)
+			if err == nil && rb.session.capVersion < newVersion {
+				rb.session.capVersion = newVersion
+			}
 		}
 		// weechat 1.4 has a bug here where it won't accept the CAP reply unless it contains
 		// the server.name source... otherwise it doesn't respond to the CAP message with

--- a/irc/server.go
+++ b/irc/server.go
@@ -744,7 +744,7 @@ func (server *Server) applyConfig(config *Config, initial bool) (err error) {
 	removedCaps.Union(updatedCaps)
 
 	if !addedCaps.Empty() || !removedCaps.Empty() {
-		capBurstSessions = server.clients.AllWithCaps(caps.CapNotify)
+		capBurstSessions = server.clients.AllWithCapsNotify()
 
 		added[caps.Cap301] = addedCaps.String(caps.Cap301, CapValues)
 		added[caps.Cap302] = addedCaps.String(caps.Cap302, CapValues)


### PR DESCRIPTION
It looks like cap-notify's been a little busted. Not related to the bnc stuff, just in general probably. This PR fixes that up a little.

It seems there's still s'more to do with regards to getting the values to be passed-thru on cap value replies, seems to be sending out empty lines currently. The SASL enable/disable block should reeeally just use the same structure as the STS section below, that handles things a whole lot more nicely.

Issues this should resolve:

- Currently, if someone sends `CAP LS 302` they won't automagically receive `cap-notify` messages (as the spec indicates they should). This PR should mean they will, without having to explicitly request that capability separately.
- Currently, if someone sends `CAP LS 303`, they won't get any of the `302` stuff (specifically, the auto-`cap-notify` behaviour above). This PR should mean they will.

Issues to be resolved:

- It, uh. Seems that cap values aren't being correctly sent in soooome situations, maybe? Investigate, I've had some trouble around `sasl` in particular, dunno exactly what's going on there.