### PR TITLE
fix #331

### DIFF
--- a/irc/client_lookup_set.go
+++ b/irc/client_lookup_set.go
@@ -18,20 +18,6 @@ import (
 	"sync"
 )
 
-// ExpandUserHost takes a userhost, and returns an expanded version.
-func ExpandUserHost(userhost string) (expanded string) {
-	expanded = userhost
-	// fill in missing wildcards for nicks
-	//TODO(dan): this would fail with dan@lol, fix that.
-	if !strings.Contains(expanded, "!") {
-		expanded += "!*"
-	}
-	if !strings.Contains(expanded, "@") {
-		expanded += "@*"
-	}
-	return
-}
-
 // ClientManager keeps track of clients by nick, enforcing uniqueness of casefolded nicks
 type ClientManager struct {
 	sync.RWMutex // tier 2
@@ -241,7 +227,7 @@ func (clients *ClientManager) AllWithCapsNotify(capabs ...caps.Capability) (sess
 func (clients *ClientManager) FindAll(userhost string) (set ClientSet) {
 	set = make(ClientSet)
 
-	userhost, err := Casefold(ExpandUserHost(userhost))
+	userhost, err := CanonicalizeMaskWildcard(userhost)
 	if err != nil {
 		return set
 	}

--- a/irc/strings_test.go
+++ b/irc/strings_test.go
@@ -188,3 +188,27 @@ func TestSkeleton(t *testing.T) {
 	// should not raise an error:
 	skeleton("けらんぐ")
 }
+
+func TestCanonicalizeMaskWildcard(t *testing.T) {
+	tester := func(input, expected string, expectedErr error) {
+		out, err := CanonicalizeMaskWildcard(input)
+		if out != expected {
+			t.Errorf("expected %s to canonicalize to %s, instead %s", input, expected, out)
+		}
+		if err != expectedErr {
+			t.Errorf("expected %s to produce error %v, instead %v", input, expectedErr, err)
+		}
+	}
+
+	tester("shivaram", "shivaram!*@*", nil)
+	tester("slingamn!shivaram", "slingamn!shivaram@*", nil)
+	tester("ברוך", "ברוך!*@*", nil)
+	tester("hacker@monad.io", "*!hacker@monad.io", nil)
+	tester("Evan!hacker@monad.io", "evan!hacker@monad.io", nil)
+	tester("РОТАТО!Potato", "ротато!potato@*", nil)
+	tester("tkadich*", "tkadich*!*@*", nil)
+	tester("SLINGAMN!*@*", "slingamn!*@*", nil)
+	tester("slingamn!shivaram*", "slingamn!shivaram*@*", nil)
+	tester("slingamn!", "slingamn!*@*", nil)
+	tester("shivaram*@good-fortune", "*!shivaram*@good-fortune", nil)
+}


### PR DESCRIPTION
We were trying to run `Casefold` against the expanded mask wildcard (like `ברוך!*@*`). This would fail due to the bidi rule.

You still can't use wildcards with non-ASCII nicks for this reason, but this branch will at least fix non-wildcard uses.