### PR TITLE
make account names permanent identifiers

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -24,6 +24,7 @@ import (
 const (
 	keyAccountExists           = "account.exists %s"
 	keyAccountVerified         = "account.verified %s"
+	keyAccountUnregistered     = "account.unregistered %s"
 	keyAccountCallback         = "account.callback %s"
 	keyAccountVerificationCode = "account.verificationcode %s"
 	keyAccountName             = "account.name %s" // stores the 'preferred name' of the account, not casemapped
@@ -363,6 +364,7 @@ func (am *AccountManager) Register(client *Client, account string, callbackNames
 	}
 
 	accountKey := fmt.Sprintf(keyAccountExists, casefoldedAccount)
+	unregisteredKey := fmt.Sprintf(keyAccountUnregistered, casefoldedAccount)
 	accountNameKey := fmt.Sprintf(keyAccountName, casefoldedAccount)
 	callbackKey := fmt.Sprintf(keyAccountCallback, casefoldedAccount)
 	registeredTimeKey := fmt.Sprintf(keyAccountRegTime, casefoldedAccount)
@@ -401,7 +403,11 @@ func (am *AccountManager) Register(client *Client, account string, callbackNames
 		}
 
 		return am.server.store.Update(func(tx *buntdb.Tx) error {
-			_, err := am.loadRawAccount(tx, casefoldedAccount)
+			if _, err := tx.Get(unregisteredKey); err == nil {
+				return errAccountAlreadyUnregistered
+			}
+
+			_, err = am.loadRawAccount(tx, casefoldedAccount)
 			if err != errAccountDoesNotExist {
 				return errAccountAlreadyRegistered
 			}
@@ -432,7 +438,7 @@ func (am *AccountManager) Register(client *Client, account string, callbackNames
 
 	code, err := am.dispatchCallback(client, casefoldedAccount, callbackNamespace, callbackValue)
 	if err != nil {
-		am.Unregister(casefoldedAccount)
+		am.Unregister(casefoldedAccount, true)
 		return errCallbackFailed
 	} else {
 		return am.server.store.Update(func(tx *buntdb.Tx) error {
@@ -1063,7 +1069,7 @@ func (am *AccountManager) loadRawAccount(tx *buntdb.Tx, casefoldedAccount string
 	return
 }
 
-func (am *AccountManager) Unregister(account string) error {
+func (am *AccountManager) Unregister(account string, erase bool) error {
 	config := am.server.Config()
 	casefoldedAccount, err := CasefoldName(account)
 	if err != nil {
@@ -1084,6 +1090,7 @@ func (am *AccountManager) Unregister(account string) error {
 	channelsKey := fmt.Sprintf(keyAccountChannels, casefoldedAccount)
 	joinedChannelsKey := fmt.Sprintf(keyAccountJoinedChannels, casefoldedAccount)
 	lastSeenKey := fmt.Sprintf(keyAccountLastSeen, casefoldedAccount)
+	unregisteredKey := fmt.Sprintf(keyAccountUnregistered, casefoldedAccount)
 
 	var clients []*Client
 
@@ -1104,6 +1111,13 @@ func (am *AccountManager) Unregister(account string) error {
 	var accountName string
 	var channelsStr string
 	am.server.store.Update(func(tx *buntdb.Tx) error {
+		if erase {
+			tx.Delete(unregisteredKey)
+		} else {
+			if _, err := tx.Get(accountKey); err == nil {
+				tx.Set(unregisteredKey, "1", nil)
+			}
+		}
 		tx.Delete(accountKey)
 		accountName, _ = tx.Get(accountNameKey)
 		tx.Delete(accountNameKey)
@@ -1129,7 +1143,7 @@ func (am *AccountManager) Unregister(account string) error {
 
 	if err == nil {
 		var creds AccountCredentials
-		if err = json.Unmarshal([]byte(credText), &creds); err == nil {
+		if err := json.Unmarshal([]byte(credText), &creds); err == nil {
 			for _, cert := range creds.Certfps {
 				certFPKey := fmt.Sprintf(keyCertToAccount, cert)
 				am.server.store.Update(func(tx *buntdb.Tx) error {
@@ -1169,7 +1183,7 @@ func (am *AccountManager) Unregister(account string) error {
 		}
 	}
 
-	if err != nil {
+	if err != nil && !erase {
 		return errAccountDoesNotExist
 	}
 

--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -1098,7 +1098,10 @@ func (am *AccountManager) Unregister(account string, erase bool) error {
 	// on our way out, unregister all the account's channels and delete them from the db
 	defer func() {
 		for _, channelName := range registeredChannels {
-			am.server.channels.SetUnregistered(channelName, casefoldedAccount)
+			err := am.server.channels.SetUnregistered(channelName, casefoldedAccount)
+			if err != nil {
+				am.server.logger.Error("internal", "couldn't unregister channel", channelName, err.Error())
+			}
 		}
 	}()
 

--- a/irc/channelreg.go
+++ b/irc/channelreg.go
@@ -231,6 +231,7 @@ func (reg *ChannelRegistry) LoadChannel(nameCasefolded string) (info RegisteredC
 
 		info = RegisteredChannel{
 			Name:           name,
+			NameCasefolded: nameCasefolded,
 			RegisteredAt:   time.Unix(regTimeInt, 0).UTC(),
 			Founder:        founder,
 			Topic:          topic,

--- a/irc/errors.go
+++ b/irc/errors.go
@@ -13,6 +13,7 @@ import (
 // Runtime Errors
 var (
 	errAccountAlreadyRegistered       = errors.New(`Account already exists`)
+	errAccountAlreadyUnregistered     = errors.New(`That account name was registered previously and can't be reused`)
 	errAccountAlreadyVerified         = errors.New(`Account is already verified`)
 	errAccountCantDropPrimaryNick     = errors.New("Can't unreserve primary nickname")
 	errAccountCreation                = errors.New("Account could not be created")

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -66,7 +66,7 @@ func registrationErrorToMessageAndCode(err error) (message, code string) {
 	case errAccountBadPassphrase:
 		code = "REG_INVALID_CREDENTIAL"
 		message = err.Error()
-	case errAccountAlreadyRegistered, errAccountAlreadyVerified:
+	case errAccountAlreadyRegistered, errAccountAlreadyVerified, errAccountAlreadyUnregistered:
 		message = err.Error()
 	case errAccountCreation, errAccountMustHoldNick, errAccountBadPassphrase, errCertfpAlreadyExists, errFeatureDisabled:
 		message = err.Error()


### PR DESCRIPTION
This was easier than I expected. Basically, the "unregister" and the "erase" operations share almost all their code. "Unregister" sets a database key "parking" the account name indefinitely. "Erase" deletes the key if present.