### PR TITLE
fix #1151

### DIFF
--- a/conventional.yaml
+++ b/conventional.yaml
@@ -100,7 +100,7 @@ server:
 
     # casemapping controls what kinds of strings are permitted as identifiers (nicknames,
     # channel names, account names, etc.), and how they are normalized for case.
-    # with the recommended default of 'precis', utf-8 identifiers that are "sane"
+    # with the recommended default of 'precis', UTF8 identifiers that are "sane"
     # (according to RFC 8265) are allowed, and the server additionally tries to protect
     # against confusable characters ("homoglyph attacks").
     # the other options are 'ascii' (traditional ASCII-only identifiers), and 'permissive',
@@ -109,6 +109,11 @@ server:
     # we recommend leaving this value at its default (changing it once the network is
     # already up and running is problematic).
     casemapping: "precis"
+
+    # enforce-utf8 controls whether the server allows non-UTF8 bytes in messages
+    # (as in traditional IRC) or preemptively discards non-UTF8 messages (since
+    # they cannot be relayed to websocket clients).
+    enforce-utf8: true
 
     # whether to look up user hostnames with reverse DNS.
     # (disabling this will expose user IPs instead of hostnames;

--- a/default.yaml
+++ b/default.yaml
@@ -126,7 +126,7 @@ server:
 
     # casemapping controls what kinds of strings are permitted as identifiers (nicknames,
     # channel names, account names, etc.), and how they are normalized for case.
-    # with the recommended default of 'precis', utf-8 identifiers that are "sane"
+    # with the recommended default of 'precis', UTF8 identifiers that are "sane"
     # (according to RFC 8265) are allowed, and the server additionally tries to protect
     # against confusable characters ("homoglyph attacks").
     # the other options are 'ascii' (traditional ASCII-only identifiers), and 'permissive',
@@ -135,6 +135,11 @@ server:
     # we recommend leaving this value at its default (changing it once the network is
     # already up and running is problematic).
     casemapping: "precis"
+
+    # enforce-utf8 controls whether the server allows non-UTF8 bytes in messages
+    # (as in traditional IRC) or preemptively discards non-UTF8 messages (since
+    # they cannot be relayed to websocket clients).
+    enforce-utf8: true
 
     # whether to look up user hostnames with reverse DNS.
     # (disabling this will expose user IPs instead of hostnames;

--- a/irc/commands.go
+++ b/irc/commands.go
@@ -79,6 +79,11 @@ var unknownCommand = Command{
 	usablePreReg: true,
 }
 
+var invalidUtf8Command = Command{
+	handler:      invalidUtf8Handler,
+	usablePreReg: true,
+}
+
 // Commands holds all commands executable by a client connected to us.
 var Commands map[string]Command
 

--- a/irc/config.go
+++ b/irc/config.go
@@ -518,6 +518,7 @@ type Config struct {
 		supportedCaps *caps.Set
 		capValues     caps.Values
 		Casemapping   Casemapping
+		EnforceUtf8   bool   `yaml:"enforce-utf8"`
 		OutputPath    string `yaml:"output-path"`
 	}
 

--- a/irc/errors.go
+++ b/irc/errors.go
@@ -66,6 +66,7 @@ var (
 	errCredsExternallyManaged         = errors.New("Credentials are externally managed and cannot be changed here")
 	errInvalidMultilineBatch          = errors.New("Invalid multiline batch")
 	errTimedOut                       = errors.New("Operation timed out")
+	errInvalidUtf8                    = errors.New("Message rejected for invalid utf8")
 )
 
 // Socket Errors

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2930,6 +2930,6 @@ func unknownCommandHandler(server *Server, client *Client, msg ircmsg.IrcMessage
 
 // fake handler for invalid utf8
 func invalidUtf8Handler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
-	rb.Add(nil, server.name, ERR_UNKNOWNERROR, client.Nick(), utils.SafeErrorParam(msg.Command), client.t("Message rejected for containing invalid UTF-8"))
+	rb.Add(nil, server.name, "FAIL", utils.SafeErrorParam(msg.Command), "INVALID_UTF8", client.t("Message rejected for containing invalid UTF-8"))
 	return false
 }

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2927,3 +2927,9 @@ func unknownCommandHandler(server *Server, client *Client, msg ircmsg.IrcMessage
 	rb.Add(nil, server.name, ERR_UNKNOWNCOMMAND, client.Nick(), utils.SafeErrorParam(msg.Command), client.t("Unknown command"))
 	return false
 }
+
+// fake handler for invalid utf8
+func invalidUtf8Handler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
+	rb.Add(nil, server.name, ERR_UNKNOWNERROR, client.Nick(), utils.SafeErrorParam(msg.Command), client.t("Message rejected for containing invalid UTF-8"))
+	return false
+}

--- a/irc/ircconn.go
+++ b/irc/ircconn.go
@@ -76,7 +76,6 @@ func (cc *IRCStreamConn) ReadLine() (line []byte, err error) {
 	if isPrefix {
 		return nil, errReadQ
 	}
-	line = bytes.TrimSuffix(line, crlf)
 	if globalUtf8EnforcementSetting && !utf8.Valid(line) {
 		err = errInvalidUtf8
 	}

--- a/irc/ircconn.go
+++ b/irc/ircconn.go
@@ -77,6 +77,9 @@ func (cc *IRCStreamConn) ReadLine() (line []byte, err error) {
 		return nil, errReadQ
 	}
 	line = bytes.TrimSuffix(line, crlf)
+	if globalUtf8EnforcementSetting && !utf8.Valid(line) {
+		err = errInvalidUtf8
+	}
 	return
 }
 
