### PR TITLE
more memory-efficient implementation of line reading

### DIFF
--- a/irc/history/history.go
+++ b/irc/history/history.go
@@ -321,18 +321,6 @@ func (list *Buffer) next(index int) int {
 	}
 }
 
-// return n such that v <= n and n == 2**i for some i
-func roundUpToPowerOfTwo(v int) int {
-	// http://graphics.stanford.edu/~seander/bithacks.html
-	v -= 1
-	v |= v >> 1
-	v |= v >> 2
-	v |= v >> 4
-	v |= v >> 8
-	v |= v >> 16
-	return v + 1
-}
-
 func (list *Buffer) maybeExpand() {
 	if list.window == 0 {
 		return // autoresize is disabled
@@ -352,7 +340,7 @@ func (list *Buffer) maybeExpand() {
 		return // oldest element is old enough to overwrite
 	}
 
-	newSize := roundUpToPowerOfTwo(length + 1)
+	newSize := utils.RoundUpToPowerOfTwo(length + 1)
 	if list.maximumSize < newSize {
 		newSize = list.maximumSize
 	}

--- a/irc/history/history_test.go
+++ b/irc/history/history_test.go
@@ -241,17 +241,6 @@ func TestDisabledByResize(t *testing.T) {
 	assertEqual(len(items), 0, t)
 }
 
-func TestRoundUp(t *testing.T) {
-	assertEqual(roundUpToPowerOfTwo(2), 2, t)
-	assertEqual(roundUpToPowerOfTwo(3), 4, t)
-	assertEqual(roundUpToPowerOfTwo(64), 64, t)
-	assertEqual(roundUpToPowerOfTwo(65), 128, t)
-	assertEqual(roundUpToPowerOfTwo(100), 128, t)
-	assertEqual(roundUpToPowerOfTwo(1000), 1024, t)
-	assertEqual(roundUpToPowerOfTwo(1025), 2048, t)
-	assertEqual(roundUpToPowerOfTwo(269435457), 536870912, t)
-}
-
 func BenchmarkInsert(b *testing.B) {
 	buf := NewHistoryBuffer(1024, 0)
 	b.ResetTimer()

--- a/irc/ircconn_test.go
+++ b/irc/ircconn_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2020 Shivaram Lingamneni <slingamn@cs.stanford.edu>
+// released under the MIT license
+
+package irc
+
+import (
+	"io"
+	"math/rand"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/oragono/oragono/irc/utils"
+)
+
+// mockConn is a fake net.Conn / io.Reader that yields len(counts) lines,
+// each consisting of counts[i] 'a' characters and a terminating '\n'
+type mockConn struct {
+	counts []int
+}
+
+func min(i, j int) (m int) {
+	if i < j {
+		return i
+	} else {
+		return j
+	}
+}
+
+func (c *mockConn) Read(b []byte) (n int, err error) {
+	for len(b) > 0 {
+		if len(c.counts) == 0 {
+			return n, io.EOF
+		}
+		if c.counts[0] == 0 {
+			b[0] = '\n'
+			c.counts = c.counts[1:]
+			b = b[1:]
+			n += 1
+			continue
+		}
+		size := min(c.counts[0], len(b))
+		for i := 0; i < size; i++ {
+			b[i] = 'a'
+		}
+		c.counts[0] -= size
+		b = b[size:]
+		n += size
+	}
+	return n, nil
+}
+
+func (c *mockConn) Write(b []byte) (n int, err error) {
+	return
+}
+
+func (c *mockConn) Close() error {
+	c.counts = nil
+	return nil
+}
+
+func (c *mockConn) LocalAddr() net.Addr {
+	return nil
+}
+
+func (c *mockConn) RemoteAddr() net.Addr {
+	return nil
+}
+
+func (c *mockConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *mockConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *mockConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+func newMockConn(counts []int) *utils.WrappedConn {
+	cpCounts := make([]int, len(counts))
+	copy(cpCounts, counts)
+	c := &mockConn{
+		counts: cpCounts,
+	}
+	return &utils.WrappedConn{
+		Conn: c,
+	}
+}
+
+// construct a mock reader with some number of \n-terminated lines,
+// verify that IRCStreamConn can read and split them as expected
+func doLineReaderTest(counts []int, t *testing.T) {
+	c := newMockConn(counts)
+	r := NewIRCStreamConn(c)
+	var readCounts []int
+	for {
+		line, err := r.ReadLine()
+		if err == nil {
+			readCounts = append(readCounts, len(line))
+		} else if err == io.EOF {
+			break
+		} else {
+			panic(err)
+		}
+	}
+
+	if !reflect.DeepEqual(counts, readCounts) {
+		t.Errorf("expected %#v, got %#v", counts, readCounts)
+	}
+}
+
+const (
+	maxMockReaderLen     = 100
+	maxMockReaderLineLen = 4096 + 511
+)
+
+func TestLineReader(t *testing.T) {
+	counts := []int{44, 428, 3, 0, 200, 2000, 0, 4044, 33, 3, 2, 1, 0, 1, 2, 3, 48, 555}
+	doLineReaderTest(counts, t)
+
+	// fuzz
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 1000; i++ {
+		countsLen := r.Intn(maxMockReaderLen) + 1
+		counts := make([]int, countsLen)
+		for i := 0; i < countsLen; i++ {
+			counts[i] = r.Intn(maxMockReaderLineLen)
+		}
+		doLineReaderTest(counts, t)
+	}
+}

--- a/irc/socket.go
+++ b/irc/socket.go
@@ -69,10 +69,6 @@ func (socket *Socket) Read() (string, error) {
 
 	if err == io.EOF {
 		socket.Close()
-		// process last message properly (such as ERROR/QUIT/etc), just fail next reads/writes
-		if line != "" {
-			err = nil
-		}
 	}
 
 	return line, err

--- a/irc/utils/math.go
+++ b/irc/utils/math.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2020 Shivaram Lingamneni <slingamn@cs.stanford.edu>
+// released under the MIT license
+
+package utils
+
+// return n such that v <= n and n == 2**i for some i
+func RoundUpToPowerOfTwo(v int) int {
+	// http://graphics.stanford.edu/~seander/bithacks.html
+	v -= 1
+	v |= v >> 1
+	v |= v >> 2
+	v |= v >> 4
+	v |= v >> 8
+	v |= v >> 16
+	return v + 1
+}

--- a/irc/utils/math_test.go
+++ b/irc/utils/math_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 Shivaram Lingamneni <slingamn@cs.stanford.edu>
+// released under the MIT license
+
+package utils
+
+import (
+	"testing"
+)
+
+func TestRoundUp(t *testing.T) {
+	assertEqual(RoundUpToPowerOfTwo(2), 2, t)
+	assertEqual(RoundUpToPowerOfTwo(3), 4, t)
+	assertEqual(RoundUpToPowerOfTwo(64), 64, t)
+	assertEqual(RoundUpToPowerOfTwo(65), 128, t)
+	assertEqual(RoundUpToPowerOfTwo(100), 128, t)
+	assertEqual(RoundUpToPowerOfTwo(1000), 1024, t)
+	assertEqual(RoundUpToPowerOfTwo(1025), 2048, t)
+	assertEqual(RoundUpToPowerOfTwo(269435457), 536870912, t)
+}


### PR DESCRIPTION
Not necessarily for merge; I'm not entirely sure this code is correct.

This produces about a 20% savings in RSS on the connectflood benchmark (i.e., connecting a lot of concurrent clients that don't do anything on the server).