### PR TITLE
remove obsolete consistency check

### DIFF
--- a/irc/config.go
+++ b/irc/config.go
@@ -797,19 +797,6 @@ func LoadConfig(filename string) (config *Config, err error) {
 		}
 	}
 
-	for _, listenAddress := range config.Server.TorListeners.Listeners {
-		found := false
-		for _, configuredListener := range config.Server.Listen {
-			if listenAddress == configuredListener {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, fmt.Errorf("%s is configured as a Tor listener, but is not in server.listen", listenAddress)
-		}
-	}
-
 	err = config.prepareListeners()
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare listeners: %v", err)


### PR DESCRIPTION
tor-listeners.listeners was checked against listen,
but listen is obsolete now, so config load would fail
on a config that used the new style `listeners` instead of
`listen` --- unless tor-listeners.listeners was empty, which
it should be under the new style, but there's no need to enforce
that