### PR TITLE
Apply default user modes just before registration.

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -337,7 +337,6 @@ func (server *Server) RunClient(conn IRCConn) {
 	session.idletimer.Initialize(session)
 	session.resetFakelag()
 
-	ApplyUserModeChanges(client, config.Accounts.defaultUserModes, false, nil)
 	if wConn.Secure {
 		client.SetMode(modes.TLS, true)
 	}

--- a/irc/config.go
+++ b/irc/config.go
@@ -256,7 +256,7 @@ type AccountConfig struct {
 		exemptedNets []net.IPNet
 	} `yaml:"require-sasl"`
 	DefaultUserModes    *string `yaml:"default-user-modes"`
-	defaultUserModes    modes.ModeChanges
+	defaultUserModes    modes.Modes
 	LDAP                ldap.ServerConfig
 	LoginThrottling     ThrottleConfig `yaml:"login-throttling"`
 	SkipServerPassword  bool           `yaml:"skip-server-password"`

--- a/irc/modes_test.go
+++ b/irc/modes_test.go
@@ -43,19 +43,19 @@ func TestParseDefaultUserModes(t *testing.T) {
 
 	var parseTests = []struct {
 		raw      *string
-		expected modes.ModeChanges
+		expected modes.Modes
 	}{
-		{&iR, modes.ModeChanges{{Mode: modes.Invisible, Op: modes.Add}, {Mode: modes.RegisteredOnly, Op: modes.Add}}},
-		{&i, modes.ModeChanges{{Mode: modes.Invisible, Op: modes.Add}}},
-		{&empty, modes.ModeChanges{}},
-		{&rminusi, modes.ModeChanges{{Mode: modes.RegisteredOnly, Op: modes.Add}}},
-		{nil, modes.ModeChanges{}},
+		{&iR, modes.Modes{modes.Invisible, modes.RegisteredOnly}},
+		{&i, modes.Modes{modes.Invisible}},
+		{&empty, modes.Modes{}},
+		{&rminusi, modes.Modes{modes.RegisteredOnly}},
+		{nil, modes.Modes{}},
 	}
 
 	for _, testcase := range parseTests {
 		result := ParseDefaultUserModes(testcase.raw)
 		if !reflect.DeepEqual(result, testcase.expected) {
-			t.Errorf("expected modes %v, got %v", testcase.expected, result)
+			t.Errorf("expected modes %s, got %s", testcase.expected, result)
 		}
 	}
 }

--- a/irc/server.go
+++ b/irc/server.go
@@ -266,11 +266,18 @@ func (server *Server) tryRegister(c *Client, session *Session) (exiting bool) {
 		return true
 	}
 
+	// Apply default user modes (without updating the invisible counter)
+	// The number of invisible users will be updated by server.stats.Register
+	// if we're using default user mode +i.
+	for _, defaultMode := range server.Config().Accounts.defaultUserModes {
+		c.SetMode(defaultMode, true)
+	}
+
 	// registration has succeeded:
 	c.SetRegistered()
 
 	// count new user in statistics
-	server.stats.Register()
+	server.stats.Register(c.HasMode(modes.Invisible))
 	server.monitorManager.AlertAbout(c, true)
 
 	server.playRegistrationBurst(session)

--- a/irc/stats.go
+++ b/irc/stats.go
@@ -41,9 +41,12 @@ func (s *Stats) AddRegistered(invisible, operator bool) {
 }
 
 // Transition a client from unregistered to registered
-func (s *Stats) Register() {
+func (s *Stats) Register(invisible bool) {
 	s.mutex.Lock()
 	s.Unknown -= 1
+	if invisible {
+		s.Invisible += 1
+	}
 	s.Total += 1
 	s.setMax()
 	s.mutex.Unlock()


### PR DESCRIPTION
Previously, we were applying defaults before the user had completed registration. This meant that the number of invisible users was incremented when the user connected, and then the total was incremented when registration was completed.

Now both counters are updated at the same time. If a user disconnects prior to registration, +i has not yet been applied so it would not be decremented.

Fixes #1077.