### PR TITLE
implement draft/multiline

### DIFF
--- a/gencapdefs.py
+++ b/gencapdefs.py
@@ -177,6 +177,12 @@ CAPDEFS = [
         url="https://oragono.io/nope",
         standard="Oragono vendor",
     ),
+    CapDef(
+        identifier="Multiline",
+        name="draft/multiline",
+        url="https://github.com/ircv3/ircv3-specifications/pull/398",
+        standard="Proposed IRCv3",
+    ),
 ]
 
 def validate_defs():

--- a/irc/caps/constants.go
+++ b/irc/caps/constants.go
@@ -55,6 +55,10 @@ const (
 	// LabelTagName is the tag name used for the labeled-response spec.
 	// https://ircv3.net/specs/extensions/labeled-response.html
 	LabelTagName = "draft/label"
+	// More draft names associated with draft/multiline:
+	MultilineBatchType = "draft/multiline"
+	MultilineConcatTag = "draft/multiline-concat"
+	MultilineFmsgidTag = "draft/fmsgid"
 )
 
 func init() {

--- a/irc/caps/defs.go
+++ b/irc/caps/defs.go
@@ -7,7 +7,7 @@ package caps
 
 const (
 	// number of recognized capabilities:
-	numCapabs = 27
+	numCapabs = 28
 	// length of the uint64 array that represents the bitset:
 	bitsetLen = 1
 )
@@ -52,6 +52,10 @@ const (
 	// Languages is the proposed IRCv3 capability named "draft/languages":
 	// https://gist.github.com/DanielOaks/8126122f74b26012a3de37db80e4e0c6
 	Languages Capability = iota
+
+	// Multiline is the Proposed IRCv3 capability named "draft/multiline":
+	// https://github.com/ircv3/ircv3-specifications/pull/398
+	Multiline Capability = iota
 
 	// Rename is the proposed IRCv3 capability named "draft/rename":
 	// https://github.com/SaberUK/ircv3-specifications/blob/rename/extensions/rename.md
@@ -135,6 +139,7 @@ var (
 		"draft/event-playback",
 		"draft/labeled-response-0.2",
 		"draft/languages",
+		"draft/multiline",
 		"draft/rename",
 		"draft/resume-0.5",
 		"draft/setname",

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -1042,7 +1042,7 @@ func (channel *Channel) CanSpeak(client *Client) bool {
 	return true
 }
 
-func msgCommandToHistType(server *Server, command string) (history.ItemType, error) {
+func msgCommandToHistType(command string) (history.ItemType, error) {
 	switch command {
 	case "PRIVMSG":
 		return history.Privmsg, nil
@@ -1051,13 +1051,23 @@ func msgCommandToHistType(server *Server, command string) (history.ItemType, err
 	case "TAGMSG":
 		return history.Tagmsg, nil
 	default:
-		server.logger.Error("internal", "unrecognized messaging command", command)
 		return history.ItemType(0), errInvalidParams
 	}
 }
 
+func histTypeToMsgCommand(t history.ItemType) string {
+	switch t {
+	case history.Notice:
+		return "NOTICE"
+	case history.Tagmsg:
+		return "TAGMSG"
+	default:
+		return "PRIVMSG"
+	}
+}
+
 func (channel *Channel) SendSplitMessage(command string, minPrefixMode modes.Mode, clientOnlyTags map[string]string, client *Client, message utils.SplitMessage, rb *ResponseBuffer) {
-	histType, err := msgCommandToHistType(channel.server, command)
+	histType, err := msgCommandToHistType(command)
 	if err != nil {
 		return
 	}

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -1055,17 +1055,6 @@ func msgCommandToHistType(command string) (history.ItemType, error) {
 	}
 }
 
-func histTypeToMsgCommand(t history.ItemType) string {
-	switch t {
-	case history.Notice:
-		return "NOTICE"
-	case history.Tagmsg:
-		return "TAGMSG"
-	default:
-		return "PRIVMSG"
-	}
-}
-
 func (channel *Channel) SendSplitMessage(command string, minPrefixMode modes.Mode, clientOnlyTags map[string]string, client *Client, message utils.SplitMessage, rb *ResponseBuffer) {
 	histType, err := msgCommandToHistType(command)
 	if err != nil {

--- a/irc/client_test.go
+++ b/irc/client_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2019 Shivaram Lingamneni
+// released under the MIT license
+
+package irc
+
+import (
+	"testing"
+)
+
+func TestGenerateBatchID(t *testing.T) {
+	var session Session
+	s := make(StringSet)
+
+	count := 100000
+	for i := 0; i < count; i++ {
+		s.Add(session.generateBatchID())
+	}
+
+	if len(s) != count {
+		t.Error("duplicate batch ID detected")
+	}
+}
+
+func BenchmarkGenerateBatchID(b *testing.B) {
+	var session Session
+	for i := 0; i < b.N; i++ {
+		session.generateBatchID()
+	}
+}

--- a/irc/config.go
+++ b/irc/config.go
@@ -234,6 +234,10 @@ type Limits struct {
 	TopicLen             int           `yaml:"topiclen"`
 	WhowasEntries        int           `yaml:"whowas-entries"`
 	RegistrationMessages int           `yaml:"registration-messages"`
+	Multiline            struct {
+		MaxBytes int `yaml:"max-bytes"`
+		MaxLines int `yaml:"max-lines"`
+	}
 }
 
 // STSConfig controls the STS configuration/
@@ -683,6 +687,18 @@ func LoadConfig(filename string) (config *Config, err error) {
 		config.Server.capValues[caps.MaxLine] = strconv.Itoa(config.Limits.LineLen.Rest)
 	}
 
+	if config.Limits.Multiline.MaxBytes <= 0 {
+		config.Server.supportedCaps.Disable(caps.Multiline)
+	} else {
+		var multilineCapValue string
+		if config.Limits.Multiline.MaxLines == 0 {
+			multilineCapValue = fmt.Sprintf("max-bytes=%d", config.Limits.Multiline.MaxBytes)
+		} else {
+			multilineCapValue = fmt.Sprintf("max-bytes=%d,max-lines=%d", config.Limits.Multiline.MaxBytes, config.Limits.Multiline.MaxLines)
+		}
+		config.Server.capValues[caps.Multiline] = multilineCapValue
+	}
+
 	if !config.Accounts.Bouncer.Enabled {
 		config.Server.supportedCaps.Disable(caps.Bouncer)
 	}
@@ -868,4 +884,48 @@ func LoadConfig(filename string) (config *Config, err error) {
 	}
 
 	return config, nil
+}
+
+// Diff returns changes in supported caps across a rehash.
+func (config *Config) Diff(oldConfig *Config) (addedCaps, removedCaps *caps.Set) {
+	addedCaps = caps.NewSet()
+	removedCaps = caps.NewSet()
+	if oldConfig == nil {
+		return
+	}
+
+	if oldConfig.Server.capValues[caps.Languages] != config.Server.capValues[caps.Languages] {
+		// XXX updated caps get a DEL line and then a NEW line with the new value
+		addedCaps.Add(caps.Languages)
+		removedCaps.Add(caps.Languages)
+	}
+
+	if !oldConfig.Accounts.AuthenticationEnabled && config.Accounts.AuthenticationEnabled {
+		addedCaps.Add(caps.SASL)
+	} else if oldConfig.Accounts.AuthenticationEnabled && !config.Accounts.AuthenticationEnabled {
+		removedCaps.Add(caps.SASL)
+	}
+
+	if !oldConfig.Accounts.Bouncer.Enabled && config.Accounts.Bouncer.Enabled {
+		addedCaps.Add(caps.Bouncer)
+	} else if oldConfig.Accounts.Bouncer.Enabled && !config.Accounts.Bouncer.Enabled {
+		removedCaps.Add(caps.Bouncer)
+	}
+
+	if oldConfig.Limits.Multiline.MaxBytes != 0 && config.Limits.Multiline.MaxBytes == 0 {
+		removedCaps.Add(caps.Multiline)
+	} else if oldConfig.Limits.Multiline.MaxBytes == 0 && config.Limits.Multiline.MaxBytes != 0 {
+		addedCaps.Add(caps.Multiline)
+	} else if oldConfig.Limits.Multiline != config.Limits.Multiline {
+		removedCaps.Add(caps.Multiline)
+		addedCaps.Add(caps.Multiline)
+	}
+
+	if oldConfig.Server.STS.Enabled != config.Server.STS.Enabled || oldConfig.Server.capValues[caps.STS] != config.Server.capValues[caps.STS] {
+		// XXX: STS is always removed by CAP NEW sts=duration=0, not CAP DEL
+		// so the appropriate notify is always a CAP NEW; put it in addedCaps for any change
+		addedCaps.Add(caps.STS)
+	}
+
+	return
 }

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -545,10 +545,11 @@ func batchHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Res
 			histType, err := msgCommandToHistType(batch.command)
 			if err != nil {
 				histType = history.Privmsg
+				batch.command = "PRIVMSG"
 			}
 			// see previous caution about modifying ResponseBuffer.Label
 			rb.Label = batch.responseLabel
-			dispatchMessageToTarget(client, batch.tags, histType, batch.target, batch.message, rb)
+			dispatchMessageToTarget(client, batch.tags, histType, batch.command, batch.target, batch.message, rb)
 		}
 	}
 
@@ -2137,14 +2138,13 @@ func messageHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *R
 		}
 		// each target gets distinct msgids
 		splitMsg := utils.MakeSplitMessage(message, !rb.session.capabilities.Has(caps.MaxLine))
-		dispatchMessageToTarget(client, clientOnlyTags, histType, targetString, splitMsg, rb)
+		dispatchMessageToTarget(client, clientOnlyTags, histType, msg.Command, targetString, splitMsg, rb)
 	}
 	return false
 }
 
-func dispatchMessageToTarget(client *Client, tags map[string]string, histType history.ItemType, target string, message utils.SplitMessage, rb *ResponseBuffer) {
+func dispatchMessageToTarget(client *Client, tags map[string]string, histType history.ItemType, command, target string, message utils.SplitMessage, rb *ResponseBuffer) {
 	server := client.server
-	command := histTypeToMsgCommand(histType)
 
 	prefixes, target := modes.SplitChannelMembershipPrefixes(target)
 	lowestPrefix := modes.GetLowestChannelModePrefix(prefixes)

--- a/irc/help.go
+++ b/irc/help.go
@@ -121,6 +121,12 @@ http://ircv3.net/specs/extensions/sasl-3.1.html`,
 If [message] is sent, marks you away. If [message] is not sent, marks you no
 longer away.`,
 	},
+	"batch": {
+		text: `BATCH {+,-}reference-tag type [params...]
+
+BATCH initiates an IRCv3 client-to-server batch. You should never need to
+issue this command manually.`,
+	},
 	"brb": {
 		text: `BRB [message]
 

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -579,6 +579,11 @@ limits:
     # DoS / resource exhaustion attacks):
     registration-messages: 1024
 
+    # message length limits for the new multiline cap
+    multiline:
+        max-bytes: 4096 # 0 means disabled
+        max-lines: 24   # 0 means no limit
+
 # fakelag: prevents clients from spamming commands too rapidly
 fakelag:
     # whether to enforce fakelag


### PR DESCRIPTION
This implements https://github.com/ircv3/ircv3-specifications/pull/398 with fallback msgids (currently tagged `draft/fmsgid`). As usual, the diff is more readable when ignoring whitespace changes :-)

Due to security concerns, multiline is disabled unless explicitly configured in the `limits` section, although it is enabled in the new default config.

Some of the changes here ("collapsing" the outer labeled-response batch, config "diff", and the new shorter batch IDs) are useful even without multiline.