### PR TITLE
don't check the real IP for bans on proxy-before-TLS

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -222,7 +222,10 @@ func (server *Server) RunClient(conn clientConn, proxyLine string) {
 		isBanned, banMsg = server.checkTorLimits()
 	} else {
 		realIP = utils.AddrToIP(conn.Conn.RemoteAddr())
-		isBanned, banMsg = server.checkBans(realIP)
+		// skip the ban check for k8s-style proxy-before-TLS
+		if proxyLine == "" {
+			isBanned, banMsg = server.checkBans(realIP)
+		}
 	}
 
 	if isBanned {


### PR DESCRIPTION
In the k8s PROXY-before-TLS setting, we don't know all the IPs
of the load balancers, so we can't whitelist them, so they're at
risk of being d-lined.