### PR TITLE
add client compatibility switches

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -5,7 +5,6 @@ package irc
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/smtp"
 	"strconv"
@@ -480,7 +479,7 @@ func (am *AccountManager) dispatchCallback(client *Client, casefoldedAccount str
 	} else if callbackNamespace == "mailto" {
 		return am.dispatchMailtoCallback(client, casefoldedAccount, callbackValue)
 	} else {
-		return "", errors.New(fmt.Sprintf("Callback not implemented: %s", callbackNamespace))
+		return "", fmt.Errorf("Callback not implemented: %s", callbackNamespace)
 	}
 }
 
@@ -1262,7 +1261,6 @@ func (am *AccountManager) Logout(client *Client) {
 		}
 	}
 	am.accountToClients[casefoldedAccount] = remainingClients
-	return
 }
 
 var (

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -1043,34 +1043,6 @@ func (channel *Channel) ShowMaskList(client *Client, mode modes.Mode, rb *Respon
 	rb.Add(nil, client.server.name, rplendoflist, nick, channel.name, client.t("End of list"))
 }
 
-func (channel *Channel) applyModeMask(client *Client, mode modes.Mode, op modes.ModeOp, mask string, rb *ResponseBuffer) bool {
-	list := channel.lists[mode]
-	if list == nil {
-		// This should never happen, but better safe than panicky.
-		return false
-	}
-
-	if (op == modes.List) || (mask == "") {
-		channel.ShowMaskList(client, mode, rb)
-		return false
-	}
-
-	if !channel.ClientIsAtLeast(client, modes.ChannelOperator) {
-		rb.Add(nil, client.server.name, ERR_CHANOPRIVSNEEDED, client.Nick(), channel.Name(), client.t("You're not a channel operator"))
-		return false
-	}
-
-	if op == modes.Add {
-		return list.Add(mask)
-	}
-
-	if op == modes.Remove {
-		return list.Remove(mask)
-	}
-
-	return false
-}
-
 // Quit removes the given client from the channel
 func (channel *Channel) Quit(client *Client) {
 	channelEmpty := func() bool {

--- a/irc/client.go
+++ b/irc/client.go
@@ -836,7 +836,8 @@ func (client *Client) LoggedIntoAccount() bool {
 func (client *Client) RplISupport(rb *ResponseBuffer) {
 	translatedISupport := client.t("are supported by this server")
 	nick := client.Nick()
-	for _, cachedTokenLine := range client.server.ISupport().CachedReply {
+	config := client.server.Config()
+	for _, cachedTokenLine := range config.Server.isupport.CachedReply {
 		length := len(cachedTokenLine) + 2
 		tokenline := make([]string, length)
 		tokenline[0] = nick

--- a/irc/client.go
+++ b/irc/client.go
@@ -538,14 +538,12 @@ func (client *Client) tryResume() (success bool) {
 func (client *Client) tryResumeChannels() {
 	details := client.resumeDetails
 
-	channels := make([]*Channel, len(details.Channels))
 	for _, name := range details.Channels {
 		channel := client.server.channels.Get(name)
 		if channel == nil {
 			continue
 		}
 		channel.Resume(client, details.OldClient, details.Timestamp)
-		channels = append(channels, channel)
 	}
 
 	// replay direct PRIVSMG history

--- a/irc/client.go
+++ b/irc/client.go
@@ -1085,7 +1085,8 @@ var (
 func (session *Session) SendRawMessage(message ircmsg.IrcMessage, blocking bool) error {
 	// use dumb hack to force the last param to be a trailing param if required
 	var usedTrailingHack bool
-	if commandsThatMustUseTrailing[message.Command] && len(message.Params) > 0 {
+	config := session.client.server.Config()
+	if config.Server.Compatibility.forceTrailing && commandsThatMustUseTrailing[message.Command] && len(message.Params) > 0 {
 		lastParam := message.Params[len(message.Params)-1]
 		// to force trailing, we ensure the final param contains a space
 		if strings.IndexByte(lastParam, ' ') == -1 {

--- a/irc/config.go
+++ b/irc/config.go
@@ -286,9 +286,14 @@ type Config struct {
 		WebIRC               []webircConfig `yaml:"webirc"`
 		MaxSendQString       string         `yaml:"max-sendq"`
 		MaxSendQBytes        int
-		AllowPlaintextResume bool                              `yaml:"allow-plaintext-resume"`
-		ConnectionLimiter    connection_limits.LimiterConfig   `yaml:"connection-limits"`
-		ConnectionThrottler  connection_limits.ThrottlerConfig `yaml:"connection-throttling"`
+		AllowPlaintextResume bool `yaml:"allow-plaintext-resume"`
+		Compatibility        struct {
+			ForceTrailing      *bool `yaml:"force-trailing"`
+			forceTrailing      bool
+			SendUnprefixedSasl bool `yaml:"send-unprefixed-sasl"`
+		}
+		ConnectionLimiter   connection_limits.LimiterConfig   `yaml:"connection-limits"`
+		ConnectionThrottler connection_limits.ThrottlerConfig `yaml:"connection-throttling"`
 	}
 
 	Languages struct {
@@ -696,6 +701,13 @@ func LoadConfig(filename string) (config *Config, err error) {
 	}
 	if config.Channels.Registration.MaxChannelsPerAccount == 0 {
 		config.Channels.Registration.MaxChannelsPerAccount = 15
+	}
+
+	forceTrailingPtr := config.Server.Compatibility.ForceTrailing
+	if forceTrailingPtr != nil {
+		config.Server.Compatibility.forceTrailing = *forceTrailingPtr
+	} else {
+		config.Server.Compatibility.forceTrailing = true
 	}
 
 	// in the current implementation, we disable history by creating a history buffer

--- a/irc/config.go
+++ b/irc/config.go
@@ -280,6 +280,7 @@ type Config struct {
 		STS                  STSConfig
 		CheckIdent           bool `yaml:"check-ident"`
 		MOTD                 string
+		motdLines            []string
 		MOTDFormatting       bool     `yaml:"motd-formatting"`
 		ProxyAllowedFrom     []string `yaml:"proxy-allowed-from"`
 		proxyAllowedFromNets []net.IPNet
@@ -709,6 +710,8 @@ func LoadConfig(filename string) (config *Config, err error) {
 	} else {
 		config.Server.Compatibility.forceTrailing = true
 	}
+
+	config.loadMOTD()
 
 	// in the current implementation, we disable history by creating a history buffer
 	// with zero capacity. but the `enabled` config option MUST be respected regardless

--- a/irc/config.go
+++ b/irc/config.go
@@ -20,6 +20,7 @@ import (
 	"code.cloudfoundry.org/bytefmt"
 	"github.com/oragono/oragono/irc/connection_limits"
 	"github.com/oragono/oragono/irc/custime"
+	"github.com/oragono/oragono/irc/isupport"
 	"github.com/oragono/oragono/irc/languages"
 	"github.com/oragono/oragono/irc/logger"
 	"github.com/oragono/oragono/irc/modes"
@@ -293,6 +294,7 @@ type Config struct {
 			forceTrailing      bool
 			SendUnprefixedSasl bool `yaml:"send-unprefixed-sasl"`
 		}
+		isupport            isupport.List
 		ConnectionLimiter   connection_limits.LimiterConfig   `yaml:"connection-limits"`
 		ConnectionThrottler connection_limits.ThrottlerConfig `yaml:"connection-throttling"`
 	}
@@ -712,6 +714,11 @@ func LoadConfig(filename string) (config *Config, err error) {
 	}
 
 	config.loadMOTD()
+
+	err = config.generateISupport()
+	if err != nil {
+		return nil, err
+	}
 
 	// in the current implementation, we disable history by creating a history buffer
 	// with zero capacity. but the `enabled` config option MUST be respected regardless

--- a/irc/config.go
+++ b/irc/config.go
@@ -393,7 +393,7 @@ func (conf *Config) OperatorClasses() (map[string]*OperClass, error) {
 
 			// get inhereted info from other operclasses
 			if len(info.Extends) > 0 {
-				einfo, _ := ocs[info.Extends]
+				einfo := ocs[info.Extends]
 
 				for capab := range einfo.Capabilities {
 					oc.Capabilities[capab] = true

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -8,7 +8,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/oragono/oragono/irc/isupport"
 	"github.com/oragono/oragono/irc/languages"
 	"github.com/oragono/oragono/irc/modes"
 )
@@ -19,12 +18,6 @@ func (server *Server) Config() (config *Config) {
 
 func (server *Server) SetConfig(config *Config) {
 	atomic.StorePointer(&server.config, unsafe.Pointer(config))
-}
-
-func (server *Server) ISupport() *isupport.List {
-	server.configurableStateMutex.RLock()
-	defer server.configurableStateMutex.RUnlock()
-	return server.isupport
 }
 
 func (server *Server) Limits() Limits {

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1184,20 +1184,14 @@ func inviteHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Re
 func isonHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
 	var nicks = msg.Params
 
-	var err error
-	var casefoldedNick string
-	ison := make([]string, 0)
+	ison := make([]string, 0, len(msg.Params))
 	for _, nick := range nicks {
-		casefoldedNick, err = CasefoldName(nick)
-		if err != nil {
-			continue
-		}
-		if iclient := server.clients.Get(casefoldedNick); iclient != nil {
-			ison = append(ison, iclient.nick)
+		if iclient := server.clients.Get(nick); iclient != nil {
+			ison = append(ison, iclient.Nick())
 		}
 	}
 
-	rb.Add(nil, server.name, RPL_ISON, client.nick, strings.Join(nicks, " "))
+	rb.Add(nil, server.name, RPL_ISON, client.nick, strings.Join(ison, " "))
 	return false
 }
 
@@ -2099,7 +2093,7 @@ func npcaHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 
 // OPER <name> <password>
 func operHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
-	if client.HasMode(modes.Operator) == true {
+	if client.HasMode(modes.Operator) {
 		rb.Add(nil, server.name, ERR_UNKNOWNERROR, client.Nick(), "OPER", client.t("You're already opered-up!"))
 		return false
 	}

--- a/irc/isupport/list.go
+++ b/irc/isupport/list.go
@@ -22,9 +22,13 @@ type List struct {
 // NewList returns a new List
 func NewList() *List {
 	var il List
+	il.Initialize()
+	return &il
+}
+
+func (il *List) Initialize() {
 	il.Tokens = make(map[string]*string)
 	il.CachedReply = make([][]string, 0)
-	return &il
 }
 
 // Add adds an RPL_ISUPPORT token to our internal list

--- a/irc/modes/modes.go
+++ b/irc/modes/modes.go
@@ -170,7 +170,7 @@ func SplitChannelMembershipPrefixes(target string) (prefixes string, name string
 			prefixes = target[:i+1]
 			name = target[i+1:]
 		default:
-			break
+			return
 		}
 	}
 

--- a/irc/semaphores.go
+++ b/irc/semaphores.go
@@ -36,5 +36,4 @@ func (serversem *ServerSemaphores) Initialize() {
 		capacity = MaxServerSemaphoreCapacity
 	}
 	serversem.ClientDestroy.Initialize(capacity)
-	return
 }

--- a/irc/server.go
+++ b/irc/server.go
@@ -24,7 +24,6 @@ import (
 	"github.com/goshuirc/irc-go/ircfmt"
 	"github.com/oragono/oragono/irc/caps"
 	"github.com/oragono/oragono/irc/connection_limits"
-	"github.com/oragono/oragono/irc/isupport"
 	"github.com/oragono/oragono/irc/logger"
 	"github.com/oragono/oragono/irc/modes"
 	"github.com/oragono/oragono/irc/sno"
@@ -73,12 +72,10 @@ type Server struct {
 	ctime               time.Time
 	dlines              *DLineManager
 	helpIndexManager    HelpIndexManager
-	isupport            *isupport.List
 	klines              *KLineManager
 	listeners           map[string]*ListenerWrapper
 	logger              *logger.Manager
 	monitorManager      *MonitorManager
-	motdLines           []string
 	name                string
 	nameCasefolded      string
 	rehashMutex         sync.Mutex // tier 4
@@ -174,13 +171,6 @@ func (config *Config) generateISupport() (err error) {
 
 	err = isupport.RegenerateCachedReply()
 	return
-}
-
-func loadChannelList(channel *Channel, list string, maskMode modes.Mode) {
-	if list == "" {
-		return
-	}
-	channel.lists[maskMode].AddAll(strings.Split(list, " "))
 }
 
 // Shutdown shuts down the server.
@@ -518,9 +508,7 @@ func (client *Client) getWhoisOf(target *Client, rb *ResponseBuffer) {
 	tLanguages := target.Languages()
 	if 0 < len(tLanguages) {
 		params := []string{cnick, tnick}
-		for _, str := range client.server.Languages().Codes(tLanguages) {
-			params = append(params, str)
-		}
+		params = append(params, client.server.Languages().Codes(tLanguages)...)
 		params = append(params, client.t("can speak these languages"))
 		rb.Add(nil, client.server.name, RPL_WHOISLANGUAGE, params...)
 	}

--- a/irc/snomanager.go
+++ b/irc/snomanager.go
@@ -52,7 +52,7 @@ func (m *SnoManager) RemoveMasks(client *Client, masks ...sno.Mask) {
 	for _, mask := range masks {
 		currentClientList := m.sendLists[mask]
 
-		if currentClientList == nil || len(currentClientList) == 0 {
+		if len(currentClientList) == 0 {
 			continue
 		}
 
@@ -70,7 +70,7 @@ func (m *SnoManager) RemoveClient(client *Client) {
 	for mask := range m.sendLists {
 		currentClientList := m.sendLists[mask]
 
-		if currentClientList == nil || len(currentClientList) == 0 {
+		if len(currentClientList) == 0 {
 			continue
 		}
 
@@ -87,7 +87,7 @@ func (m *SnoManager) Send(mask sno.Mask, content string) {
 
 	currentClientList := m.sendLists[mask]
 
-	if currentClientList == nil || len(currentClientList) == 0 {
+	if len(currentClientList) == 0 {
 		return
 	}
 

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -125,6 +125,21 @@ server:
     # this should be big enough to hold bursts of channel/direct messages
     max-sendq: 16k
 
+    # compatibility with legacy clients
+    compatibility:
+        # many clients require that the final parameter of certain messages be an
+        # RFC1459 trailing parameter, i.e., prefixed with :, whether or not this is
+        # actually required. this forces Oragono to send those parameters
+        # as trailings. this is recommended unless you're testing clients for conformance;
+        # defaults to true when unset for that reason.
+        force-trailing: true
+
+        # some clients (ZNC 1.6.x and lower, Pidgin 2.12 and lower, Adium) do not
+        # respond correctly to SASL messages with the server name as a prefix:
+        # https://github.com/znc/znc/issues/1212
+        # this works around that bug, allowing them to use SASL.
+        send-unprefixed-sasl: true
+
     # maximum number of connections per subnet
     connection-limits:
         # whether to enforce connection limits or not


### PR DESCRIPTION
1. ZNC 1.6.x is going to be common in the wild for at least another 4 years (when Ubuntu 18.04 goes EOL). Broken SASL has the potential to hold people back from adopting new practices (SASL over TLS everywhere together with strict nickname reservation). I think we should bite the bullet and add compatibility code for this. I tested this change with 18.04's package of ZNC 1.6.6+deb1ubuntu0.1.
1. I put in a switch to turn off the "force trailing" hack as well, since I was in the neighborhood.
1. This is something I've been contemplating for a while: I changed `server.Config()` to be an atomic pointer load. This is kind of silly because the saving is fairly small (on my system: from 15 nanoseconds for an uncontended rlock acquisition, to less than a nanosecond). On the other hand, it's pretty much the safest possible use case for the `unsafe` package.

If there's one of these changes in particular that you don't like, I have a bunch of development branches with probably every possible subset of these changes; I can close this PR and revive one of them instead :-)