### PR TITLE
Revert "Add support for Unix domain sockets"

### DIFF
--- a/irc/mysql/history.go
+++ b/irc/mysql/history.go
@@ -90,8 +90,6 @@ func (m *MySQL) Open() (err error) {
 	var address string
 	if m.config.Port != 0 {
 		address = fmt.Sprintf("tcp(%s:%d)", m.config.Host, m.config.Port)
-	} else {
-		address = fmt.Sprintf("unix(%s)", m.config.Host)
 	}
 
 	m.db, err = sql.Open("mysql", fmt.Sprintf("%s:%s@%s/%s", m.config.User, m.config.Password, address, m.config.HistoryDatabase))


### PR DESCRIPTION
Reverts oragono/oragono#1013

This has a backwards compatibility problem so I'm reverting it for now.