### PR TITLE
Add ChanServ and NickServ LIST commands.

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -1047,6 +1047,17 @@ func (am *AccountManager) AuthenticateByPassphrase(client *Client, accountName s
 	return err
 }
 
+func (am *AccountManager) AllNicks() []string {
+	am.RLock()
+	defer am.RUnlock()
+
+	nicks := make([]string, 0, len(am.nickToAccount))
+	for nick := range am.nickToAccount {
+		nicks = append(nicks, nick)
+	}
+	return nicks
+}
+
 func (am *AccountManager) LoadAccount(accountName string) (result ClientAccount, err error) {
 	casefoldedAccount, err := CasefoldName(accountName)
 	if err != nil {

--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -1050,21 +1050,23 @@ func (am *AccountManager) AuthenticateByPassphrase(client *Client, accountName s
 
 // AllNicks returns the uncasefolded nicknames for all accounts, including additional (grouped) nicks.
 func (am *AccountManager) AllNicks() (result []string) {
-	// Account names
 	accountNamePrefix := fmt.Sprintf(keyAccountName, "")
+	accountAdditionalNicksPrefix := fmt.Sprintf(keyAccountAdditionalNicks, "")
+
 	am.server.store.View(func(tx *buntdb.Tx) error {
-		return tx.AscendGreaterOrEqual("", accountNamePrefix, func(key, value string) bool {
+		// Account names
+		err := tx.AscendGreaterOrEqual("", accountNamePrefix, func(key, value string) bool {
 			if !strings.HasPrefix(key, accountNamePrefix) {
 				return false
 			}
 			result = append(result, value)
 			return true
 		})
-	})
+		if err != nil {
+			return err
+		}
 
-	// Additional nicknames
-	accountAdditionalNicksPrefix := fmt.Sprintf(keyAccountAdditionalNicks, "")
-	am.server.store.View(func(tx *buntdb.Tx) error {
+		// Additional nicks
 		return tx.AscendGreaterOrEqual("", accountAdditionalNicksPrefix, func(key, value string) bool {
 			if !strings.HasPrefix(key, accountAdditionalNicksPrefix) {
 				return false


### PR DESCRIPTION
These commands search the registered nicknames/channels for ones matching the provided regex, or return the entire list.

Only operators with chanreg (for ChanServ) or accreg (for NickServ) capabilities can use LIST.

Fixes #974