### PR TITLE
fix #817

### DIFF
--- a/irc/commands.go
+++ b/irc/commands.go
@@ -47,7 +47,7 @@ func (cmd *Command) Run(server *Server, client *Client, session *Session, msg ir
 		}
 		if session.batch.label != "" && !cmd.allowedInBatch {
 			rb.Add(nil, server.name, "FAIL", "BATCH", "MULTILINE_INVALID", client.t("Command not allowed during a multiline batch"))
-			session.batch = MultilineBatch{}
+			session.EndMultilineBatch("")
 			return false
 		}
 

--- a/irc/errors.go
+++ b/irc/errors.go
@@ -59,6 +59,7 @@ var (
 	errCASFailed                      = errors.New("Compare-and-swap update of database value failed")
 	errEmptyCredentials               = errors.New("No more credentials are approved")
 	errCredsExternallyManaged         = errors.New("Credentials are externally managed and cannot be changed here")
+	errInvalidMultilineBatch          = errors.New("Invalid multiline batch")
 )
 
 // Socket Errors

--- a/irc/fakelag.go
+++ b/irc/fakelag.go
@@ -25,6 +25,7 @@ const (
 // from the loop that accepts the client's input and runs commands
 type Fakelag struct {
 	config    FakelagConfig
+	suspended bool
 	nowFunc   func() time.Time
 	sleepFunc func(time.Duration)
 
@@ -38,6 +39,22 @@ func (fl *Fakelag) Initialize(config FakelagConfig) {
 	fl.nowFunc = time.Now
 	fl.sleepFunc = time.Sleep
 	fl.state = FakelagBursting
+}
+
+// Idempotently turn off fakelag if it's enabled
+func (fl *Fakelag) Suspend() {
+	if fl.config.Enabled {
+		fl.suspended = true
+		fl.config.Enabled = false
+	}
+}
+
+// Idempotently turn fakelag back on if it was previously Suspend'ed
+func (fl *Fakelag) Unsuspend() {
+	if fl.suspended {
+		fl.config.Enabled = true
+		fl.suspended = false
+	}
 }
 
 // register a new command, sleep if necessary to delay it

--- a/irc/fakelag_test.go
+++ b/irc/fakelag_test.go
@@ -121,3 +121,35 @@ func TestFakelag(t *testing.T) {
 		t.Fatalf("should not have slept")
 	}
 }
+
+func TestSuspend(t *testing.T) {
+	window, _ := time.ParseDuration("1s")
+	fl, _ := newFakelagForTesting(window, 3, 2, window)
+	assertEqual(fl.config.Enabled, true, t)
+
+	// suspend idempotently disables
+	fl.Suspend()
+	assertEqual(fl.config.Enabled, false, t)
+	fl.Suspend()
+	assertEqual(fl.config.Enabled, false, t)
+	// unsuspend idempotently enables
+	fl.Unsuspend()
+	assertEqual(fl.config.Enabled, true, t)
+	fl.Unsuspend()
+	assertEqual(fl.config.Enabled, true, t)
+	fl.Suspend()
+	assertEqual(fl.config.Enabled, false, t)
+
+	fl2, _ := newFakelagForTesting(window, 3, 2, window)
+	fl2.config.Enabled = false
+
+	// if we were never enabled, suspend and unsuspend are both no-ops
+	fl2.Suspend()
+	assertEqual(fl2.config.Enabled, false, t)
+	fl2.Suspend()
+	assertEqual(fl2.config.Enabled, false, t)
+	fl2.Unsuspend()
+	assertEqual(fl2.config.Enabled, false, t)
+	fl2.Unsuspend()
+	assertEqual(fl2.config.Enabled, false, t)
+}


### PR DESCRIPTION
This was surprisingly tricky. The big worry here is a code path where fakelag gets switched off and never switched back on, allowing unthrottled sends from unprivileged users.

The strategy for dealing with this is that if you're in a multiline batch, you can only send correctly tagged PRIVMSG and NOTICE, and if you fail to do so at any time, you end up in `session.EndMultilineBatch`, which unconditionally reenables fakelag and bills you for the data you used during the batch.