### PR TITLE
tweaks

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -1635,8 +1635,9 @@ func (session *Session) SendRawMessage(message ircmsg.IrcMessage, blocking bool)
 	// assemble message
 	line, err := message.LineBytesStrict(false, MaxLineLen)
 	if err != nil {
-		logline := fmt.Sprintf("Error assembling message for sending: %v\n%s", err, debug.Stack())
-		session.client.server.logger.Error("internal", logline)
+		errorParams := []string{"Error assembling message for sending", err.Error(), message.Command}
+		errorParams = append(errorParams, message.Params...)
+		session.client.server.logger.Error("internal", errorParams...)
 
 		message = ircmsg.MakeMessage(nil, session.client.server.name, ERR_UNKNOWNERROR, "*", "Error assembling message for sending")
 		line, _ := message.LineBytesStrict(false, 0)

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1083,6 +1083,7 @@ func infoHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Resp
 	rb.Add(nil, server.name, RPL_INFO, nick, fmt.Sprintf(client.t("This is Oragono version %s."), SemVer))
 	if Commit != "" {
 		rb.Add(nil, server.name, RPL_INFO, nick, fmt.Sprintf(client.t("It was built from git hash %s."), Commit))
+		rb.Add(nil, server.name, RPL_INFO, nick, fmt.Sprintf(client.t("It was compiled using %s."), runtime.Version()))
 	}
 	rb.Add(nil, server.name, RPL_INFO, nick, "")
 	rb.Add(nil, server.name, RPL_INFO, nick, client.t("Oragono is released under the MIT license."))


### PR DESCRIPTION
1. A stack trace is typically no longer informative about the root cause of a malformed line; most such traces just go through `(*ResponseBuffer).Send` now
2. Include the Go version in the `/INFO` output