### PR TITLE
Add RPL_NAMREPLY to trailing hack list

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -1410,6 +1410,7 @@ var (
 		"PRIVMSG": true,
 		"NOTICE":  true,
 
+		RPL_NAMREPLY:      true, // weird conflicting legacy format reasons: https://forums.mirc.com/ubbthreads.php/topics/266939/re-nick-list
 		RPL_WHOISCHANNELS: true,
 		RPL_USERHOST:      true,
 	}


### PR DESCRIPTION
It seems way back in the olden times, `RPL_NAMREPLY` had some weird conflicting formats and the colon on the last param was required to sort out which format was being processed. As much as I _love_ sticking to the make-clients-respect-the-message-format (and specifically the last param being exactly the same regardless of trailing or not), this at least seems to have some historical reasons for being treated this way and for clients to require the colon: https://forums.mirc.com/ubbthreads.php/topics/266939/re-nick-list