### PR TITLE
mitigate #772

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -955,16 +955,16 @@ func (client *Client) updateNick(nick, nickCasefolded, skeleton string) {
 
 // updateNickMaskNoMutex updates the casefolded nickname and nickmask, not acquiring any mutexes.
 func (client *Client) updateNickMaskNoMutex() {
+	if client.nick == "*" {
+		return // pre-registration, don't bother generating the hostname
+	}
+
 	client.hostname = client.getVHostNoMutex()
 	if client.hostname == "" {
 		client.hostname = client.cloakedHostname
 		if client.hostname == "" {
 			client.hostname = client.rawHostname
 		}
-	}
-
-	if client.hostname == "" {
-		return // pre-registration, don't bother generating the hostname
 	}
 
 	cfhostname := strings.ToLower(client.hostname)

--- a/irc/server.go
+++ b/irc/server.go
@@ -331,6 +331,12 @@ func (server *Server) tryRegister(c *Client, session *Session) (exiting bool) {
 		return true
 	}
 
+	// we have the final value of the IP address: do the hostname lookup
+	// (nickmask will be set below once nickname assignment succeeds)
+	if session.rawHostname == "" {
+		session.client.lookupHostname(session, false)
+	}
+
 	rb := NewResponseBuffer(session)
 	nickAssigned := performNickChange(server, c, c, session, c.preregNick, rb)
 	rb.Send(true)
@@ -338,10 +344,6 @@ func (server *Server) tryRegister(c *Client, session *Session) (exiting bool) {
 		c.preregNick = ""
 		return
 	}
-
-	// we have nickname, username, and the final value of the IP address:
-	// do the hostname lookup and set the nickmask
-	session.client.lookupHostname(session, false)
 
 	if session.client != c {
 		// reattached, bail out.


### PR DESCRIPTION
The active ingredient is moving the hostname lookup before `performNickChange` (which is what actually attaches the session to the old client).