### PR TITLE
Revert "never set the certfp lookup key before verification"

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -378,6 +378,9 @@ func (am *AccountManager) Register(client *Client, account string, callbackNames
 			tx.Set(registeredTimeKey, registeredTimeStr, setOptions)
 			tx.Set(credentialsKey, credStr, setOptions)
 			tx.Set(callbackKey, callbackSpec, setOptions)
+			if certfp != "" {
+				tx.Set(certFPKey, casefoldedAccount, setOptions)
+			}
 			return nil
 		})
 	}()


### PR DESCRIPTION
This reverts commit a120cc24436a69402f95644eb5e1ef92c04148b2.

I realized the point of this is to "park" the certfp so that it can't be registered by anyone else during the verification period. This seems acceptable. You can't log in before verification because `AuthenticateByCertFP` checks the verified flag on the account.