### PR TITLE
fix #952

### DIFF
--- a/conventional.yaml
+++ b/conventional.yaml
@@ -233,17 +233,6 @@ server:
         # fake TLD at the end of the hostname, e.g., pwbs2ui4377257x8.oragono
         netname: "oragono"
 
-        # secret key to prevent dictionary attacks against cloaked IPs
-        # any high-entropy secret is valid for this purpose:
-        # you MUST generate a new one for your installation.
-        # suggestion: use the output of `oragono mksecret`
-        # note that rotating this key will invalidate all existing ban masks.
-        secret: "siaELnk6Kaeo65K3RCrwJjlWaZ-Bt3WuZ2L8MXLbNb4"
-
-        # name of an environment variable to pull the secret from, for use with
-        # k8s secret distribution:
-        # secret-environment-variable: "ORAGONO_CLOAKING_SECRET"
-
         # the cloaked hostname is derived only from the CIDR (most significant bits
         # of the IP address), up to a configurable number of bits. this is the
         # granularity at which bans will take effect for IPv4. Note that changing

--- a/conventional.yaml
+++ b/conventional.yaml
@@ -110,8 +110,9 @@ server:
     # already up and running is problematic).
     casemapping: "precis"
 
-    # whether to look up user hostnames with reverse DNS
-    # (to suppress this for privacy purposes, use the ip-cloaking options below)
+    # whether to look up user hostnames with reverse DNS.
+    # (disabling this will expose user IPs instead of hostnames;
+    # to make IP/hostname information private, see the ip-cloaking section)
     lookup-hostnames: true
     # whether to confirm hostname lookups using "forward-confirmed reverse DNS", i.e., for
     # any hostname returned from reverse DNS, resolve it back to an IP address and reject it
@@ -230,8 +231,9 @@ server:
         # whether to enable IP cloaking
         enabled: false
 
-        # fake TLD at the end of the hostname, e.g., pwbs2ui4377257x8.oragono
-        netname: "oragono"
+        # fake TLD at the end of the hostname, e.g., pwbs2ui4377257x8.irc
+        # you may want to use your network name here
+        netname: "irc"
 
         # the cloaked hostname is derived only from the CIDR (most significant bits
         # of the IP address), up to a configurable number of bits. this is the

