### PR TITLE
fix #537

### DIFF
--- a/irc/config.go
+++ b/irc/config.go
@@ -320,7 +320,8 @@ type Config struct {
 	Channels struct {
 		DefaultModes         *string `yaml:"default-modes"`
 		defaultModes         modes.Modes
-		MaxChannelsPerClient int `yaml:"max-channels-per-client"`
+		MaxChannelsPerClient int  `yaml:"max-channels-per-client"`
+		OpOnlyCreation       bool `yaml:"operator-only-creation"`
 		Registration         ChannelRegistrationConfig
 	}
 

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -368,6 +368,10 @@ channels:
     # how many channels can a client be in at once?
     max-channels-per-client: 100
 
+    # if this is true, new channels can only be created by operators with the
+    # `chanreg` operator capability
+    operator-only-creation: false
+
     # channel registration - requires an account
     registration:
         # can users register new channels?


### PR DESCRIPTION
As usual, this is more readable with `-w`.