### PR TITLE
use strings.Builder instead of bytes.Buffer where applicable

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -6,7 +6,6 @@
 package irc
 
 import (
-	"bytes"
 	"fmt"
 	"strconv"
 	"strings"
@@ -447,7 +446,7 @@ func (channel *Channel) Names(client *Client, rb *ResponseBuffer) {
 
 	maxNamLen := 480 - len(client.server.name) - len(client.Nick())
 	var namesLines []string
-	var buffer bytes.Buffer
+	var buffer strings.Builder
 	if isJoined || !channel.flags.HasMode(modes.Secret) || isOper {
 		for _, target := range channel.Members() {
 			var nick string

--- a/irc/utils/glob.go
+++ b/irc/utils/glob.go
@@ -4,14 +4,14 @@
 package utils
 
 import (
-	"bytes"
 	"regexp"
 	"regexp/syntax"
+	"strings"
 )
 
 // yet another glob implementation in Go
 
-func addRegexp(buf *bytes.Buffer, glob string, submatch bool) (err error) {
+func addRegexp(buf *strings.Builder, glob string, submatch bool) (err error) {
 	for _, r := range glob {
 		switch r {
 		case '*':
@@ -36,7 +36,7 @@ func addRegexp(buf *bytes.Buffer, glob string, submatch bool) (err error) {
 }
 
 func CompileGlob(glob string, submatch bool) (result *regexp.Regexp, err error) {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	buf.WriteByte('^')
 	err = addRegexp(&buf, glob, submatch)
 	if err != nil {
@@ -50,7 +50,7 @@ func CompileGlob(glob string, submatch bool) (result *regexp.Regexp, err error) 
 // This is used for channel ban/invite/exception lists. It's applicable to k-lines
 // but we're not using it there yet.
 func CompileMasks(masks []string) (result *regexp.Regexp, err error) {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	buf.WriteString("^(")
 	for i, mask := range masks {
 		err = addRegexp(&buf, mask, false)

--- a/irc/utils/text.go
+++ b/irc/utils/text.go
@@ -4,7 +4,6 @@
 package utils
 
 import (
-	"bytes"
 	"strings"
 	"time"
 )
@@ -98,7 +97,7 @@ func (sm *SplitMessage) Is512() bool {
 type TokenLineBuilder struct {
 	lineLen int
 	delim   string
-	buf     bytes.Buffer
+	buf     strings.Builder
 	result  []string
 }
 


### PR DESCRIPTION
`strings.Builder` is faster in the cases where the result is used as a string (with `bytes.Buffer`, the mutable buffer has to be copied to produce an immutable string).