### PR TITLE
fix #526

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1638,14 +1638,7 @@ func listHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 
 // LUSERS [<mask> [<server>]]
 func lusersHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
-	//TODO(vegax87) Fix network statistics and additional parameters
-	totalCount, invisibleCount, operCount := server.stats.GetStats()
-
-	rb.Add(nil, server.name, RPL_LUSERCLIENT, client.nick, fmt.Sprintf(client.t("There are %[1]d users and %[2]d invisible on %[3]d server(s)"), totalCount-invisibleCount, invisibleCount, 1))
-	rb.Add(nil, server.name, RPL_LUSEROP, client.nick, strconv.Itoa(operCount), client.t("IRC Operators online"))
-	rb.Add(nil, server.name, RPL_LUSERCHANNELS, client.nick, strconv.Itoa(server.channels.Len()), client.t("channels formed"))
-	rb.Add(nil, server.name, RPL_LUSERME, client.nick, fmt.Sprintf(client.t("I have %[1]d clients and %[2]d servers"), totalCount, 1))
-
+	server.Lusers(client, rb)
 	return false
 }
 
@@ -2582,7 +2575,7 @@ func userhostHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *
 // VERSION
 func versionHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
 	rb.Add(nil, server.name, RPL_VERSION, client.nick, Ver, server.name)
-	client.RplISupport(rb)
+	server.RplISupport(client, rb)
 	return false
 }
 

--- a/irc/languages/languages.go
+++ b/irc/languages/languages.go
@@ -164,6 +164,11 @@ func (lm *Manager) Count() int {
 	return len(lm.Languages)
 }
 
+// Enabled returns whether translation is enabled.
+func (lm *Manager) Enabled() bool {
+	return len(lm.translations) != 0
+}
+
 // Translators returns the languages we have and the translators.
 func (lm *Manager) Translators() []string {
 	var tlist sort.StringSlice

--- a/irc/numerics.go
+++ b/irc/numerics.go
@@ -50,6 +50,8 @@ const (
 	RPL_TRACELOG                  = "261"
 	RPL_TRACEEND                  = "262"
 	RPL_TRYAGAIN                  = "263"
+	RPL_LOCALUSERS                = "265"
+	RPL_GLOBALUSERS               = "266"
 	RPL_WHOISCERTFP               = "276"
 	RPL_AWAY                      = "301"
 	RPL_USERHOST                  = "302"


### PR DESCRIPTION
Also a lock-free path for `client.t()` when translations are disabled.