### PR TITLE
fix #1061

### DIFF
--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1997,7 +1997,7 @@ func dispatchMessageToTarget(client *Client, tags map[string]string, histType hi
 			AccountName: accountName,
 			Tags:        tags,
 		}
-		if !item.IsStorable() {
+		if !item.IsStorable() || !allowedPlusR {
 			return
 		}
 		targetedItem := item


### PR DESCRIPTION
This unconditionally refuses to store the message if it was blocked by +R, which goes against the earlier objective of making it impossible to tell when that happens. I decided I don't really care one way or another.