### PR TITLE
fix #982

### DIFF
--- a/irc/config.go
+++ b/irc/config.go
@@ -746,7 +746,7 @@ func (conf *Config) Operators(oc map[string]*OperClass) (map[string]*Oper, error
 func loadTlsConfig(config TLSListenConfig, webSocket bool) (tlsConfig *tls.Config, err error) {
 	cert, err := tls.LoadX509KeyPair(config.Cert, config.Key)
 	if err != nil {
-		return nil, ErrInvalidCertKeyPair
+		return nil, &CertKeyError{Err: err}
 	}
 	clientAuth := tls.RequestClientCert
 	if webSocket {

--- a/irc/errors.go
+++ b/irc/errors.go
@@ -7,6 +7,8 @@ package irc
 
 import (
 	"errors"
+	"fmt"
+
 	"github.com/oragono/oragono/irc/utils"
 )
 
@@ -78,10 +80,17 @@ var (
 	errInvalidCharacter  = errors.New("Invalid character")
 )
 
+type CertKeyError struct {
+	Err error
+}
+
+func (ck *CertKeyError) Error() string {
+	return fmt.Sprintf("Invalid TLS cert/key pair: %v", ck.Err)
+}
+
 // Config Errors
 var (
 	ErrDatastorePathMissing    = errors.New("Datastore path missing")
-	ErrInvalidCertKeyPair      = errors.New("tls cert+key: invalid pair")
 	ErrLimitsAreInsane         = errors.New("Limits aren't setup properly, check them and make them sane")
 	ErrLineLengthsTooSmall     = errors.New("Line lengths must be 512 or greater (check the linelen section under server->limits)")
 	ErrLoggerExcludeEmpty      = errors.New("Encountered logging type '-' with no type to exclude")

--- a/oragono.go
+++ b/oragono.go
@@ -145,8 +145,11 @@ Options:
 
 	configfile := arguments["--conf"].(string)
 	config, err := irc.LoadConfig(configfile)
-	if err != nil && !(err == irc.ErrInvalidCertKeyPair && arguments["mkcerts"].(bool)) {
-		log.Fatal("Config file did not load successfully: ", err.Error())
+	if err != nil {
+		_, isCertError := err.(*irc.CertKeyError)
+		if !(isCertError && arguments["mkcerts"].(bool)) {
+			log.Fatal("Config file did not load successfully: ", err.Error())
+		}
 	}
 
 	logman, err := logger.NewManager(config.Logging)


### PR DESCRIPTION
I looked at the [fancy new error handling stuff](https://blog.golang.org/go1.13-errors) but it didn't seem any better for this use case than a regular type assertion.

```
2020/05/06 05:57:05 Config file did not load successfully: failed to prepare listeners: Invalid TLS cert/key pair: open tls.crt: no such file or directory
```