### PR TITLE
three fixes

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -377,22 +377,22 @@ func (channel *Channel) Names(client *Client, rb *ResponseBuffer) {
 	rb.Add(nil, client.server.name, RPL_ENDOFNAMES, client.nick, channel.name, client.t("End of NAMES list"))
 }
 
-func channelUserModeIsAtLeast(clientModes *modes.ModeSet, permission modes.Mode) bool {
-	if clientModes == nil {
+// does `clientMode` give you privileges to grant/remove `targetMode` to/from people,
+// or to kick them?
+func channelUserModeHasPrivsOver(clientMode modes.Mode, targetMode modes.Mode) bool {
+	switch clientMode {
+	case modes.ChannelFounder:
+		return true
+	case modes.ChannelAdmin, modes.ChannelOperator:
+		// admins cannot kick other admins, operators *can* kick other operators
+		return targetMode != modes.ChannelFounder && targetMode != modes.ChannelAdmin
+	case modes.Halfop:
+		// halfops cannot kick other halfops
+		return targetMode != modes.ChannelFounder && targetMode != modes.ChannelAdmin && targetMode != modes.Halfop
+	default:
+		// voice and unprivileged cannot kick anyone
 		return false
 	}
-
-	for _, mode := range modes.ChannelUserModes {
-		if clientModes.HasMode(mode) {
-			return true
-		}
-
-		if mode == permission {
-			break
-		}
-	}
-
-	return false
 }
 
 // ClientIsAtLeast returns whether the client has at least the given channel privilege.
@@ -400,7 +400,16 @@ func (channel *Channel) ClientIsAtLeast(client *Client, permission modes.Mode) b
 	channel.stateMutex.RLock()
 	clientModes := channel.members[client]
 	channel.stateMutex.RUnlock()
-	return channelUserModeIsAtLeast(clientModes, permission)
+
+	for _, mode := range modes.ChannelUserModes {
+		if clientModes.HasMode(mode) {
+			return true
+		}
+		if mode == permission {
+			break
+		}
+	}
+	return false
 }
 
 func (channel *Channel) ClientPrefixes(client *Client, isMultiPrefix bool) string {
@@ -420,28 +429,13 @@ func (channel *Channel) ClientHasPrivsOver(client *Client, target *Client) bool 
 	targetModes := channel.members[target]
 	channel.stateMutex.RUnlock()
 
-	if clientModes.HasMode(modes.ChannelFounder) {
-		// founder can kick anyone
-		return true
-	} else if clientModes.HasMode(modes.ChannelAdmin) {
-		// admins cannot kick other admins
-		return !channelUserModeIsAtLeast(targetModes, modes.ChannelAdmin)
-	} else if clientModes.HasMode(modes.ChannelOperator) {
-		// operators *can* kick other operators
-		return !channelUserModeIsAtLeast(targetModes, modes.ChannelAdmin)
-	} else if clientModes.HasMode(modes.Halfop) {
-		// halfops cannot kick other halfops
-		return !channelUserModeIsAtLeast(targetModes, modes.Halfop)
-	} else {
-		// voice and unprivileged cannot kick anyone
-		return false
-	}
+	return channelUserModeHasPrivsOver(clientModes.HighestChannelUserMode(), targetModes.HighestChannelUserMode())
 }
 
 func (channel *Channel) hasClient(client *Client) bool {
 	channel.stateMutex.RLock()
-	defer channel.stateMutex.RUnlock()
 	_, present := channel.members[client]
+	channel.stateMutex.RUnlock()
 	return present
 }
 
@@ -902,7 +896,7 @@ func msgCommandToHistType(server *Server, command string) (history.ItemType, err
 	}
 }
 
