### PR TITLE
correct trailing space on +R usermode documentation

### DIFF
--- a/irc/help.go
+++ b/irc/help.go
@@ -68,7 +68,7 @@ Oragono supports the following user modes:
   +a  |  User is marked as being away. This mode is set with the /AWAY command.
   +i  |  User is marked as invisible (their channels are hidden from whois replies).
   +o  |  User is an IRC operator.
-  +R  |  User only accepts messages from other registered users. 
+  +R  |  User only accepts messages from other registered users.
   +s  |  Server Notice Masks (see help with /HELPOP snomasks).
   +Z  |  User is connected via TLS.
   +B  |  User is a bot.


### PR DESCRIPTION
@DanielOaks when this kind of thing happens, existing translations don't go away entirely, right? They're still on the site as a reference for creating a new translation?