### PR TITLE
fix TAGMSG playback

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -1017,7 +1017,7 @@ func (channel *Channel) replayHistoryItems(rb *ResponseBuffer, items []history.I
 		case history.Notice:
 			rb.AddSplitMessageFromClient(item.Nick, item.AccountName, item.Tags, "NOTICE", chname, item.Message)
 		case history.Tagmsg:
-			if rb.session.capabilities.Has(caps.MessageTags) {
+			if eventPlayback {
 				rb.AddSplitMessageFromClient(item.Nick, item.AccountName, item.Tags, "TAGMSG", chname, item.Message)
 			}
 		case history.Join:

--- a/irc/client.go
+++ b/irc/client.go
@@ -897,7 +897,7 @@ func (client *Client) replayPrivmsgHistory(rb *ResponseBuffer, items []history.I
 	}
 	batchID = rb.StartNestedHistoryBatch(target)
 
-	allowTags := rb.session.capabilities.Has(caps.MessageTags)
+	allowTags := rb.session.capabilities.Has(caps.EventPlayback)
 	for _, item := range items {
 		var command string
 		switch item.Type {

--- a/irc/responsebuffer.go
+++ b/irc/responsebuffer.go
@@ -119,7 +119,12 @@ func (rb *ResponseBuffer) AddFromClient(time time.Time, msgid string, fromNickMa
 // AddSplitMessageFromClient adds a new split message from a specific client to our queue.
 func (rb *ResponseBuffer) AddSplitMessageFromClient(fromNickMask string, fromAccount string, tags map[string]string, command string, target string, message utils.SplitMessage) {
 	if message.Is512() {
-		rb.AddFromClient(message.Time, message.Msgid, fromNickMask, fromAccount, tags, command, target, message.Message)
+		if message.Message == "" {
+			// XXX this is a TAGMSG
+			rb.AddFromClient(message.Time, message.Msgid, fromNickMask, fromAccount, tags, command, target)
+		} else {
+			rb.AddFromClient(message.Time, message.Msgid, fromNickMask, fromAccount, tags, command, target, message.Message)
+		}
 	} else {
 		if rb.session.capabilities.Has(caps.Multiline) {
 			batch := rb.session.composeMultilineBatch(fromNickMask, fromAccount, tags, command, target, message)

--- a/irc/utils/text.go
+++ b/irc/utils/text.go
@@ -90,7 +90,7 @@ func (sm *SplitMessage) IsRestrictedCTCPMessage() bool {
 }
 
 func (sm *SplitMessage) Is512() bool {
-	return sm.Message != ""
+	return sm.Split == nil
 }
 
 // TokenLineBuilder is a helper for building IRC lines composed of delimited tokens,


### PR DESCRIPTION
1. TAGMSG were incorrectly being considered multilines, because Is512() was checking the wrong thing, and then not getting replayed at all (unclear whether this is a bug in 2.0.0 or a regression from development, so not sure whether it gets a changelog entry)
2. Playback of TAGMSG should depend on event-playback, not on message-tags (this is a bug in 2.0.0 and should get a changelog entry)

I wrote an irctest for this but GitHub won't let me PR it right now, whatever.