### PR TITLE
Allow stdout/stderr colorization to be turned off

### DIFF
--- a/irc/logger/logger.go
+++ b/irc/logger/logger.go
@@ -301,7 +301,7 @@ func (logger *singleLogger) Log(level Level, logType string, messageParts ...str
 			formattedBuf.WriteRune(' ')
 			formattedBuf.WriteString(separator)
 			formattedBuf.WriteRune(' ')
-			if logger.MethodFile.Enabled {
+			if logger.MethodFile.Enabled || !logger.Colorized.Value() {
 				rawBuf.WriteString(" : ")
 			}
 		}

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -595,6 +595,11 @@ logging:
         # filename to log to, if file method is selected
         # filename: ircd.log
 
+        # if logging to stdout or stderr and you don't want colorized output
+        # set this to false. If you do, set to true or leave undefined -
+        # it defaults to true
+        # colorized: true
+
         # type(s) of logs to keep here. you can use - to exclude those types
         #
         # exclusions take precedent over inclusions, so if you exclude a type it will NEVER


### PR DESCRIPTION
Add a new logging stanza option "colorizable", which allows you
to turn off the ANSI colorization of stdout or stderr logging
targets. Useful for running oragono under systemd with stock
journal+syslog logging - otherwise you get a lot of ANSI control
characters in your syslog.

Defaults to `true`, to retain backwards compatability.