### PR TITLE
make strict enforcement the default

### DIFF
--- a/irc/idletimer.go
+++ b/irc/idletimer.go
@@ -269,9 +269,9 @@ func (nt *NickTimer) Touch(rb *ResponseBuffer) {
 		// #449
 		for _, mSession := range nt.client.Sessions() {
 			if mSession == session {
-				rb.Add(nil, "NickServ", "NOTICE", tnick, message)
+				rb.Add(nil, nsPrefix, "NOTICE", tnick, message)
 			} else {
-				mSession.Send(nil, "NickServ", "NOTICE", tnick, message)
+				mSession.Send(nil, nsPrefix, "NOTICE", tnick, message)
 			}
 		}
 	} else if shouldRename {

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -32,7 +32,8 @@ func servCmdRequiresBouncerEnabled(config *Config) bool {
 	return config.Accounts.Bouncer.Enabled
 }
 
-var (
+const (
+	nsPrefix = "NickServ!NickServ@localhost"
 	// ZNC's nickserv module will not detect this unless it is:
 	// 1. sent with prefix `nickserv`
 	// 2. contains the string "identify"
@@ -267,7 +268,7 @@ information on the settings and their possible values, see HELP SET.`,
 func nsNotice(rb *ResponseBuffer, text string) {
 	// XXX i can't figure out how to use OragonoServices[servicename].prefix here
 	// without creating a compile-time initialization loop
-	rb.Add(nil, "NickServ!NickServ@localhost", "NOTICE", rb.target.Nick(), text)
+	rb.Add(nil, nsPrefix, "NOTICE", rb.target.Nick(), text)
 }
 
 func nsGetHandler(server *Server, client *Client, command string, params []string, rb *ResponseBuffer) {

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -303,7 +303,7 @@ accounts:
         #             already logged-in using SASL or NickServ
         #   optional: no enforcement by default, but allow users to opt in to
         #             the enforcement level of their choice
-        method: timeout
+        method: strict
 
         # allow users to set their own nickname enforcement status, e.g.,
         # to opt in to strict enforcement


### PR DESCRIPTION
This is more of a discussion ticket with an attached patch :-)

Timeout-based enforcement on darwin.network has been disruptive and unpopular: people log in, everything seems fine (they may have been missing the notice due to the lack of a fully-specified nickmask, which this PR also corrects), then they get renamed to `Guest-1c9d95f548e09a82` or something equally impenetrable.

In contrast, clients handle strict enforcement better: they respond to `433 ERR_NICKNAMEINUSE` by adding a `_` to the nickname and moving on. (Once registration completes, you can identify to nickserv and switch manually; now that we have #261 in place, there's no one in practice who needs to automate this.) So there's an interesting question about how to retrain people not to automatically believe that `shivaram_` is the same person as `shivaram`, but that's out of scope for now :-)

I tested that ZNC 1.6's nickserv module understands `Nickserv!NickServ@localhost` and responds to it.