### PR TITLE
/ns erase should confirm with /ns erase rather than unregister.

### DIFF
--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -935,7 +935,7 @@ func nsUnregisterHandler(server *Server, client *Client, command string, params 
 		} else {
 			nsNotice(rb, ircfmt.Unescape(client.t("$bWarning: unregistering this account will remove its stored privileges.$b")))
 		}
-		nsNotice(rb, fmt.Sprintf(client.t("To confirm, run this command: %s"), fmt.Sprintf("/NS UNREGISTER %s %s", accountName, expectedCode)))
+		nsNotice(rb, fmt.Sprintf(client.t("To confirm, run this command: %s"), fmt.Sprintf("/NS %s %s %s", strings.ToUpper(command), accountName, expectedCode)))
 		return
 	}
 


### PR DESCRIPTION
14:39 <oragono_> **erase** oragono
14:39 -NickServ(NickServ@localhost)- Warning: erasing this account will allow it to be re-registered; consider UNREGISTER instead.
14:39 -NickServ(NickServ@localhost)- To confirm, run this command: /NS **UNREGISTER** oragono 8srfw