### PR TITLE
fix an edge case with `/NS SASET user always-on true`

### DIFF
--- a/irc/getters.go
+++ b/irc/getters.go
@@ -330,6 +330,8 @@ func (client *Client) SetAccountSettings(settings AccountSettings) {
 	alwaysOn := persistenceEnabled(client.server.Config().Accounts.Multiclient.AlwaysOn, settings.AlwaysOn)
 	client.stateMutex.Lock()
 	if client.registered {
+		// only allow the client to become always-on if their nick equals their account name
+		alwaysOn = alwaysOn && client.nick == client.accountName
 		autoreplayMissedDisabled = (client.accountSettings.AutoreplayMissed && !settings.AutoreplayMissed)
 		becameAlwaysOn = (!client.alwaysOn && alwaysOn)
 		client.alwaysOn = alwaysOn


### PR DESCRIPTION
If force-nick-equals-account is disabled, then this could cause
a client with a non-reserved (or grouped) nick to become always-on.
(This can't happen with `/NS SET always-on true` because we check in
advance.)