### PR TITLE
Assorted fixes

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -1048,10 +1048,9 @@ func (channel *Channel) SendSplitMessage(command string, minPrefixMode modes.Mod
 }
 
 func (channel *Channel) applyModeToMember(client *Client, mode modes.Mode, op modes.ModeOp, nick string, rb *ResponseBuffer) (result *modes.ModeChange) {
-	casefoldedName, err := CasefoldName(nick)
-	target := channel.server.clients.Get(casefoldedName)
-	if err != nil || target == nil {
-		rb.Add(nil, client.server.name, ERR_NOSUCHNICK, client.Nick(), nick, client.t("No such nick"))
+	target := channel.server.clients.Get(nick)
+	if target == nil {
+		rb.Add(nil, client.server.name, ERR_NOSUCHNICK, client.Nick(), utils.SafeErrorParam(nick), client.t("No such nick"))
 		return nil
 	}
 

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -684,13 +684,18 @@ func (channel *Channel) Part(client *Client, message string, rb *ResponseBuffer)
 	splitMessage := utils.MakeSplitMessage(message, true)
 
 	details := client.Details()
-	for _, member := range channel.Members() {
-		member.sendFromClientInternal(false, splitMessage.Time, splitMessage.Msgid, details.nickMask, details.accountName, nil, "PART", chname, message)
+	params := make([]string, 1, 2)
+	params[0] = chname
+	if message != "" {
+		params = append(params, message)
 	}
-	rb.AddFromClient(splitMessage.Time, splitMessage.Msgid, details.nickMask, details.accountName, nil, "PART", chname, message)
+	for _, member := range channel.Members() {
+		member.sendFromClientInternal(false, splitMessage.Time, splitMessage.Msgid, details.nickMask, details.accountName, nil, "PART", params...)
+	}
+	rb.AddFromClient(splitMessage.Time, splitMessage.Msgid, details.nickMask, details.accountName, nil, "PART", params...)
 	for _, session := range client.Sessions() {
 		if session != rb.session {
-			session.sendFromClientInternal(false, splitMessage.Time, splitMessage.Msgid, details.nickMask, details.accountName, nil, "PART", chname, message)
+			session.sendFromClientInternal(false, splitMessage.Time, splitMessage.Msgid, details.nickMask, details.accountName, nil, "PART", params...)
 		}
 	}
 

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1234,9 +1234,8 @@ func inviteHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Re
 		return false
 	}
 
-	casefoldedChannelName, err := CasefoldChannel(channelName)
-	channel := server.channels.Get(casefoldedChannelName)
-	if err != nil || channel == nil {
+	channel := server.channels.Get(channelName)
+	if channel == nil {
 		rb.Add(nil, server.name, ERR_NOSUCHCHANNEL, client.nick, utils.SafeErrorParam(channelName), client.t("No such channel"))
 		return false
 	}
@@ -1675,9 +1674,7 @@ func lusersHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Re
 
 // MODE <target> [<modestring> [<mode arguments>...]]
 func modeHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
-	_, errChan := CasefoldChannel(msg.Params[0])
-
-	if errChan == nil {
+	if 0 < len(msg.Params[0]) && msg.Params[0][0] == '#' {
 		return cmodeHandler(server, client, msg, rb)
 	}
 	return umodeHandler(server, client, msg, rb)
@@ -1685,10 +1682,9 @@ func modeHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 
 // MODE <channel> [<modestring> [<mode arguments>...]]
 func cmodeHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
-	channelName, err := CasefoldChannel(msg.Params[0])
-	channel := server.channels.Get(channelName)
+	channel := server.channels.Get(msg.Params[0])
 
-	if err != nil || channel == nil {
+	if channel == nil {
 		rb.Add(nil, server.name, ERR_NOSUCHCHANNEL, client.nick, utils.SafeErrorParam(msg.Params[0]), client.t("No such channel"))
 		return false
 	}
@@ -1748,12 +1744,9 @@ func cmodeHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Res
 // MODE <client> [<modestring> [<mode arguments>...]]
 func umodeHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
 	cDetails := client.Details()
-	nickname, err := CasefoldName(msg.Params[0])
-	target := server.clients.Get(nickname)
-	if err != nil || target == nil {
-		if len(msg.Params[0]) > 0 {
-			rb.Add(nil, server.name, ERR_NOSUCHNICK, cDetails.nick, msg.Params[0], client.t("No such nick"))
-		}
+	target := server.clients.Get(msg.Params[0])
+	if target == nil {
+		rb.Add(nil, server.name, ERR_NOSUCHNICK, cDetails.nick, utils.SafeErrorParam(msg.Params[0]), client.t("No such nick"))
 		return false
 	}
 
@@ -2459,12 +2452,9 @@ func timeHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 
 // TOPIC <channel> [<topic>]
 func topicHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
-	name, err := CasefoldChannel(msg.Params[0])
-	channel := server.channels.Get(name)
-	if err != nil || channel == nil {
-		if len(msg.Params[0]) > 0 {
-			rb.Add(nil, server.name, ERR_NOSUCHCHANNEL, client.nick, utils.SafeErrorParam(msg.Params[0]), client.t("No such channel"))
-		}
+	channel := server.channels.Get(msg.Params[0])
+	if channel == nil {
+		rb.Add(nil, server.name, ERR_NOSUCHCHANNEL, client.nick, utils.SafeErrorParam(msg.Params[0]), client.t("No such channel"))
 		return false
 	}
 

--- a/irc/nickname.go
+++ b/irc/nickname.go
@@ -49,7 +49,7 @@ func performNickChange(server *Server, client *Client, target *Client, session *
 	} else if err == errNicknameReserved {
 		rb.Add(nil, server.name, ERR_NICKNAMEINUSE, currentNick, nickname, client.t("Nickname is reserved by a different account"))
 	} else if err == errNicknameInvalid {
-		rb.Add(nil, server.name, ERR_ERRONEUSNICKNAME, currentNick, nickname, client.t("Erroneous nickname"))
+		rb.Add(nil, server.name, ERR_ERRONEUSNICKNAME, currentNick, utils.SafeErrorParam(nickname), client.t("Erroneous nickname"))
 	} else if err != nil {
 		rb.Add(nil, server.name, ERR_UNKNOWNERROR, currentNick, "NICK", fmt.Sprintf(client.t("Could not set or change nickname: %s"), err.Error()))
 	}

--- a/irc/types.go
+++ b/irc/types.go
@@ -7,12 +7,14 @@ package irc
 
 import "github.com/oragono/oragono/irc/modes"
 
+type empty struct{}
+
 // ClientSet is a set of clients.
-type ClientSet map[*Client]bool
+type ClientSet map[*Client]empty
 
 // Add adds the given client to this set.
 func (clients ClientSet) Add(client *Client) {
-	clients[client] = true
+	clients[client] = empty{}
 }
 
 // Remove removes the given client from this set.
@@ -22,7 +24,8 @@ func (clients ClientSet) Remove(client *Client) {
 
 // Has returns true if the given client is in this set.
 func (clients ClientSet) Has(client *Client) bool {
-	return clients[client]
+	_, ok := clients[client]
+	return ok
 }
 
 // MemberSet is a set of members with modes.

--- a/irc/utils/args.go
+++ b/irc/utils/args.go
@@ -54,3 +54,12 @@ func StringToBool(str string) (result bool, err error) {
 	}
 	return
 }
+
+// Checks that a parameter can be passed as a non-trailing, and returns "*"
+// if it can't. See #697.
+func SafeErrorParam(param string) string {
+	if param == "" || param[0] == ':' || strings.IndexByte(param, ' ') != -1 {
+		return "*"
+	}
+	return param
+}

--- a/irc/utils/args_test.go
+++ b/irc/utils/args_test.go
@@ -21,3 +21,12 @@ func TestStringToBool(t *testing.T) {
 	val, err = StringToBool("default")
 	assertEqual(err, ErrInvalidParams, t)
 }
+
+func TestSafeErrorParam(t *testing.T) {
+	assertEqual(SafeErrorParam("hi"), "hi", t)
+	assertEqual(SafeErrorParam("#hi"), "#hi", t)
+	assertEqual(SafeErrorParam("#hi there"), "*", t)
+	assertEqual(SafeErrorParam(":"), "*", t)
+	assertEqual(SafeErrorParam("#hi:there"), "#hi:there", t)
+	assertEqual(SafeErrorParam(""), "*", t)
+}


### PR DESCRIPTION
* Fix #679 (borked reply to `JOIN #chan,\r\n`)
* Replace invalid error parameters with *'s in various places
* Fix PART with no message sending an empty trailing parameter to the channel
* Fix some error responses not getting labeled