--- a/irc/chanserv.go
+++ b/irc/chanserv.go
@@ -407,7 +407,7 @@ func csUnregisterHandler(server *Server, client *Client, command string, params 
 	expectedCode := utils.ConfirmationCode(info.Name, info.RegisteredAt)
 	if expectedCode != verificationCode {
 		csNotice(rb, ircfmt.Unescape(client.t("$bWarning: unregistering this channel will remove all stored channel attributes.$b")))
-		csNotice(rb, fmt.Sprintf(client.t("To confirm channel unregistration, type: /CS UNREGISTER %[1]s %[2]s"), channelKey, expectedCode))
+		csNotice(rb, fmt.Sprintf(client.t("To confirm, run this command: %s"), fmt.Sprintf("/CS UNREGISTER %s %s", channelKey, expectedCode)))
 		return
 	}
 

--- a/irc/cloaks/cloak_test.go
+++ b/irc/cloaks/cloak_test.go
@@ -27,7 +27,7 @@ func cloakConfForTesting() CloakConfig {
 	config := CloakConfig{
 		Enabled:     true,
 		Netname:     "oragono",
-		Secret:      "_BdVPWB5sray7McbFmeuJL996yaLgG4l9tEyficGXKg",
+		secret:      "_BdVPWB5sray7McbFmeuJL996yaLgG4l9tEyficGXKg",
 		CidrLenIPv4: 32,
 		CidrLenIPv6: 64,
 		NumBits:     80,
@@ -55,7 +55,7 @@ func TestCloakDeterminism(t *testing.T) {
 	assertEqual(config.ComputeCloak(v6ipdifferentcidr), "ccmptyrjwsxv4f4d.oragono", t)
 
 	// cloak values must be sensitive to changes in the secret key
-	config.Secret = "HJcXK4lLawxBE4-9SIdPji_21YiL3N5r5f5-SPNrGVY"
+	config.SetSecret("HJcXK4lLawxBE4-9SIdPji_21YiL3N5r5f5-SPNrGVY")
 	assertEqual(config.ComputeCloak(v4ip), "4khy3usk8mfu42pe.oragono", t)
 	assertEqual(config.ComputeCloak(v6mappedIP), "4khy3usk8mfu42pe.oragono", t)
 	assertEqual(config.ComputeCloak(v6ip), "mxpk3c83vdxkek9j.oragono", t)
@@ -66,7 +66,7 @@ func TestCloakShortv4Cidr(t *testing.T) {
 	config := CloakConfig{
 		Enabled:     true,
 		Netname:     "oragono",
-		Secret:      "_BdVPWB5sray7McbFmeuJL996yaLgG4l9tEyficGXKg",
+		secret:      "_BdVPWB5sray7McbFmeuJL996yaLgG4l9tEyficGXKg",
 		CidrLenIPv4: 24,
 		CidrLenIPv6: 64,
 		NumBits:     60,

--- a/irc/config.go
+++ b/irc/config.go
@@ -1114,9 +1114,6 @@ func LoadConfig(filename string) (config *Config, err error) {
 
 	config.Server.Cloaks.Initialize()
 	if config.Server.Cloaks.Enabled {
-		if config.Server.Cloaks.Secret == "" || config.Server.Cloaks.Secret == "siaELnk6Kaeo65K3RCrwJjlWaZ-Bt3WuZ2L8MXLbNb4" {
-			return nil, fmt.Errorf("You must generate a new value of server.ip-cloaking.secret to enable cloaking")
-		}
 		if !utils.IsHostname(config.Server.Cloaks.Netname) {
 			return nil, fmt.Errorf("Invalid netname for cloaked hostnames: %s", config.Server.Cloaks.Netname)
 		}

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -713,7 +713,7 @@ func debugHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Res
 		}
 		code := utils.ConfirmationCode(server.name, server.ctime)
 		if len(msg.Params) == 1 || msg.Params[1] != code {
-			rb.Notice(fmt.Sprintf(client.t("To crash the server, issue the following command: /DEBUG CRASHSERVER %s"), code))
+			rb.Notice(fmt.Sprintf(client.t("To confirm, run this command: %s"), fmt.Sprintf("/DEBUG CRASHSERVER %s", code)))
 			return false
 		}
 		server.logger.Error("server", fmt.Sprintf("DEBUG CRASHSERVER executed by operator %s", client.Oper().Name))

--- a/irc/hostserv.go
+++ b/irc/hostserv.go
@@ -451,7 +451,7 @@ func hsSetCloakSecretHandler(server *Server, client *Client, command string, par
 	expectedCode := utils.ConfirmationCode(secret, server.ctime)
 	if len(params) == 1 || params[1] != expectedCode {
 		hsNotice(rb, ircfmt.Unescape(client.t("$bWarning: changing the cloak secret will invalidate stored ban/invite/exception lists.$b")))
-		hsNotice(rb, fmt.Sprintf(client.t("To confirm, type: /HS SETCLOAKSECRET %[1]s %[2]s"), secret, expectedCode))
+		hsNotice(rb, fmt.Sprintf(client.t("To confirm, run this command: %s"), fmt.Sprintf("/HS SETCLOAKSECRET %s %s", secret, expectedCode)))
 		return
 	}
 	StoreCloakSecret(server.store, secret)

--- a/irc/hostserv.go
+++ b/irc/hostserv.go
@@ -9,7 +9,10 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/goshuirc/irc-go/ircfmt"
+
 	"github.com/oragono/oragono/irc/sno"
+	"github.com/oragono/oragono/irc/utils"
 )
 
 const (
@@ -170,6 +173,19 @@ the offered vhosts, use /HOSTSERV OFFERLIST.`,
 			authRequired: true,
 			minParams:    1,
 			maxParams:    1,
+		},
+		"setcloaksecret": {
+			handler: hsSetCloakSecretHandler,
+			help: `Syntax: $bSETCLOAKSECRET$b <secret> [code]
+
+SETCLOAKSECRET can be used to set or rotate the cloak secret. You should use
+a cryptographically strong secret. To prevent accidental modification, a
+verification code is required; invoking the command without a code will
+display the necessary code.`,
+			helpShort: `$bSETCLOAKSECRET$b modifies the IP cloaking secret.`,
+			capabs:    []string{"vhosts", "rehash"},
+			minParams: 1,
+			maxParams: 2,
 		},
 	}
 )
@@ -428,4 +444,16 @@ func hsTakeHandler(server *Server, client *Client, command string, params []stri
 		hsNotice(rb, client.t("Successfully set vhost"))
 		server.snomasks.Send(sno.LocalVhosts, fmt.Sprintf("Client %s (account %s) took vhost %s", client.Nick(), account, vhost))
 	}
+}
+
+func hsSetCloakSecretHandler(server *Server, client *Client, command string, params []string, rb *ResponseBuffer) {
+	secret := params[0]
+	expectedCode := utils.ConfirmationCode(secret, server.ctime)
+	if len(params) == 1 || params[1] != expectedCode {
+		hsNotice(rb, ircfmt.Unescape(client.t("$bWarning: changing the cloak secret will invalidate stored ban/invite/exception lists.$b")))
+		hsNotice(rb, fmt.Sprintf(client.t("To confirm, type: /HS SETCLOAKSECRET %[1]s %[2]s"), secret, expectedCode))
+		return
+	}
+	StoreCloakSecret(server.store, secret)
+	hsNotice(rb, client.t("Rotated the cloak secret; you must rehash or restart the server for it to take effect"))
 }

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -905,11 +905,10 @@ func nsUnregisterHandler(server *Server, client *Client, command string, params 
 	if expectedCode != verificationCode {
 		if erase {
 			nsNotice(rb, ircfmt.Unescape(client.t("$bWarning: erasing this account will allow it to be re-registered; consider UNREGISTER instead.$b")))
-			nsNotice(rb, fmt.Sprintf(client.t("To confirm account erase, type: /NS ERASE %[1]s %[2]s"), accountName, expectedCode))
 		} else {
 			nsNotice(rb, ircfmt.Unescape(client.t("$bWarning: unregistering this account will remove its stored privileges.$b")))
-			nsNotice(rb, fmt.Sprintf(client.t("To confirm account unregistration, type: /NS UNREGISTER %[1]s %[2]s"), accountName, expectedCode))
 		}
+		nsNotice(rb, fmt.Sprintf(client.t("To confirm, run this command: %s"), fmt.Sprintf("/NS UNREGISTER %s %s", accountName, expectedCode)))
 		return
 	}
 

--- a/oragono.go
+++ b/oragono.go
@@ -17,7 +17,6 @@ import (
 	"github.com/oragono/oragono/irc"
 	"github.com/oragono/oragono/irc/logger"
 	"github.com/oragono/oragono/irc/mkcerts"
-	"github.com/oragono/oragono/irc/utils"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -97,7 +96,6 @@ Usage:
 	oragono upgradedb [--conf <filename>] [--quiet]
 	oragono genpasswd [--conf <filename>] [--quiet]
 	oragono mkcerts [--conf <filename>] [--quiet]
-	oragono mksecret [--conf <filename>] [--quiet]
 	oragono run [--conf <filename>] [--quiet] [--smoke]
 	oragono -h | --help
 	oragono --version
@@ -109,7 +107,7 @@ Options:
 
 	arguments, _ := docopt.ParseArgs(usage, nil, version)
 
-	// don't require a config file for genpasswd or mksecret
+	// don't require a config file for genpasswd
 	if arguments["genpasswd"].(bool) {
 		var password string
 		fd := int(os.Stdin.Fd())
@@ -134,9 +132,6 @@ Options:
 		if terminal.IsTerminal(fd) {
 			fmt.Println()
 		}
-		return
-	} else if arguments["mksecret"].(bool) {
-		fmt.Println(utils.GenerateSecretKey())
 		return
 	} else if arguments["mkcerts"].(bool) {
 		doMkcerts(arguments["--conf"].(string), arguments["--quiet"].(bool))

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -131,8 +131,9 @@ server:
     # already up and running is problematic).
     casemapping: "precis"
 
-    # whether to look up user hostnames with reverse DNS
-    # (to suppress this for privacy purposes, use the ip-cloaking options below)
+    # whether to look up user hostnames with reverse DNS.
+    # (disabling this will expose user IPs instead of hostnames;
+    # to make IP/hostname information private, see the ip-cloaking section)
     lookup-hostnames: true
     # whether to confirm hostname lookups using "forward-confirmed reverse DNS", i.e., for
     # any hostname returned from reverse DNS, resolve it back to an IP address and reject it
@@ -249,10 +250,11 @@ server:
     # IP is not already known, it is infeasible to recover it from the cloaked name.
     ip-cloaking:
         # whether to enable IP cloaking
-        enabled: false
+        enabled: true
 
-        # fake TLD at the end of the hostname, e.g., pwbs2ui4377257x8.oragono
-        netname: "oragono"
+        # fake TLD at the end of the hostname, e.g., pwbs2ui4377257x8.irc
+        # you may want to use your network name here
+        netname: "irc"
 
         # the cloaked hostname is derived only from the CIDR (most significant bits
         # of the IP address), up to a configurable number of bits. this is the

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -254,17 +254,6 @@ server:
         # fake TLD at the end of the hostname, e.g., pwbs2ui4377257x8.oragono
         netname: "oragono"
 
-        # secret key to prevent dictionary attacks against cloaked IPs
-        # any high-entropy secret is valid for this purpose:
-        # you MUST generate a new one for your installation.
-        # suggestion: use the output of `oragono mksecret`
-        # note that rotating this key will invalidate all existing ban masks.
-        secret: "siaELnk6Kaeo65K3RCrwJjlWaZ-Bt3WuZ2L8MXLbNb4"
-
-        # name of an environment variable to pull the secret from, for use with
-        # k8s secret distribution:
-        # secret-environment-variable: "ORAGONO_CLOAKING_SECRET"
-
         # the cloaked hostname is derived only from the CIDR (most significant bits
         # of the IP address), up to a configurable number of bits. this is the
         # granularity at which bans will take effect for IPv4. Note that changing


### PR DESCRIPTION
I removed support for the environment variable entirely. I don't think anyone is using it yet. If someone is, they can manually import using `HS SETCLOAKSECRET`.

There are a lot of different pathways here:

1. New database
2. Upgrading with a cloak secret in the config
3. Upgrading with no secret in the config

I think I tested them all.