### PR TITLE
refactor /HELP for services

### DIFF
--- a/irc/chanserv.go
+++ b/irc/chanserv.go
@@ -17,13 +17,7 @@ import (
 	"github.com/oragono/oragono/irc/sno"
 )
 
-const chanservHelp = `ChanServ lets you register and manage channels.
-
-To see in-depth help for a specific ChanServ command, try:
-    $b/CS HELP <command>$b
-
-Here are the commands you can use:
-%s`
+const chanservHelp = `ChanServ lets you register and manage channels.`
 
 func chanregEnabled(config *Config) bool {
 	return config.Channels.Registration.Enabled

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1091,7 +1091,7 @@ Get an explanation of <argument>, or "index" for a list of help topics.`), rb)
 
 	if exists && (!helpHandler.oper || (helpHandler.oper && client.HasMode(modes.Operator))) {
 		if helpHandler.textGenerator != nil {
-			client.sendHelp(strings.ToUpper(argument), client.t(helpHandler.textGenerator(client)), rb)
+			client.sendHelp(strings.ToUpper(argument), helpHandler.textGenerator(client), rb)
 		} else {
 			client.sendHelp(strings.ToUpper(argument), client.t(helpHandler.text), rb)
 		}

--- a/irc/help.go
+++ b/irc/help.go
@@ -136,22 +136,12 @@ Used in capability negotiation. See the IRCv3 specs for more info:
 http://ircv3.net/specs/core/capability-negotiation-3.1.html
 http://ircv3.net/specs/core/capability-negotiation-3.2.html`,
 	},
-	"chanserv": {
-		text: `CHANSERV <subcommand> [params]
-
-ChanServ controls channel registrations.`,
-	},
 	"chathistory": {
 		text: `CHATHISTORY [params]
 
 CHATHISTORY is an experimental history replay command. See these documents:
 https://github.com/MuffinMedic/ircv3-specifications/blob/chathistory/extensions/chathistory.md
 https://gist.github.com/DanielOaks/c104ad6e8759c01eb5c826d627caf80d`,
-	},
-	"cs": {
-		text: `CS <subcommand> [params]
-
-ChanServ controls channel registrations.`,
 	},
 	"debug": {
 		oper: true,
@@ -212,18 +202,6 @@ Replay message history. <target> can be a channel name, "me" to replay direct
 message history, or a nickname to replay another client's direct message
 history (they must be logged into the same account as you). At most [limit]
 messages will be replayed.`,
-	},
-	"hostserv": {
-		text: `HOSTSERV <command> [params]
-
-HostServ lets you manage your vhost (a string displayed in place of your
-real hostname).`,
-	},
-	"hs": {
-		text: `HS <command> [params]
-
-HostServ lets you manage your vhost (a string displayed in place of your
-real hostname).`,
 	},
 	"info": {
 		text: `INFO
@@ -351,11 +329,6 @@ view the channel membership prefixes supported by this server, see the help for
 
 Sets your nickname to the new given one.`,
 	},
-	"nickserv": {
-		text: `NICKSERV <subcommand> [params]
-
-NickServ controls accounts and user registrations.`,
-	},
 	"notice": {
 		text: `NOTICE <target>{,<target>} <text to be sent>
 
@@ -374,11 +347,6 @@ Requires the roleplay mode (+E) to be set on the target.`,
 The NPC command is used to send an action to the target as the source.
 
 Requires the roleplay mode (+E) to be set on the target.`,
-	},
-	"ns": {
-		text: `NS <subcommand> [params]
-
-NickServ controls accounts and user registrations.`,
 	},
 	"oper": {
 		text: `OPER <name> <password>

--- a/irc/hostserv.go
+++ b/irc/hostserv.go
@@ -11,13 +11,7 @@ import (
 )
 
 const hostservHelp = `HostServ lets you manage your vhost (i.e., the string displayed
-in place of your client's hostname/IP).
-
-To see in-depth help for a specific HostServ command, try:
-    $b/HS HELP <command>$b
-
-Here are the commands you can use:
-%s`
+in place of your client's hostname/IP).`
 
 var (
 	errVHostBadCharacters = errors.New("Vhost contains prohibited characters")

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -41,13 +41,7 @@ const (
 	nsTimeoutNotice = `This nickname is reserved. Please login within %v (using $b/msg NickServ IDENTIFY <password>$b or SASL), or switch to a different nickname.`
 )
 
-const nickservHelp = `NickServ lets you register and login to an account.
-
-To see in-depth help for a specific NickServ command, try:
-    $b/NS HELP <command>$b
-
-Here are the commands you can use:
-%s`
+const nickservHelp = `NickServ lets you register and log into an account.`
 
 var (
 	nickservCommands = map[string]*serviceCommand{


### PR DESCRIPTION
#587 except not broken.

1. DRY "banner" descriptions of each services
2. `/HELP NICKSERV` now refers the user to `/NICKSERV HELP`, etc.
3. Fix double translation of `textGenerator` output