### PR TITLE
remove m -> rn mapping

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -62,11 +62,11 @@
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
-  digest = "1:7caf3ea977a13cd8b9a2e1ecef1ccaa8e38f831b4f6ffcb8bd0aa909c48afb3a"
+  digest = "1:e7de6e4830c9d4fe1463c09a2ee15ec3eb9455c2ea916044675c413e8a9c6608"
   name = "github.com/oragono/confusables"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d5dd03409482fae2457f0742be22782890f720c2"
+  revision = "fe1cf31a24b01cac37194669863df51713e08e54"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,7 +50,7 @@
   name = "github.com/oragono/go-ident"
 
 [[constraint]]
-  revision = "d5dd03409482fae2457f0742be22782890f720c2"
+  revision = "fe1cf31a24b01cac37194669863df51713e08e54"
   name = "github.com/oragono/confusables"
 
 [[constraint]]

--- a/irc/strings.go
+++ b/irc/strings.go
@@ -148,7 +148,7 @@ func Skeleton(name string) (string, error) {
 	// same as PRECIS:
 	name = width.Fold.String(name)
 
-	name = confusables.Skeleton(name)
+	name = confusables.SkeletonTweaked(name)
 
 	// internationalized lowercasing for skeletons; this is much more lenient than
 	// Casefold. In particular, skeletons are expected to mix scripts (which may

--- a/irc/strings_test.go
+++ b/irc/strings_test.go
@@ -153,8 +153,8 @@ func TestSkeleton(t *testing.T) {
 		return skel
 	}
 
-	if skeleton("warning") != skeleton("waming") {
-		t.Errorf("i give up, Oragono should consider rn confusable with m")
+	if skeleton("warning") == skeleton("waming") {
+		t.Errorf("Oragono shouldn't consider rn confusable with m")
 	}
 
 	if skeleton("Phi|ip") != "philip" {
@@ -165,7 +165,7 @@ func TestSkeleton(t *testing.T) {
 		t.Errorf("fullwidth characters should skeletonize to plain old ascii characters")
 	}
 
-	if skeleton("ＳＭＴ") != "smt" {
+	if skeleton("ＳＭＴ") != skeleton("smt") {
 		t.Errorf("after skeletonizing, we should casefold")
 	}
 


### PR DESCRIPTION
Sorry to be second-guessing this AGAIN but the m -> rn thing has been bothering me; it seems like the most likely to interfere with legitimate use (although it's still extremely unlikely).

"Purely alphabetic lowercase ASCII identifiers do not collide with each other" seems right to me.