### PR TITLE
clean up account-notify logout notification

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -15,7 +15,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/oragono/oragono/irc/caps"
 	"github.com/oragono/oragono/irc/connection_limits"
 	"github.com/oragono/oragono/irc/email"
 	"github.com/oragono/oragono/irc/ldap"
@@ -1937,6 +1936,7 @@ type rawClientAccount struct {
 }
 
 // logoutOfAccount logs the client out of their current account.
+// TODO(#1027) delete this entire method and just use client.Logout()
 func (am *AccountManager) logoutOfAccount(client *Client) {
 	if client.Account() == "" {
 		// already logged out
@@ -1945,12 +1945,4 @@ func (am *AccountManager) logoutOfAccount(client *Client) {
 
 	client.Logout()
 	go client.nickTimer.Touch(nil)
-
-	// dispatch account-notify
-	// TODO: doing the I/O here is kind of a kludge, let's move this somewhere else
-	go func() {
-		for friend := range client.Friends(caps.AccountNotify) {
-			friend.Send(nil, client.NickMaskString(), "ACCOUNT", "*")
-		}
-	}()
 }


### PR DESCRIPTION
don't need to send account-notify * (logout notification)
because either we never sent the initial account-notify
(if we are being logged out as part of fixupNickEqualsAccount)
or else we are immediately going to kill the client
(if we are being logged out as part of unregister/erase)