### PR TITLE
remove oragono.io/maxline-2 and fmsgid

### DIFF
--- a/gencapdefs.py
+++ b/gencapdefs.py
@@ -82,12 +82,6 @@ CAPDEFS = [
         standard="proposed IRCv3",
     ),
     CapDef(
-        identifier="MaxLine",
-        name="oragono.io/maxline-2",
-        url="https://oragono.io/maxline-2",
-        standard="Oragono-specific",
-    ),
-    CapDef(
         identifier="MessageTags",
         name="message-tags",
         url="https://ircv3.net/specs/extensions/message-tags.html",

--- a/irc/caps/constants.go
+++ b/irc/caps/constants.go
@@ -58,7 +58,6 @@ const (
 	// More draft names associated with draft/multiline:
 	MultilineBatchType = "draft/multiline"
 	MultilineConcatTag = "draft/multiline-concat"
-	MultilineFmsgidTag = "draft/fmsgid"
 )
 
 func init() {

--- a/irc/caps/defs.go
+++ b/irc/caps/defs.go
@@ -7,7 +7,7 @@ package caps
 
 const (
 	// number of recognized capabilities:
-	numCapabs = 27
+	numCapabs = 26
 	// length of the uint64 array that represents the bitset:
 	bitsetLen = 1
 )
@@ -89,10 +89,6 @@ const (
 	// https://oragono.io/bnc
 	Bouncer Capability = iota
 
-	// MaxLine is the Oragono-specific capability named "oragono.io/maxline-2":
-	// https://oragono.io/maxline-2
-	MaxLine Capability = iota
-
 	// Nope is the Oragono vendor capability named "oragono.io/nope":
 	// https://oragono.io/nope
 	Nope Capability = iota
@@ -144,7 +140,6 @@ var (
 		"message-tags",
 		"multi-prefix",
 		"oragono.io/bnc",
-		"oragono.io/maxline-2",
 		"oragono.io/nope",
 		"sasl",
 		"server-time",

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -643,7 +643,7 @@ func (channel *Channel) Join(client *Client, key string, isSajoin bool, rb *Resp
 
 		channel.regenerateMembersCache()
 
-		message = utils.MakeSplitMessage("", true)
+		message = utils.MakeMessage("")
 		histItem := history.Item{
 			Type:        history.Join,
 			Nick:        details.nickMask,
@@ -766,7 +766,7 @@ func (channel *Channel) Part(client *Client, message string, rb *ResponseBuffer)
 
 	channel.Quit(client)
 
-	splitMessage := utils.MakeSplitMessage(message, true)
+	splitMessage := utils.MakeMessage(message)
 
 	details := client.Details()
 	params := make([]string, 1, 2)
@@ -1233,7 +1233,7 @@ func (channel *Channel) Kick(client *Client, target *Client, comment string, rb 
 		comment = comment[:kicklimit]
 	}
 
-	message := utils.MakeSplitMessage(comment, true)
+	message := utils.MakeMessage(comment)
 	clientMask := client.NickMaskString()
 	clientAccount := client.AccountName()
 

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -366,7 +366,6 @@ func batchHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Res
 		} else {
 			batch := rb.session.batch
 			rb.session.batch = MultilineBatch{}
-			batch.message.Time = time.Now().UTC()
 			histType, err := msgCommandToHistType(batch.command)
 			if err != nil {
 				histType = history.Privmsg
@@ -515,10 +514,6 @@ func capHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Respo
 				rb.session.SetResumeID(id)
 			}
 		}
-
-		// update maxlenrest, just in case they altered the maxline cap
-		rb.session.SetMaxlenRest()
-
 	case "END":
 		if !client.registered {
 			rb.session.capState = caps.NegotiatedState
@@ -1962,7 +1957,7 @@ func messageHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *R
 			break
 		}
 		// each target gets distinct msgids
-		splitMsg := utils.MakeSplitMessage(message, !rb.session.capabilities.Has(caps.MaxLine))
+		splitMsg := utils.MakeMessage(message)
 		dispatchMessageToTarget(client, clientOnlyTags, histType, msg.Command, targetString, splitMsg, rb)
 	}
 	return false

--- a/irc/history/history.go
+++ b/irc/history/history.go
@@ -50,15 +50,7 @@ type Item struct {
 
 // HasMsgid tests whether a message has the message id `msgid`.
 func (item *Item) HasMsgid(msgid string) bool {
-	if item.Message.Msgid == msgid {
-		return true
-	}
-	for _, pair := range item.Message.Wrapped {
-		if pair.Msgid == msgid {
-			return true
-		}
-	}
-	return false
+	return item.Message.Msgid == msgid
 }
 
 func (item *Item) isStorable() bool {

--- a/irc/nickname.go
+++ b/irc/nickname.go
@@ -57,7 +57,7 @@ func performNickChange(server *Server, client *Client, target *Client, session *
 		return false
 	}
 
-	message := utils.MakeSplitMessage("", true)
+	message := utils.MakeMessage("")
 	histItem := history.Item{
 		Type:        history.Nick,
 		Nick:        origNickMask,

--- a/irc/server.go
+++ b/irc/server.go
@@ -564,10 +564,7 @@ func (server *Server) applyConfig(config *Config, initial bool) (err error) {
 		globalCasemappingSetting = config.Server.Casemapping
 	} else {
 		// enforce configs that can't be changed after launch:
-		currentLimits := server.Config().Limits
-		if currentLimits.LineLen.Rest != config.Limits.LineLen.Rest {
-			return fmt.Errorf("Maximum line length (linelen) cannot be changed after launching the server, rehash aborted")
-		} else if server.name != config.Server.Name {
+		if server.name != config.Server.Name {
 			return fmt.Errorf("Server name cannot be changed after launching the server, rehash aborted")
 		} else if server.Config().Datastore.Path != config.Datastore.Path {
 			return fmt.Errorf("Datastore path cannot be changed after launching the server, rehash aborted")

--- a/irc/utils/text.go
+++ b/irc/utils/text.go
@@ -42,9 +42,6 @@ func MakeMessage(original string) (result SplitMessage) {
 }
 
 func (sm *SplitMessage) Append(message string, concat bool) {
-	if sm.Time.IsZero() {
-		sm.Time = time.Now().UTC()
-	}
 	if sm.Msgid == "" {
 		sm.Msgid = GenerateSecretToken()
 	}
@@ -52,6 +49,10 @@ func (sm *SplitMessage) Append(message string, concat bool) {
 		Message: message,
 		Concat:  concat,
 	})
+}
+
+func (sm *SplitMessage) SetTime() {
+	sm.Time = time.Now().UTC()
 }
 
 func (sm *SplitMessage) LenLines() int {

--- a/irc/utils/text_test.go
+++ b/irc/utils/text_test.go
@@ -4,60 +4,13 @@
 package utils
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 )
 
 const (
-	threeMusketeers = "In the meantime D’Artagnan, who had plunged into a bypath, continued his route and reached St. Cloud; but instead of following the main street he turned behind the château, reached a sort of retired lane, and found himself soon in front of the pavilion named. It was situated in a very private spot. A high wall, at the angle of which was the pavilion, ran along one side of this lane, and on the other was a little garden connected with a poor cottage which was protected by a hedge from passers-by."
-
 	monteCristo = `Both the count and Baptistin had told the truth when they announced to Morcerf the proposed visit of the major, which had served Monte Cristo as a pretext for declining Albert's invitation. Seven o'clock had just struck, and M. Bertuccio, according to the command which had been given him, had two hours before left for Auteuil, when a cab stopped at the door, and after depositing its occupant at the gate, immediately hurried away, as if ashamed of its employment. The visitor was about fifty-two years of age, dressed in one of the green surtouts, ornamented with black frogs, which have so long maintained their popularity all over Europe. He wore trousers of blue cloth, boots tolerably clean, but not of the brightest polish, and a little too thick in the soles, buckskin gloves, a hat somewhat resembling in shape those usually worn by the gendarmes, and a black cravat striped with white, which, if the proprietor had not worn it of his own free will, might have passed for a halter, so much did it resemble one. Such was the picturesque costume of the person who rang at the gate, and demanded if it was not at No. 30 in the Avenue des Champs-Elysees that the Count of Monte Cristo lived, and who, being answered by the porter in the affirmative, entered, closed the gate after him, and began to ascend the steps.`
 )
-
-func assertWrapCorrect(text string, lineWidth int, allowSplitWords bool, t *testing.T) {
-	lines := WordWrap(text, lineWidth)
-
-	reconstructed := strings.Join(lines, "")
-	if text != reconstructed {
-		t.Errorf("text %v does not match original %v", text, reconstructed)
-	}
-
-	for _, line := range lines {
-		if len(line) > lineWidth {
-			t.Errorf("line too long: %d, %v", len(line), line)
-		}
-	}
-
-	if !allowSplitWords {
-		origWords := strings.Fields(text)
-		var newWords []string
-		for _, line := range lines {
-			newWords = append(newWords, strings.Fields(line)...)
-		}
-
-		if !reflect.DeepEqual(origWords, newWords) {
-			t.Errorf("words %v do not match wrapped words %v", origWords, newWords)
-		}
-	}
-
-}
-
-func TestWordWrap(t *testing.T) {
-	assertWrapCorrect("jackdaws love my big sphinx of quartz", 12, false, t)
-	// long word that will necessarily be split:
-	assertWrapCorrect("jackdawslovemybigsphinxofquartz", 12, true, t)
-
-	assertWrapCorrect(threeMusketeers, 40, true, t)
-	assertWrapCorrect(monteCristo, 20, false, t)
-}
-
-func BenchmarkWordWrap(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		WordWrap(threeMusketeers, 40)
-		WordWrap(monteCristo, 60)
-	}
-}
 
 func TestTokenLineBuilder(t *testing.T) {
 	lineLen := 400

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -586,13 +586,6 @@ limits:
     # maximum length of channel lists (beI modes)
     chan-list-modes: 60
 
-    # maximum length of IRC lines
-    # this should generally be 1024-2048, and will only apply when negotiated by clients
-    linelen:
-        # ratified version of the message-tags cap fixes the max tag length at 8191 bytes
-        # configurable length for the rest of the message:
-        rest: 2048
-
     # maximum number of messages to accept during registration (prevents
     # DoS / resource exhaustion attacks):
     registration-messages: 1024


### PR DESCRIPTION
This removes maxline support, and also makes our multiline implementation conform to the current version of https://github.com/ircv3/ircv3-specifications/pull/398 (no fallback msgids, fallback PRIVMSG other than the first are sent without a msgid).

I feel conflicted about this because I think it makes `CHATHISTORY` harder for client developers to use (unless they add full support for multiline, they won't be able to deduplicate all history messages by msgid). But I'm not sure there's much appetite for a solution that avoids this.