### PR TITLE
Send labeled-response=all to indicate we do it for all commands

### DIFF
--- a/irc/config.go
+++ b/irc/config.go
@@ -860,6 +860,9 @@ func LoadConfig(filename string) (config *Config, err error) {
 	config.Server.supportedCaps = caps.NewCompleteSet()
 	config.Server.capValues = make(caps.Values)
 
+	// indicates that we send labeled responses for ALL commands
+	config.Server.capValues[caps.LabeledResponse] = "all"
+
 	err = config.prepareListeners()
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare listeners: %v", err)


### PR DESCRIPTION
e's indicated that they're going to do something like this as well, if we're able to assure clients that labeled-response is supported for _everything_ then it makes things simpler on their end and gives them a better assumption about server behaviour.