### PR TITLE
use servername instead of nickmask for RPL_UMODEIS prefix

### DIFF
--- a/irc/server.go
+++ b/irc/server.go
@@ -407,7 +407,7 @@ func (server *Server) playRegistrationBurst(session *Session) {
 
 	modestring := c.ModeString()
 	if modestring != "+" {
-		session.Send(nil, d.nickMask, RPL_UMODEIS, d.nick, modestring)
+		session.Send(nil, server.name, RPL_UMODEIS, d.nick, modestring)
 	}
 
 	c.attemptAutoOper(session)
@@ -993,8 +993,8 @@ func (target *Client) RplList(channel *Channel, rb *ResponseBuffer) {
 
 var (
 	infoString1 = strings.Split(`      ▄▄▄   ▄▄▄·  ▄▄ •        ▐ ▄
-▪     ▀▄ █·▐█ ▀█ ▐█ ▀ ▪▪     •█▌▐█▪     
- ▄█▀▄ ▐▀▀▄ ▄█▀▀█ ▄█ ▀█▄ ▄█▀▄▪▐█▐▐▌ ▄█▀▄ 
+▪     ▀▄ █·▐█ ▀█ ▐█ ▀ ▪▪     •█▌▐█▪
+ ▄█▀▄ ▐▀▀▄ ▄█▀▀█ ▄█ ▀█▄ ▄█▀▄▪▐█▐▐▌ ▄█▀▄
 ▐█▌.▐▌▐█•█▌▐█ ▪▐▌▐█▄▪▐█▐█▌ ▐▌██▐█▌▐█▌.▐▌
  ▀█▄▀▪.▀  ▀ ▀  ▀ ·▀▀▀▀  ▀█▄▀ ▀▀ █▪ ▀█▄▀▪
 


### PR DESCRIPTION
Reported by jess on #oragono

sorry for the later 2-line diff (just the editor trimming whitespace)