### PR TITLE
new recommended default: proxy allowed from localhost

### DIFF
--- a/conventional.yaml
+++ b/conventional.yaml
@@ -137,7 +137,7 @@ server:
     # this should be restricted to 127.0.0.1/8 and ::1/128 (unless you have a good reason)
     # you should also add these addresses to the connection limits and throttling exemption lists
     proxy-allowed-from:
-        # - localhost
+        - localhost
         # - "192.168.1.1"
         # - "192.168.10.1/24"
 

--- a/conventional.yaml
+++ b/conventional.yaml
@@ -134,8 +134,9 @@ server:
     motd-formatting: true
 
     # addresses/CIDRs the PROXY command can be used from
-    # this should be restricted to 127.0.0.1/8 and ::1/128 (unless you have a good reason)
-    # you should also add these addresses to the connection limits and throttling exemption lists
+    # this should be restricted to localhost (127.0.0.1/8, ::1/128, and unix sockets),
+    # unless you have a good reason. you should also add these addresses to the
+    # connection limits and throttling exemption lists.
     proxy-allowed-from:
         - localhost
         # - "192.168.1.1"

--- a/irc/server.go
+++ b/irc/server.go
@@ -601,6 +601,10 @@ func (server *Server) applyConfig(config *Config) (err error) {
 		newISupportReplies = oldConfig.Server.isupport.GetDifference(&config.Server.isupport)
 	}
 
+	if len(config.Server.ProxyAllowedFrom) != 0 {
+		server.logger.Info("server", "Proxied IPs will be accepted from", strings.Join(config.Server.ProxyAllowedFrom, ", "))
+	}
+
 	// we are now open for business
 	err = server.setupListeners(config)
 

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -158,7 +158,7 @@ server:
     # this should be restricted to 127.0.0.1/8 and ::1/128 (unless you have a good reason)
     # you should also add these addresses to the connection limits and throttling exemption lists
     proxy-allowed-from:
-        # - localhost
+        - localhost
         # - "192.168.1.1"
         # - "192.168.10.1/24"
 

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -155,8 +155,9 @@ server:
     motd-formatting: true
 
     # addresses/CIDRs the PROXY command can be used from
-    # this should be restricted to 127.0.0.1/8 and ::1/128 (unless you have a good reason)
-    # you should also add these addresses to the connection limits and throttling exemption lists
+    # this should be restricted to localhost (127.0.0.1/8, ::1/128, and unix sockets),
+    # unless you have a good reason. you should also add these addresses to the
+    # connection limits and throttling exemption lists.
     proxy-allowed-from:
         - localhost
         # - "192.168.1.1"


### PR DESCRIPTION
This is a pain point for websockets. Hard to see how it could cause any problems.