### PR TITLE
upgrade go-ident to fix parsing issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/oragono/confusables v0.0.0-20190624102032-fe1cf31a24b0
-	github.com/oragono/go-ident v0.0.0-20170110123031-337fed0fd21a
+	github.com/oragono/go-ident v0.0.0-20200511222032-830550b1d775
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/tidwall/buntdb v1.1.2
 	github.com/toorop/go-dkim v0.0.0-20191019073156-897ad64a2eeb

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/oragono/confusables v0.0.0-20190624102032-fe1cf31a24b0 h1:4qw57EiWD2M
 github.com/oragono/confusables v0.0.0-20190624102032-fe1cf31a24b0/go.mod h1:+uesPRay9e5tW6zhw4CJkRV3QOEbbZIJcsuo9ZnC+hE=
 github.com/oragono/go-ident v0.0.0-20170110123031-337fed0fd21a h1:tZApUffT5QuX4XhJLz2KfBJT8JgdwjLUBWtvmRwgFu4=
 github.com/oragono/go-ident v0.0.0-20170110123031-337fed0fd21a/go.mod h1:r5Fk840a4eu3ii1kxGDNSJupQu9Z1UC1nfJOZZXC24c=
+github.com/oragono/go-ident v0.0.0-20200511222032-830550b1d775 h1:AMAsAn/i4AgsmWQYdMoze9omwtHpbxrKuT+AT1LmhtI=
+github.com/oragono/go-ident v0.0.0-20200511222032-830550b1d775/go.mod h1:r5Fk840a4eu3ii1kxGDNSJupQu9Z1UC1nfJOZZXC24c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/irc/client.go
+++ b/irc/client.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	// IdentTimeoutSeconds is how many seconds before our ident (username) check times out.
-	IdentTimeoutSeconds  = 1.5
+	// IdentTimeout is how long before our ident (username) check times out.
+	IdentTimeout         = time.Second + 500*time.Millisecond
 	IRCv3TimestampFormat = utils.IRCv3TimestampFormat
 )
 
@@ -483,7 +483,7 @@ func (client *Client) doIdentLookup(conn net.Conn) {
 	clientPort := remoteTCPAddr.Port
 
 	client.Notice(client.t("*** Looking up your username"))
-	resp, err := ident.Query(remoteTCPAddr.IP.String(), serverPort, clientPort, IdentTimeoutSeconds)
+	resp, err := ident.Query(remoteTCPAddr.IP.String(), serverPort, clientPort, IdentTimeout)
 	if err == nil {
 		err := client.SetNames(resp.Identifier, "", true)
 		if err == nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -30,7 +30,7 @@ github.com/goshuirc/irc-go/ircmsg
 # github.com/oragono/confusables v0.0.0-20190624102032-fe1cf31a24b0
 ## explicit
 github.com/oragono/confusables
-# github.com/oragono/go-ident v0.0.0-20170110123031-337fed0fd21a
+# github.com/oragono/go-ident v0.0.0-20200511222032-830550b1d775
 ## explicit
 github.com/oragono/go-ident
 # github.com/stretchr/testify v1.4.0


### PR DESCRIPTION
This worked correctly on the testnet (BitBot's nickmask is now `BitBot!bitbot@muv8gzn63bjkn.oragono` as expected).