### PR TITLE
increase default sendq and multiline max-lines

### DIFF
--- a/oragono.yaml
+++ b/oragono.yaml
@@ -152,7 +152,7 @@ server:
 
     # maximum length of clients' sendQ in bytes
     # this should be big enough to hold bursts of channel/direct messages
-    max-sendq: 16k
+    max-sendq: 96k
 
     # compatibility with legacy clients
     compatibility:
@@ -593,7 +593,7 @@ limits:
     # message length limits for the new multiline cap
     multiline:
         max-bytes: 4096 # 0 means disabled
-        max-lines: 24   # 0 means no limit
+        max-lines: 100  # 0 means no limit
 
 # fakelag: prevents clients from spamming commands too rapidly
 fakelag:


### PR DESCRIPTION
From discussion on the multiline spec PR, our sendq value is very conservative compared to Unreal and Inspircd (even considering that the client's own responses don't use the sendq).

The maximum size on the wire of a multiline is roughly max(max_bytes, 100 * max_lines), so the sendq holds about 10 maximal multilines, which seems OK I guess.