### PR TITLE
Copy Insp's new BOT ISUPPORT token and WHO behaviour

### DIFF
--- a/irc/config.go
+++ b/irc/config.go
@@ -1166,6 +1166,7 @@ func (config *Config) generateISupport() (err error) {
 	isupport := &config.Server.isupport
 	isupport.Initialize()
 	isupport.Add("AWAYLEN", strconv.Itoa(config.Limits.AwayLen))
+	isupport.Add("BOT", "B")
 	isupport.Add("CASEMAPPING", "ascii")
 	isupport.Add("CHANLIMIT", fmt.Sprintf("%s:%d", chanTypes, config.Channels.MaxChannelsPerClient))
 	isupport.Add("CHANMODES", strings.Join([]string{modes.Modes{modes.BanMask, modes.ExceptMask, modes.InviteMask}.String(), modes.Modes{modes.Key}.String(), modes.Modes{modes.UserLimit}.String(), modes.Modes{modes.InviteOnly, modes.Moderated, modes.NoOutside, modes.OpOnlyTopic, modes.ChanRoleplaying, modes.Secret, modes.NoCTCP, modes.RegisteredOnly}.String()}, ","))

--- a/irc/server.go
+++ b/irc/server.go
@@ -444,6 +444,9 @@ func (client *Client) rplWhoReply(channel *Channel, target *Client, rb *Response
 		flags += channel.ClientPrefixes(target, rb.session.capabilities.Has(caps.MultiPrefix))
 		channelName = channel.name
 	}
+	if target.HasMode(modes.Bot) {
+		flags += "B"
+	}
 	details := target.Details()
 	// hardcode a hopcount of 0 for now
 	rb.Add(nil, client.server.name, RPL_WHOREPLY, client.Nick(), channelName, details.username, details.hostname, client.server.name, details.nick, flags, "0 "+details.realname)


### PR DESCRIPTION
This matches Insp's new behaviour and allows an initial better way for clients to see which other users are bots. See also https://github.com/inspircd/inspircd/commit/31815edd6a6b98434bace5359234d2b47397ee0a