### PR TITLE
fix #1031

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,25 +30,30 @@ builds:
         goarch: arm64
     flags:
       - -trimpath
-archive:
-  name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-  format: tar.gz
-  replacements:
-    386: i386
-    amd64: x64
-    darwin: osx
-  format_overrides:
-    - goos: windows
-      format: zip
-  files:
-    - README
-    - CHANGELOG.md
-    - oragono.motd
-    - oragono.yaml
-    - docs/*
-    - languages/*.yaml
-    - languages/*.json
-    - languages/*.md
-  wrap_in_directory: true
+    # #1031: don't include the git hash in an official build
+    # default is: "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser"
+    ldflags:
+      - "-s -w -X main.build={{.Version}}"
+
+archives:
+  -
+    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: macos
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - README
+      - CHANGELOG.md
+      - oragono.motd
+      - oragono.yaml
+      - docs/*
+      - languages/*.yaml
+      - languages/*.json
+      - languages/*.md
+    wrap_in_directory: true
 checksum:
   name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.txt"

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
 .PHONY: all install build release capdefs test smoke
 
+GIT_COMMIT := $(shell git rev-parse --short=16 HEAD 2> /dev/null)
+
 capdef_file = ./irc/caps/defs.go
 
 all: install
 
 install:
-	go install -v
+	go install -v -ldflags "-X main.commit=$(GIT_COMMIT)"
 
 build:
-	go build -v
+	go build -v -ldflags "-X main.commit=$(GIT_COMMIT)"
 
 release:
 	goreleaser --skip-publish --rm-dist


### PR DESCRIPTION
1. Builds from git include a 16-character git hash prefix (at least when triggered from `make`)
2. Builds with goreleaser, and outside of a git repository, do not include a hash
3. Add compatibility with recent versions of goreleaser (https://github.com/goreleaser/goreleaser/pull/1282 requires `archives` instead of `archive)
4. Tweak some of the name replacements