### PR TITLE
more updates to permanent account identifiers

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -1117,7 +1117,7 @@ func (am *AccountManager) Unregister(account string, erase bool) error {
 		if erase {
 			tx.Delete(unregisteredKey)
 		} else {
-			if _, err := tx.Get(accountKey); err == nil {
+			if _, err := tx.Get(verifiedKey); err == nil {
 				tx.Set(unregisteredKey, "1", nil)
 			}
 		}


### PR DESCRIPTION
1. Fix #908 
2. With strict nickname reservation, the nickname should be reserved even after unregistration