-func (channel *Channel) SendSplitMessage(command string, minPrefix *modes.Mode, clientOnlyTags map[string]string, client *Client, message utils.SplitMessage, rb *ResponseBuffer) {
+func (channel *Channel) SendSplitMessage(command string, minPrefixMode modes.Mode, clientOnlyTags map[string]string, client *Client, message utils.SplitMessage, rb *ResponseBuffer) {
 	histType, err := msgCommandToHistType(channel.server, command)
 	if err != nil {
 		return
@@ -920,11 +914,11 @@ func (channel *Channel) SendSplitMessage(command string, minPrefix *modes.Mode, 
 	chname := channel.Name()
 	now := time.Now().UTC()
 
-	// for STATUSMSG
-	var minPrefixMode modes.Mode
-	if minPrefix != nil {
-		minPrefixMode = *minPrefix
+	// STATUSMSG targets are prefixed with the supplied min-prefix, e.g., @#channel
+	if minPrefixMode != modes.Mode(0) {
+		chname = fmt.Sprintf("%s%s", modes.ChannelModePrefixes[minPrefixMode], chname)
 	}
+
 	// send echo-message
 	// TODO this should use `now` as the time for consistency
 	if rb.session.capabilities.Has(caps.EchoMessage) {
@@ -959,7 +953,7 @@ func (channel *Channel) SendSplitMessage(command string, minPrefix *modes.Mode, 
 		if member == client {
 			continue
 		}
-		if minPrefix != nil && !channel.ClientIsAtLeast(member, minPrefixMode) {
+		if minPrefixMode != modes.Mode(0) && !channel.ClientIsAtLeast(member, minPrefixMode) {
 			// STATUSMSG
 			continue
 		}

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -352,3 +352,10 @@ func (channel *Channel) DirtyBits() (dirtyBits uint) {
 	channel.stateMutex.Unlock()
 	return
 }
+
+func (channel *Channel) HighestUserMode(client *Client) (result modes.Mode) {
+	channel.stateMutex.RLock()
+	clientModes := channel.members[client]
+	channel.stateMutex.RUnlock()
+	return clientModes.HighestChannelUserMode()
+}

--- a/irc/modes/modes_test.go
+++ b/irc/modes/modes_test.go
@@ -90,3 +90,26 @@ func TestNilReceivers(t *testing.T) {
 		t.Errorf("nil Modeset should have empty String(), got %v instead", str)
 	}
 }
+
+func TestHighestChannelUserMode(t *testing.T) {
+	set := NewModeSet()
+
+	if set.HighestChannelUserMode() != Mode(0) {
+		t.Errorf("no channel user modes should be present yet")
+	}
+
+	set.SetMode(Voice, true)
+	if set.HighestChannelUserMode() != Voice {
+		t.Errorf("should see that user is voiced")
+	}
+
+	set.SetMode(ChannelAdmin, true)
+	if set.HighestChannelUserMode() != ChannelAdmin {
+		t.Errorf("should see that user has channel admin")
+	}
+
+	set = nil
+	if set.HighestChannelUserMode() != Mode(0) {
+		t.Errorf("nil modeset should have the zero mode as highest channel-user mode")
+	}
+}

--- a/irc/modes_test.go
+++ b/irc/modes_test.go
@@ -48,3 +48,22 @@ func TestUmodeGreaterThan(t *testing.T) {
 		t.Errorf("modes should not be greater than themselves")
 	}
 }
+
+func assertEqual(supplied, expected interface{}, t *testing.T) {
+	if !reflect.DeepEqual(supplied, expected) {
+		t.Errorf("expected %v but got %v", expected, supplied)
+	}
+}
+
+func TestChannelUserModeHasPrivsOver(t *testing.T) {
+	assertEqual(channelUserModeHasPrivsOver(modes.Voice, modes.Halfop), false, t)
+	assertEqual(channelUserModeHasPrivsOver(modes.Mode(0), modes.Halfop), false, t)
+	assertEqual(channelUserModeHasPrivsOver(modes.Voice, modes.Mode(0)), false, t)
+	assertEqual(channelUserModeHasPrivsOver(modes.ChannelAdmin, modes.ChannelAdmin), false, t)
+	assertEqual(channelUserModeHasPrivsOver(modes.Halfop, modes.Halfop), false, t)
+	assertEqual(channelUserModeHasPrivsOver(modes.Voice, modes.Voice), false, t)
+
+	assertEqual(channelUserModeHasPrivsOver(modes.Halfop, modes.Voice), true, t)
+	assertEqual(channelUserModeHasPrivsOver(modes.ChannelFounder, modes.ChannelAdmin), true, t)
+	assertEqual(channelUserModeHasPrivsOver(modes.ChannelOperator, modes.ChannelOperator), true, t)
+}


### PR DESCRIPTION
1. #400 
1. STATUSMSG didn't add the designated prefix to the channel (I have an irctest covering this in an unpushed WIP branch)
1. `NAMES` didn't respect invisibility (this diff is easier to read with `-w`, i.e., ignoring whitespace changes)