### PR TITLE
new default: no public plaintext listener

### DIFF
--- a/oragono.yaml
+++ b/oragono.yaml
@@ -12,14 +12,14 @@ server:
 
     # addresses to listen on
     listeners:
-        # The standard plaintext port for IRC is 6667. This will listen on all interfaces:
-        ":6667":
-
-        # Allowing plaintext over the public Internet poses security and privacy issues,
-        # so if possible, we recommend that you comment out the above line and replace
-        # it with these two, which listen only on local interfaces:
-        # "127.0.0.1:6667": # (loopback ipv4, localhost-only)
-        # "[::1]:6667":     # (loopback ipv6, localhost-only)
+        # The standard plaintext port for IRC is 6667. Allowing plaintext over the
+        # public Internet poses serious security and privacy issues. Accordingly,
+        # we recommend using plaintext only on local (loopback) interfaces:
+        "127.0.0.1:6667": # (loopback ipv4, localhost-only)
+        "[::1]:6667":     # (loopback ipv6, localhost-only)
+        # If you need to serve plaintext on public interfaces, comment out the above
+        # two lines and uncomment the line below (which listens on all interfaces):
+        # ":6667":
         # Alternately, if you have a TLS certificate issued by a recognized CA,
         # you can configure port 6667 as an STS-only listener that only serves
         # "redirects" to the TLS port, but doesn't allow chat. See the manual


### PR DESCRIPTION
@DanielOaks I won't merge this without your approval.

I feel like public plaintext is a bad default for 2020, and goes against the ideas in https://github.com/ircv3/ircv3-ideas/issues/45. But if you think this is an unfriendly default, or insufficiently batteries-included, I get it.

@csmith I'm not 100% clear on how this would interact with the Docker configs; would 6667 still be exposed despite this change, because of `EXPOSE` and `-p`?