### PR TITLE
change the default self-signed certificate filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ _test
 oragono.prof
 oragono.mprof
 /dist
+*.pem

--- a/conventional.yaml
+++ b/conventional.yaml
@@ -24,8 +24,8 @@ server:
         # The standard SSL/TLS port for IRC is 6697. This will listen on all interfaces:
         ":6697":
             tls:
-                key: tls.key
-                cert: tls.crt
+                cert: fullchain.pem
+                key: privkey.pem
                 # 'proxy' should typically be false. It's only for Kubernetes-style load
                 # balancing that does not terminate TLS, but sends an initial PROXY line
                 # in plaintext.
@@ -44,8 +44,8 @@ server:
         # ":8097":
         #     websocket: true
         #     tls:
-        #         key: tls.key
-        #         cert: tls.crt
+        #         cert: fullchain.pem
+        #         key: privkey.pem
 
     # sets the permissions for Unix listen sockets. on a typical Linux system,
     # the default is 0775 or 0755, which prevents other users/groups from connecting

--- a/oragono.yaml
+++ b/oragono.yaml
@@ -50,8 +50,8 @@ server:
         # The standard SSL/TLS port for IRC is 6697. This will listen on all interfaces:
         ":6697":
             tls:
-                key: tls.key
-                cert: tls.crt
+                cert: fullchain.pem
+                key: privkey.pem
                 # 'proxy' should typically be false. It's only for Kubernetes-style load
                 # balancing that does not terminate TLS, but sends an initial PROXY line
                 # in plaintext.
@@ -70,8 +70,8 @@ server:
         # ":8097":
         #     websocket: true
         #     tls:
-        #         key: tls.key
-        #         cert: tls.crt
+        #         cert: fullchain.pem
+        #         key: privkey.pem
 
     # sets the permissions for Unix listen sockets. on a typical Linux system,
     # the default is 0775 or 0755, which prevents other users/groups from connecting


### PR DESCRIPTION
I'm not 100% sure about this, but anecdotally the current names are a source of confusion (sometimes people transpose the filenames). These names match the names used by Let's Encrypt, making it easier to upgrade.

Thoughts?