### PR TITLE
fix #802

### DIFF
--- a/irc/server.go
+++ b/irc/server.go
@@ -291,7 +291,7 @@ func (server *Server) playSTSBurst(session *Session) {
 	session.Send(nil, server.name, RPL_YOURHOST, nick, fmt.Sprintf("Your host is %[1]s, running version %[2]s", server.name, "oragono"))
 	session.Send(nil, server.name, RPL_CREATED, nick, fmt.Sprintf("This server was created %s", time.Time{}.Format(time.RFC1123)))
 	session.Send(nil, server.name, RPL_MYINFO, nick, server.name, "oragono", "o", "o", "o")
-	session.Send(nil, server.name, RPL_ISUPPORT, nick, "CASEMAPPING=ascii MODES")
+	session.Send(nil, server.name, RPL_ISUPPORT, nick, "CASEMAPPING=ascii", "are supported by this server")
 	session.Send(nil, server.name, ERR_NOMOTD, nick, "MOTD is unavailable")
 	for _, line := range server.Config().Server.STS.bannerLines {
 		session.Send(nil, server.name, "NOTICE", nick, line)

--- a/irc/server.go
+++ b/irc/server.go
@@ -291,7 +291,7 @@ func (server *Server) playSTSBurst(session *Session) {
 	session.Send(nil, server.name, RPL_YOURHOST, nick, fmt.Sprintf("Your host is %[1]s, running version %[2]s", server.name, "oragono"))
 	session.Send(nil, server.name, RPL_CREATED, nick, fmt.Sprintf("This server was created %s", time.Time{}.Format(time.RFC1123)))
 	session.Send(nil, server.name, RPL_MYINFO, nick, server.name, "oragono", "o", "o", "o")
-	session.Send(nil, server.name, RPL_ISUPPORT, nick, "CASEMAPPING=ascii")
+	session.Send(nil, server.name, RPL_ISUPPORT, nick, "CASEMAPPING=ascii MODES")
 	session.Send(nil, server.name, ERR_NOMOTD, nick, "MOTD is unavailable")
 	for _, line := range server.Config().Server.STS.bannerLines {
 		session.Send(nil, server.name, "NOTICE", nick, line)


### PR DESCRIPTION
I realized the STS-only cap advertisement included `labeled-response` without `batch`. So I threw in `batch` and `echo-message` for good measure.

Other server capabilities are obfuscated (hence the bogus values for 003, 004, and 005). The client can learn the server name and that the ircd is oragono, but not the oragono version, anything about how the server is configured besides the STS value, or the startup time.

````
CAP LS 302
:oragono.test CAP * LS :batch echo-message labeled-response message-tags oragono.io/nope server-time sts=duration=31536000,port=6697
CAP REQ :server-time message-tags batch labeled-response echo-message
@time=2020-07-02T07:32:30.603Z :oragono.test CAP * ACK :server-time message-tags batch labeled-response echo-message
NICK shivaram
USER u s e r
CAP END
@time=2020-07-02T07:32:41.611Z :oragono.test 001 shivaram :Welcome to the Internet Relay Network shivaram
@time=2020-07-02T07:32:41.612Z :oragono.test 002 shivaram :Your host is oragono.test, running version oragono
@time=2020-07-02T07:32:41.612Z :oragono.test 003 shivaram :This server was created Mon, 01 Jan 0001 00:00:00 UTC
@time=2020-07-02T07:32:41.612Z :oragono.test 004 shivaram oragono.test oragono o o o
@time=2020-07-02T07:32:41.612Z :oragono.test 005 shivaram CASEMAPPING=ascii
@time=2020-07-02T07:32:41.612Z :oragono.test 422 shivaram :MOTD is unavailable
@time=2020-07-02T07:32:41.612Z :oragono.test NOTICE shivaram :This server is only accessible over TLS. Please reconnect using TLS on port 6697.
ERROR :Connection closed
````