### PR TITLE
fix #527

### DIFF
--- a/gencapdefs.py
+++ b/gencapdefs.py
@@ -204,8 +204,8 @@ package caps
 
 
     numCapabs = len(CAPDEFS)
-    bitsetLen = numCapabs // 64
-    if numCapabs % 64 > 0:
+    bitsetLen = numCapabs // 32
+    if numCapabs % 32 > 0:
         bitsetLen += 1
     print ("""
 const (

--- a/irc/caps/set.go
+++ b/irc/caps/set.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Set holds a set of enabled capabilities.
-type Set [bitsetLen]uint64
+type Set [bitsetLen]uint32
 
 // NewSet returns a new Set, with the given capabilities enabled.
 func NewSet(capabs ...Capability) *Set {

--- a/irc/modes/modes.go
+++ b/irc/modes/modes.go
@@ -7,7 +7,6 @@ package modes
 
 import (
 	"strings"
-	"sync/atomic"
 
 	"github.com/oragono/oragono/irc/utils"
 )
@@ -318,12 +317,13 @@ func ParseChannelModeChanges(params ...string) (ModeChanges, map[rune]bool) {
 }
 
 // ModeSet holds a set of modes.
-type ModeSet [1]uint64
+type ModeSet [2]uint32
 
 // valid modes go from 65 ('A') to 122 ('z'), making at most 58 possible values;
-// subtract 65 from the mode value and use that bit of the uint64 to represent it
+// subtract 65 from the mode value and use that bit of the uint32 to represent it
 const (
-	minMode = 65 // 'A'
+	minMode = 65  // 'A'
+	maxMode = 122 // 'z'
 )
 
 // returns a pointer to a new ModeSet
@@ -357,11 +357,10 @@ func (set *ModeSet) AllModes() (result []Mode) {
 		return
 	}
 
-	block := atomic.LoadUint64(&set[0])
-	var i uint
-	for i = 0; i < 64; i++ {
-		if block&(1<<i) != 0 {
-			result = append(result, Mode(minMode+i))
+	var i Mode
+	for i = minMode; i <= maxMode; i++ {
+		if set.HasMode(i) {
+			result = append(result, i)
 		}
 	}
 	return

--- a/irc/modes/modes_test.go
+++ b/irc/modes/modes_test.go
@@ -77,6 +77,16 @@ func TestSetMode(t *testing.T) {
 	}
 }
 
+func TestModeString(t *testing.T) {
+	set := NewModeSet()
+	set.SetMode('A', true)
+	set.SetMode('z', true)
+
+	if modeString := set.String(); !(modeString == "Az" || modeString == "Za") {
+		t.Errorf("unexpected modestring: %s", modeString)
+	}
+}
+
 func TestNilReceivers(t *testing.T) {
 	set := NewModeSet()
 	set = nil
@@ -111,5 +121,18 @@ func TestHighestChannelUserMode(t *testing.T) {
 	set = nil
 	if set.HighestChannelUserMode() != Mode(0) {
 		t.Errorf("nil modeset should have the zero mode as highest channel-user mode")
+	}
+}
+
+func BenchmarkModeString(b *testing.B) {
+	set := NewModeSet()
+	set.SetMode('A', true)
+	set.SetMode('N', true)
+	set.SetMode('b', true)
+	set.SetMode('i', true)
+	set.SetMode('x', true)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = set.String()
 	}
 }

--- a/irc/utils/bitset.go
+++ b/irc/utils/bitset.go
@@ -5,28 +5,28 @@ package utils
 
 import "sync/atomic"
 
-// Library functions for lock-free bitsets, typically (constant-sized) arrays of uint64.
+// Library functions for lock-free bitsets, typically (constant-sized) arrays of uint32.
 // For examples of use, see caps.Set and modes.ModeSet; the array has to be converted to a
 // slice to use these functions.
 
 // BitsetGet returns whether a given bit of the bitset is set.
-func BitsetGet(set []uint64, position uint) bool {
-	idx := position / 64
-	bit := position % 64
-	block := atomic.LoadUint64(&set[idx])
+func BitsetGet(set []uint32, position uint) bool {
+	idx := position / 32
+	bit := position % 32
+	block := atomic.LoadUint32(&set[idx])
 	return (block & (1 << bit)) != 0
 }
 
 // BitsetSet sets a given bit of the bitset to 0 or 1, returning whether it changed.
-func BitsetSet(set []uint64, position uint, on bool) (changed bool) {
-	idx := position / 64
-	bit := position % 64
+func BitsetSet(set []uint32, position uint, on bool) (changed bool) {
+	idx := position / 32
+	bit := position % 32
 	addr := &set[idx]
-	var mask uint64
+	var mask uint32
 	mask = 1 << bit
 	for {
-		current := atomic.LoadUint64(addr)
-		var desired uint64
+		current := atomic.LoadUint32(addr)
+		var desired uint32
 		if on {
 			desired = current | mask
 		} else {
@@ -34,7 +34,7 @@ func BitsetSet(set []uint64, position uint, on bool) (changed bool) {
 		}
 		if current == desired {
 			return false
-		} else if atomic.CompareAndSwapUint64(addr, current, desired) {
+		} else if atomic.CompareAndSwapUint32(addr, current, desired) {
 			return true
 		}
 	}
@@ -44,9 +44,9 @@ func BitsetSet(set []uint64, position uint, on bool) (changed bool) {
 // This has false positives under concurrent modification (i.e., it can return true
 // even though w.r.t. the sequence of atomic modifications, there was no point at
 // which the bitset was completely empty), but that's not how we're using this method.
-func BitsetEmpty(set []uint64) (empty bool) {
+func BitsetEmpty(set []uint32) (empty bool) {
 	for i := 0; i < len(set); i++ {
-		if atomic.LoadUint64(&set[i]) != 0 {
+		if atomic.LoadUint32(&set[i]) != 0 {
 			return false
 		}
 	}
@@ -56,14 +56,14 @@ func BitsetEmpty(set []uint64) (empty bool) {
 // BitsetUnion modifies `set` to be the union of `set` and `other`.
 // This has race conditions in that we don't necessarily get a single
 // consistent view of `other` across word boundaries.
-func BitsetUnion(set []uint64, other []uint64) {
+func BitsetUnion(set []uint32, other []uint32) {
 	for i := 0; i < len(set); i++ {
 		for {
 			ourAddr := &set[i]
-			ourBlock := atomic.LoadUint64(ourAddr)
-			otherBlock := atomic.LoadUint64(&other[i])
+			ourBlock := atomic.LoadUint32(ourAddr)
+			otherBlock := atomic.LoadUint32(&other[i])
 			newBlock := ourBlock | otherBlock
-			if atomic.CompareAndSwapUint64(ourAddr, ourBlock, newBlock) {
+			if atomic.CompareAndSwapUint32(ourAddr, ourBlock, newBlock) {
 				break
 			}
 		}
@@ -72,23 +72,23 @@ func BitsetUnion(set []uint64, other []uint64) {
 
 // BitsetCopy copies the contents of `other` over `set`.
 // Similar caveats about race conditions as with `BitsetUnion` apply.
-func BitsetCopy(set []uint64, other []uint64) {
+func BitsetCopy(set []uint32, other []uint32) {
 	for i := 0; i < len(set); i++ {
-		data := atomic.LoadUint64(&other[i])
-		atomic.StoreUint64(&set[i], data)
+		data := atomic.LoadUint32(&other[i])
+		atomic.StoreUint32(&set[i], data)
 	}
 }
 
 // BitsetSubtract modifies `set` to subtract the contents of `other`.
 // Similar caveats about race conditions as with `BitsetUnion` apply.
-func BitsetSubtract(set []uint64, other []uint64) {
+func BitsetSubtract(set []uint32, other []uint32) {
 	for i := 0; i < len(set); i++ {
 		for {
 			ourAddr := &set[i]
-			ourBlock := atomic.LoadUint64(ourAddr)
-			otherBlock := atomic.LoadUint64(&other[i])
+			ourBlock := atomic.LoadUint32(ourAddr)
+			otherBlock := atomic.LoadUint32(&other[i])
 			newBlock := ourBlock & (^otherBlock)
-			if atomic.CompareAndSwapUint64(ourAddr, ourBlock, newBlock) {
+			if atomic.CompareAndSwapUint32(ourAddr, ourBlock, newBlock) {
 				break
 			}
 		}

--- a/irc/utils/bitset_test.go
+++ b/irc/utils/bitset_test.go
@@ -5,7 +5,7 @@ package utils
 
 import "testing"
 
-type testBitset [2]uint64
+type testBitset [4]uint32
 
 func TestSets(t *testing.T) {
 	var t1 testBitset


### PR DESCRIPTION
Passes irctest on both amd64 and x86-32. No appreciable change in the basic get/set benchmark in the caps package.