### PR TITLE
Fix Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ ADD . /go/src/github.com/oragono/oragono/
 
 # modify default config file so that it doesn't die on IPv6
 # and so it can be exposed via 6667 by default
-run sed -i 's/^\(.*\)\"127.0.0.1:6667\":.*$/\1":6667":/' /go/src/github.com/oragono/oragono/oragono.yaml
-run sed -i 's/^.*\"\[::1\]:6667\":.*$//' /go/src/github.com/oragono/oragono/oragono.yaml
+run sed -i 's/^\(\s*\)\"127.0.0.1:6667\":.*$/\1":6667":/' /go/src/github.com/oragono/oragono/oragono.yaml
+run sed -i 's/^\s*\"\[::1\]:6667\":.*$//' /go/src/github.com/oragono/oragono/oragono.yaml
 
 # make sure submodules are up-to-date
 RUN git submodule update --init

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,14 @@ RUN mkdir -p /ircd-bin
 COPY --from=build-env /go/bin/oragono /ircd-bin
 COPY --from=build-env /go/src/github.com/oragono/oragono/languages /ircd-bin/languages/
 COPY --from=build-env /go/src/github.com/oragono/oragono/oragono.yaml /ircd-bin/oragono.yaml
+
+# modify default config file so that it doesn't die on IPv6
+#  and so it can be exposed via 6667 by default
+RUN apk add --no-cache python3
+RUN apk add --no-cache jq
+RUN pip3 install yq
+RUN yq -iy 'del(.server.listeners."[::1]:6667") | del(.server.listeners."127.0.0.1:6667") | .server.listeners += {":6667": {}}' /ircd-bin/oragono.yaml
+
 COPY distrib/docker/run.sh /ircd-bin/run.sh
 RUN chmod +x /ircd-bin/run.sh
 


### PR DESCRIPTION
This PR:

- Moves the Dockerfile to the root (much more standard for projects to have it there).
- Fixes the config file (through Dockerfile fun) to remove the IPv6 listener (Docker dies on IPv6), and instead we just expose `:6667` in the default config file because the decision to not expose port 6667 is done higher-up by the user of the docker image anyways.