### PR TITLE
fix incorrect values of UTF8MAPPING for non-PRECIS casefoldings

### DIFF
--- a/irc/config.go
+++ b/irc/config.go
@@ -911,6 +911,46 @@ func LoadConfig(filename string) (config *Config, err error) {
 	return config, nil
 }
 
+// setISupport sets up our RPL_ISUPPORT reply.
+func (config *Config) generateISupport() (err error) {
+	maxTargetsString := strconv.Itoa(maxTargets)
+
+	// add RPL_ISUPPORT tokens
+	isupport := &config.Server.isupport
+	isupport.Initialize()
+	isupport.Add("AWAYLEN", strconv.Itoa(config.Limits.AwayLen))
+	isupport.Add("CASEMAPPING", "ascii")
+	isupport.Add("CHANLIMIT", fmt.Sprintf("%s:%d", chanTypes, config.Channels.MaxChannelsPerClient))
+	isupport.Add("CHANMODES", strings.Join([]string{modes.Modes{modes.BanMask, modes.ExceptMask, modes.InviteMask}.String(), "", modes.Modes{modes.UserLimit, modes.Key}.String(), modes.Modes{modes.InviteOnly, modes.Moderated, modes.NoOutside, modes.OpOnlyTopic, modes.ChanRoleplaying, modes.Secret}.String()}, ","))
+	if config.History.Enabled && config.History.ChathistoryMax > 0 {
+		isupport.Add("draft/CHATHISTORY", strconv.Itoa(config.History.ChathistoryMax))
+	}
+	isupport.Add("CHANNELLEN", strconv.Itoa(config.Limits.ChannelLen))
+	isupport.Add("CHANTYPES", chanTypes)
+	isupport.Add("ELIST", "U")
+	isupport.Add("EXCEPTS", "")
+	isupport.Add("INVEX", "")
+	isupport.Add("KICKLEN", strconv.Itoa(config.Limits.KickLen))
+	isupport.Add("MAXLIST", fmt.Sprintf("beI:%s", strconv.Itoa(config.Limits.ChanListModes)))
+	isupport.Add("MAXTARGETS", maxTargetsString)
+	isupport.Add("MODES", "")
+	isupport.Add("MONITOR", strconv.Itoa(config.Limits.MonitorEntries))
+	isupport.Add("NETWORK", config.Network.Name)
+	isupport.Add("NICKLEN", strconv.Itoa(config.Limits.NickLen))
+	isupport.Add("PREFIX", "(qaohv)~&@%+")
+	isupport.Add("RPCHAN", "E")
+	isupport.Add("RPUSER", "E")
+	isupport.Add("STATUSMSG", "~&@%+")
+	isupport.Add("TARGMAX", fmt.Sprintf("NAMES:1,LIST:1,KICK:1,WHOIS:1,USERHOST:10,PRIVMSG:%s,TAGMSG:%s,NOTICE:%s,MONITOR:", maxTargetsString, maxTargetsString, maxTargetsString))
+	isupport.Add("TOPICLEN", strconv.Itoa(config.Limits.TopicLen))
+	if config.Server.Casemapping == CasemappingPRECIS {
+		isupport.Add("UTF8MAPPING", precisUTF8MappingToken)
+	}
+
+	err = isupport.RegenerateCachedReply()
+	return
+}
+
 // Diff returns changes in supported caps across a rehash.
 func (config *Config) Diff(oldConfig *Config) (addedCaps, removedCaps *caps.Set) {
 	addedCaps = caps.NewSet()

--- a/irc/server.go
+++ b/irc/server.go
@@ -165,7 +165,7 @@ func (config *Config) generateISupport() (err error) {
 	isupport.Add("STATUSMSG", "~&@%+")
 	isupport.Add("TARGMAX", fmt.Sprintf("NAMES:1,LIST:1,KICK:1,WHOIS:1,USERHOST:10,PRIVMSG:%s,TAGMSG:%s,NOTICE:%s,MONITOR:", maxTargetsString, maxTargetsString, maxTargetsString))
 	isupport.Add("TOPICLEN", strconv.Itoa(config.Limits.TopicLen))
-	if globalCasemappingSetting == CasemappingPRECIS {
+	if config.Server.Casemapping == CasemappingPRECIS {
 		isupport.Add("UTF8MAPPING", precisUTF8MappingToken)
 	}
 

--- a/irc/server.go
+++ b/irc/server.go
@@ -133,46 +133,6 @@ func NewServer(config *Config, logger *logger.Manager) (*Server, error) {
 	return server, nil
 }
 
-// setISupport sets up our RPL_ISUPPORT reply.
-func (config *Config) generateISupport() (err error) {
-	maxTargetsString := strconv.Itoa(maxTargets)
-
-	// add RPL_ISUPPORT tokens
-	isupport := &config.Server.isupport
-	isupport.Initialize()
-	isupport.Add("AWAYLEN", strconv.Itoa(config.Limits.AwayLen))
-	isupport.Add("CASEMAPPING", "ascii")
-	isupport.Add("CHANLIMIT", fmt.Sprintf("%s:%d", chanTypes, config.Channels.MaxChannelsPerClient))
-	isupport.Add("CHANMODES", strings.Join([]string{modes.Modes{modes.BanMask, modes.ExceptMask, modes.InviteMask}.String(), "", modes.Modes{modes.UserLimit, modes.Key}.String(), modes.Modes{modes.InviteOnly, modes.Moderated, modes.NoOutside, modes.OpOnlyTopic, modes.ChanRoleplaying, modes.Secret}.String()}, ","))
-	if config.History.Enabled && config.History.ChathistoryMax > 0 {
-		isupport.Add("draft/CHATHISTORY", strconv.Itoa(config.History.ChathistoryMax))
-	}
-	isupport.Add("CHANNELLEN", strconv.Itoa(config.Limits.ChannelLen))
-	isupport.Add("CHANTYPES", chanTypes)
-	isupport.Add("ELIST", "U")
-	isupport.Add("EXCEPTS", "")
-	isupport.Add("INVEX", "")
-	isupport.Add("KICKLEN", strconv.Itoa(config.Limits.KickLen))
-	isupport.Add("MAXLIST", fmt.Sprintf("beI:%s", strconv.Itoa(config.Limits.ChanListModes)))
-	isupport.Add("MAXTARGETS", maxTargetsString)
-	isupport.Add("MODES", "")
-	isupport.Add("MONITOR", strconv.Itoa(config.Limits.MonitorEntries))
-	isupport.Add("NETWORK", config.Network.Name)
-	isupport.Add("NICKLEN", strconv.Itoa(config.Limits.NickLen))
-	isupport.Add("PREFIX", "(qaohv)~&@%+")
-	isupport.Add("RPCHAN", "E")
-	isupport.Add("RPUSER", "E")
-	isupport.Add("STATUSMSG", "~&@%+")
-	isupport.Add("TARGMAX", fmt.Sprintf("NAMES:1,LIST:1,KICK:1,WHOIS:1,USERHOST:10,PRIVMSG:%s,TAGMSG:%s,NOTICE:%s,MONITOR:", maxTargetsString, maxTargetsString, maxTargetsString))
-	isupport.Add("TOPICLEN", strconv.Itoa(config.Limits.TopicLen))
-	if config.Server.Casemapping == CasemappingPRECIS {
-		isupport.Add("UTF8MAPPING", precisUTF8MappingToken)
-	}
-
-	err = isupport.RegenerateCachedReply()
-	return
-}
-
 // Shutdown shuts down the server.
 func (server *Server) Shutdown() {
 	//TODO(dan): Make sure we disallow new nicks


### PR DESCRIPTION
This is a minor bug in #695. When a non-PRECIS casemapping was enabled, initially `UTF8MAPPING=rfc8265` would be sent in isupport, and then the first rehash would remove it with `005 -UTF8MAPPING`, when in fact it should never have been sent at all. This bug was caused by reading the global, instead of reading the appropriate member of the `Config` object itself.

To avoid getting confused again, I'm moving `Config.generateISupport` into `irc/config.go` where it belongs.