### PR TITLE
Hide +i users from WHO * queries.

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -1022,6 +1022,21 @@ func (client *Client) ModeString() (str string) {
 	return "+" + client.modes.String()
 }
 
+// IsFriend() returns true if the given otherClient shares a channel with this client, or if they are the same user.
+func (client *Client) IsFriend(otherClient *Client) bool {
+	if client == otherClient {
+		return true
+	}
+
+	for _, channel := range client.Channels() {
+		if channel.hasClient(otherClient) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Friends refers to clients that share a channel with this client.
 func (client *Client) Friends(capabs ...caps.Capability) (result map[*Session]bool) {
 	result = make(map[*Session]bool)

--- a/irc/client.go
+++ b/irc/client.go
@@ -1022,21 +1022,6 @@ func (client *Client) ModeString() (str string) {
 	return "+" + client.modes.String()
 }
 
-// IsFriend() returns true if the given otherClient shares a channel with this client, or if they are the same user.
-func (client *Client) IsFriend(otherClient *Client) bool {
-	if client == otherClient {
-		return true
-	}
-
-	for _, channel := range client.Channels() {
-		if channel.hasClient(otherClient) {
-			return true
-		}
-	}
-
-	return false
-}
-
 // Friends refers to clients that share a channel with this client.
 func (client *Client) Friends(capabs ...caps.Capability) (result map[*Session]bool) {
 	result = make(map[*Session]bool)

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2637,7 +2637,9 @@ func whoHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Respo
 		}
 	} else {
 		for mclient := range server.clients.FindAll(mask) {
-			client.rplWhoReply(nil, mclient, rb)
+			if !mclient.HasMode(modes.Invisible) || isOper {
+				client.rplWhoReply(nil, mclient, rb)
+			}
 		}
 	}
 

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2637,7 +2637,7 @@ func whoHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Respo
 		}
 	} else {
 		for mclient := range server.clients.FindAll(mask) {
-			if !mclient.HasMode(modes.Invisible) || isOper {
+			if isOper || !mclient.HasMode(modes.Invisible) || mclient.IsFriend(client) {
 				client.rplWhoReply(nil, mclient, rb)
 			}
 		}


### PR DESCRIPTION
Opers can still see +i users.

Fixes #990.