### PR TITLE
tweaks to NAMES / WHO privacy

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -336,13 +336,14 @@ func (channel *Channel) regenerateMembersCache() {
 // Names sends the list of users joined to the channel to the given client.
 func (channel *Channel) Names(client *Client, rb *ResponseBuffer) {
 	isJoined := channel.hasClient(client)
+	isOper := client.HasMode(modes.Operator)
 	isMultiPrefix := rb.session.capabilities.Has(caps.MultiPrefix)
 	isUserhostInNames := rb.session.capabilities.Has(caps.UserhostInNames)
 
 	maxNamLen := 480 - len(client.server.name) - len(client.Nick())
 	var namesLines []string
 	var buffer bytes.Buffer
-	if isJoined || !channel.flags.HasMode(modes.Secret) {
+	if isJoined || !channel.flags.HasMode(modes.Secret) || isOper {
 		for _, target := range channel.Members() {
 			var nick string
 			if isUserhostInNames {
@@ -356,7 +357,7 @@ func (channel *Channel) Names(client *Client, rb *ResponseBuffer) {
 			if modeSet == nil {
 				continue
 			}
-			if !isJoined && target.flags.HasMode(modes.Invisible) {
+			if !isJoined && target.flags.HasMode(modes.Invisible) && !isOper {
 				continue
 			}
 			prefix := modeSet.Prefixes(isMultiPrefix)

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2595,14 +2595,18 @@ func whoHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Respo
 	//	operatorOnly = true
 	//}
 
+	isOper := client.HasMode(modes.Operator)
 	if mask[0] == '#' {
 		// TODO implement wildcard matching
 		//TODO(dan): ^ only for opers
 		channel := server.channels.Get(mask)
-		if channel != nil && channel.hasClient(client) {
-			for _, member := range channel.Members() {
-				if !member.HasMode(modes.Invisible) {
-					client.rplWhoReply(channel, member, rb)
+		if channel != nil {
+			isJoined := channel.hasClient(client)
+			if !channel.flags.HasMode(modes.Secret) || isJoined || isOper {
+				for _, member := range channel.Members() {
+					if !member.HasMode(modes.Invisible) || isJoined || isOper {
+						client.rplWhoReply(channel, member, rb)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This fixes a regression from #467 (non-members could no longer `WHO` a channel, even a non-secret one), and also makes consistent that operators can see through the secret channel mode and invisible user mode.