### PR TITLE
fix #848

### DIFF
--- a/irc/client_lookup_set.go
+++ b/irc/client_lookup_set.go
@@ -179,8 +179,8 @@ func (clients *ClientManager) SetNick(client *Client, session *Session, newNick 
 			return "", errNicknameInUse
 		}
 		if numSessions == 1 {
-			invisible := client.HasMode(modes.Invisible)
-			operator := client.HasMode(modes.Operator) || client.HasMode(modes.LocalOperator)
+			invisible := currentClient.HasMode(modes.Invisible)
+			operator := currentClient.HasMode(modes.Operator) || currentClient.HasMode(modes.LocalOperator)
 			client.server.stats.AddRegistered(invisible, operator)
 		}
 		session.autoreplayMissedSince = lastSeen


### PR DESCRIPTION
It's hard to be sure, but I reproduced both cases as described in the ticket:

1. Connect an always-on client and let it time out: double-decrement (this is what was seen on darwin)
2. Connect an always-on client, give it `+i`, and quit it: normal count goes up and invisible count goes down

and both of those cases are fixed.