### PR TITLE
fix #380

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -476,7 +476,7 @@ To unset this mode:
 
 ### +s - Secret
 
-If this mode is set, it means that your channel should be marked as 'secret'. Your channel won't show up in `/LIST` or `/WHOIS`.
+If this mode is set, it means that your channel should be marked as 'secret'. Your channel won't show up in `/LIST` or `/WHOIS`, and non-members won't be able to see its members with `/NAMES` or `/WHO`.
 
 To set this mode:
 


### PR DESCRIPTION
The second commit implements the strict behavior where channels after the first are ignored. I don't have strong feelings about this so I'm definitely open to reverting it, or removing it.