### PR TITLE
fix #1108

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -1719,7 +1719,7 @@ func (am *AccountManager) applyVHostInfo(client *Client, info VHostInfo) {
 	updated := client.SetVHost(vhost)
 	if updated {
 		// TODO: doing I/O here is kind of a kludge
-		go client.sendChghost(oldNickmask, client.Hostname())
+		client.sendChghost(oldNickmask, client.Hostname())
 	}
 }
 

--- a/irc/client.go
+++ b/irc/client.go
@@ -1052,9 +1052,9 @@ func (client *Client) SetOper(oper *Oper) {
 // XXX: CHGHOST requires prefix nickmask to have original hostname,
 // this is annoying to do correctly
 func (client *Client) sendChghost(oldNickMask string, vhost string) {
-	username := client.Username()
+	details := client.Details()
 	for fClient := range client.Friends(caps.ChgHost) {
-		fClient.sendFromClientInternal(false, time.Time{}, "", oldNickMask, client.AccountName(), nil, "CHGHOST", username, vhost)
+		fClient.sendFromClientInternal(false, time.Time{}, "", oldNickMask, details.accountName, nil, "CHGHOST", details.username, vhost)
 	}
 }
 


### PR DESCRIPTION
The active ingredient here is just removing the use of `go`. I was doing this to protect against deadlocks but I looked more carefully at the lock model and it's unnecessary.