@@ -101,9 +104,9 @@ func (wc IRCWSConn) UnderlyingConn() *utils.WrappedConn {
 
 func (wc IRCWSConn) WriteLine(buf []byte) (err error) {
 	buf = bytes.TrimSuffix(buf, crlf)
-	// there's not much we can do about this;
-	// silently drop the message
-	if !utf8.Valid(buf) {
+	if !globalUtf8EnforcementSetting && !utf8.Valid(buf) {
+		// there's not much we can do about this;
+		// silently drop the message
 		return nil
 	}
 	return wc.conn.WriteMessage(websocket.TextMessage, buf)

--- a/irc/server.go
+++ b/irc/server.go
@@ -487,6 +487,7 @@ func (server *Server) applyConfig(config *Config) (err error) {
 		server.name = config.Server.Name
 		server.nameCasefolded = config.Server.nameCasefolded
 		globalCasemappingSetting = config.Server.Casemapping
+		globalUtf8EnforcementSetting = config.Server.EnforceUtf8
 	} else {
 		// enforce configs that can't be changed after launch:
 		if server.name != config.Server.Name {
@@ -495,6 +496,8 @@ func (server *Server) applyConfig(config *Config) (err error) {
 			return fmt.Errorf("Datastore path cannot be changed after launching the server, rehash aborted")
 		} else if globalCasemappingSetting != config.Server.Casemapping {
 			return fmt.Errorf("Casemapping cannot be changed after launching the server, rehash aborted")
+		} else if globalUtf8EnforcementSetting != config.Server.EnforceUtf8 {
+			return fmt.Errorf("UTF-8 enforcement cannot be changed after launching the server, rehash aborted")
 		} else if oldConfig.Accounts.Multiclient.AlwaysOn != config.Accounts.Multiclient.AlwaysOn {
 			return fmt.Errorf("Default always-on setting cannot be changed after launching the server, rehash aborted")
 		}

--- a/irc/socket.go
+++ b/irc/socket.go
@@ -75,6 +75,9 @@ func (socket *Socket) Read() (string, error) {
 
 	if err == io.EOF && strings.TrimSpace(line) != "" {
 		// don't do anything
+	} else if err == errInvalidUtf8 {
+		// pass the data through so we can parse the command at least
+		return line, err
 	} else if err != nil {
 		return "", err
 	}

--- a/irc/socket.go
+++ b/irc/socket.go
@@ -7,7 +7,6 @@ package irc
 import (
 	"errors"
 	"io"
-	"strings"
 	"sync"
 
 	"github.com/oragono/oragono/irc/utils"
@@ -59,30 +58,24 @@ func (socket *Socket) Close() {
 
 // Read returns a single IRC line from a Socket.
 func (socket *Socket) Read() (string, error) {
+	// immediately fail if Close() has been called, even if there's
+	// still data in a bufio.Reader or websocket buffer:
 	if socket.IsClosed() {
 		return "", io.EOF
 	}
 
 	lineBytes, err := socket.conn.ReadLine()
-
-	// convert bytes to string
 	line := string(lineBytes)
 
-	// read last message properly (such as ERROR/QUIT/etc), just fail next reads/writes
 	if err == io.EOF {
 		socket.Close()
+		// process last message properly (such as ERROR/QUIT/etc), just fail next reads/writes
+		if line != "" {
+			err = nil
+		}
 	}
 
-	if err == io.EOF && strings.TrimSpace(line) != "" {
-		// don't do anything
-	} else if err == errInvalidUtf8 {
-		// pass the data through so we can parse the command at least
-		return line, err
-	} else if err != nil {
-		return "", err
-	}
-
-	return line, nil
+	return line, err
 }
 
 // Write sends the given string out of Socket. Requirements:

--- a/irc/strings.go
+++ b/irc/strings.go
@@ -53,7 +53,7 @@ var globalCasemappingSetting Casemapping = CasemappingPRECIS
 // XXX analogous unsynchronized global variable controlling utf8 validation
 // if this is off, you get the traditional IRC behavior (relaying any valid RFC1459
 // octets) and invalid utf8 messages are silently dropped for websocket clients only.
-// if this is on, invalid utf8 inputs get an ERR_UNKNOWNERROR.
+// if this is on, invalid utf8 inputs get a FAIL reply.
 var globalUtf8EnforcementSetting bool
 
 // Each pass of PRECIS casefolding is a composition of idempotent operations,

--- a/irc/strings.go
+++ b/irc/strings.go
@@ -50,6 +50,10 @@ const (
 // this happens-before all IRC connections and all casefolding operations.
 var globalCasemappingSetting Casemapping = CasemappingPRECIS
 
+// XXX analogous unsynchronized global variable controlling utf8 validation
+// if this is off, you get the traditional IRC behavior (relaying any valid RFC1459
+// octets) and invalid utf8 messages are silently dropped for websocket clients only.
+// if this is on, invalid utf8 inputs get an ERR_UNKNOWNERROR.
 var globalUtf8EnforcementSetting bool
 
 // Each pass of PRECIS casefolding is a composition of idempotent operations,

--- a/irc/strings.go
+++ b/irc/strings.go
@@ -50,6 +50,8 @@ const (
 // this happens-before all IRC connections and all casefolding operations.
 var globalCasemappingSetting Casemapping = CasemappingPRECIS
 
+var globalUtf8EnforcementSetting bool
+
 // Each pass of PRECIS casefolding is a composition of idempotent operations,
 // but not idempotent itself. Therefore, the spec says "do it four times and hope
 // it converges" (lolwtf). Golang's PRECIS implementation has a "repeat" option,


### PR DESCRIPTION
I also wrote an irctest for this. Conventional IRC sockets potentially need a validation check for inputs; websockets potentially need one for outputs; invalid utf-8 lines are labeled when applicable (compare #994).