### PR TITLE
fix #833

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -1563,15 +1563,18 @@ func (client *Client) historyStatus(config *Config) (status HistoryStatus, targe
 	}
 
 	client.stateMutex.RLock()
-	loggedIn := client.account != ""
+	target = client.account
 	historyStatus := client.accountSettings.DMHistory
-	target = client.nickCasefolded
 	client.stateMutex.RUnlock()
 
-	if !loggedIn {
+	if target == "" {
 		return HistoryEphemeral, ""
 	}
-	return historyEnabled(config.History.Persistent.DirectMessages, historyStatus), target
+	status = historyEnabled(config.History.Persistent.DirectMessages, historyStatus)
+	if status != HistoryPersistent {
+		target = ""
+	}
+	return
 }
 
 // these are bit flags indicating what part of the client status is "dirty"

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2011,11 +2011,9 @@ func dispatchMessageToTarget(client *Client, tags map[string]string, histType hi
 			item.CfCorrespondent = details.nickCasefolded
 			user.history.Add(item)
 		}
-		cPersistent := cStatus == HistoryPersistent
-		tPersistent := tStatus == HistoryPersistent
-		if cPersistent || tPersistent {
-			item.CfCorrespondent = ""
-			server.historyDB.AddDirectMessage(details.nickCasefolded, user.NickCasefolded(), cPersistent, tPersistent, targetedItem)
+		if cStatus == HistoryPersistent || tStatus == HistoryPersistent {
+			targetedItem.CfCorrespondent = ""
+			server.historyDB.AddDirectMessage(details.nickCasefolded, details.account, tDetails.nickCasefolded, tDetails.account, targetedItem)
 		}
 	}
 }


### PR DESCRIPTION
Also cleaned up a lot of the nomenclature: "recipient" is now "target", and "sender" is now "correspondent".