### PR TITLE
scripting API for IP bans

### DIFF
--- a/conventional.yaml
+++ b/conventional.yaml
@@ -256,6 +256,8 @@ server:
         timeout: 9s
         # how long after the SIGTERM before we follow up with a SIGKILL:
         kill-timeout: 1s
+        # how many scripts are allowed to run at once? 0 for no limit:
+        max-concurrency: 128
 
     # IP cloaking hides users' IP addresses from other users and from channel admins
     # (but not from server admins), while still allowing channel admins to ban
@@ -497,6 +499,8 @@ accounts:
         timeout: 9s
         # how long after the SIGTERM before we follow up with a SIGKILL:
         kill-timeout: 1s
+        # how many scripts are allowed to run at once? 0 for no limit:
+        max-concurrency: 128
 
 # channel options
 channels:

--- a/conventional.yaml
+++ b/conventional.yaml
@@ -257,7 +257,7 @@ server:
         # how long after the SIGTERM before we follow up with a SIGKILL:
         kill-timeout: 1s
         # how many scripts are allowed to run at once? 0 for no limit:
-        max-concurrency: 128
+        max-concurrency: 64
 
     # IP cloaking hides users' IP addresses from other users and from channel admins
     # (but not from server admins), while still allowing channel admins to ban
@@ -500,7 +500,7 @@ accounts:
         # how long after the SIGTERM before we follow up with a SIGKILL:
         kill-timeout: 1s
         # how many scripts are allowed to run at once? 0 for no limit:
-        max-concurrency: 128
+        max-concurrency: 64
 
 # channel options
 channels:

--- a/conventional.yaml
+++ b/conventional.yaml
@@ -243,6 +243,20 @@ server:
             #     max-concurrent-connections: 128
             #     max-connections-per-window: 1024
 
+    # pluggable IP ban mechanism, via subprocess invocation
+    # this can be used to check new connections against a DNSBL, for example
+    # see the manual for details on how to write an IP ban checking script
+    ip-check-script:
+        enabled: false
+        command: "/usr/local/bin/check-ip-ban"
+        # constant list of args to pass to the command; the actual query
+        # and result are transmitted over stdin/stdout:
+        args: []
+        # timeout for process execution, after which we send a SIGTERM:
+        timeout: 9s
+        # how long after the SIGTERM before we follow up with a SIGKILL:
+        kill-timeout: 1s
+
     # IP cloaking hides users' IP addresses from other users and from channel admins
     # (but not from server admins), while still allowing channel admins to ban
     # offending IP addresses or networks. In place of hostnames derived from reverse

--- a/default.yaml
+++ b/default.yaml
@@ -284,7 +284,7 @@ server:
         # how long after the SIGTERM before we follow up with a SIGKILL:
         kill-timeout: 1s
         # how many scripts are allowed to run at once? 0 for no limit:
-        max-concurrency: 128
+        max-concurrency: 64
 
     # IP cloaking hides users' IP addresses from other users and from channel admins
     # (but not from server admins), while still allowing channel admins to ban
@@ -528,7 +528,7 @@ accounts:
         # how long after the SIGTERM before we follow up with a SIGKILL:
         kill-timeout: 1s
         # how many scripts are allowed to run at once? 0 for no limit:
-        max-concurrency: 128
+        max-concurrency: 64
 
 # channel options
 channels:

--- a/default.yaml
+++ b/default.yaml
@@ -283,6 +283,8 @@ server:
         timeout: 9s
         # how long after the SIGTERM before we follow up with a SIGKILL:
         kill-timeout: 1s
+        # how many scripts are allowed to run at once? 0 for no limit:
+        max-concurrency: 128
 
     # IP cloaking hides users' IP addresses from other users and from channel admins
     # (but not from server admins), while still allowing channel admins to ban
@@ -525,6 +527,8 @@ accounts:
         timeout: 9s
         # how long after the SIGTERM before we follow up with a SIGKILL:
         kill-timeout: 1s
+        # how many scripts are allowed to run at once? 0 for no limit:
+        max-concurrency: 128
 
 # channel options
 channels:

--- a/default.yaml
+++ b/default.yaml
@@ -270,6 +270,20 @@ server:
             #     max-concurrent-connections: 128
             #     max-connections-per-window: 1024
 
+    # pluggable IP ban mechanism, via subprocess invocation
+    # this can be used to check new connections against a DNSBL, for example
+    # see the manual for details on how to write an IP ban checking script
+    ip-check-script:
+        enabled: false
+        command: "/usr/local/bin/check-ip-ban"
+        # constant list of args to pass to the command; the actual query
+        # and result are transmitted over stdin/stdout:
+        args: []
+        # timeout for process execution, after which we send a SIGTERM:
+        timeout: 9s
+        # how long after the SIGTERM before we follow up with a SIGKILL:
+        kill-timeout: 1s
+
     # IP cloaking hides users' IP addresses from other users and from channel admins
     # (but not from server admins), while still allowing channel admins to ban
     # offending IP addresses or networks. In place of hostnames derived from reverse

--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -1095,7 +1095,7 @@ func (am *AccountManager) AuthenticateByPassphrase(client *Client, accountName s
 	config := am.server.Config()
 	if config.Accounts.AuthScript.Enabled {
 		var output AuthScriptOutput
-		output, err = CheckAuthScript(config.Accounts.AuthScript,
+		output, err = CheckAuthScript(config.Accounts.AuthScript.ScriptConfig,
 			AuthScriptInput{AccountName: accountName, Passphrase: passphrase, IP: client.IP().String()})
 		if err != nil {
 			am.server.logger.Error("internal", "failed shell auth invocation", err.Error())
@@ -1494,7 +1494,7 @@ func (am *AccountManager) AuthenticateByCertFP(client *Client, certfp, authzid s
 	config := am.server.Config()
 	if config.Accounts.AuthScript.Enabled {
 		var output AuthScriptOutput
-		output, err = CheckAuthScript(config.Accounts.AuthScript,
+		output, err = CheckAuthScript(config.Accounts.AuthScript.ScriptConfig,
 			AuthScriptInput{Certfp: certfp, IP: client.IP().String()})
 		if err != nil {
 			am.server.logger.Error("internal", "failed shell auth invocation", err.Error())

--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -1095,7 +1095,7 @@ func (am *AccountManager) AuthenticateByPassphrase(client *Client, accountName s
 	config := am.server.Config()
 	if config.Accounts.AuthScript.Enabled {
 		var output AuthScriptOutput
-		output, err = CheckAuthScript(config.Accounts.AuthScript.ScriptConfig,
+		output, err = CheckAuthScript(am.server.semaphores.AuthScript, config.Accounts.AuthScript.ScriptConfig,
 			AuthScriptInput{AccountName: accountName, Passphrase: passphrase, IP: client.IP().String()})
 		if err != nil {
 			am.server.logger.Error("internal", "failed shell auth invocation", err.Error())
@@ -1494,7 +1494,7 @@ func (am *AccountManager) AuthenticateByCertFP(client *Client, certfp, authzid s
 	config := am.server.Config()
 	if config.Accounts.AuthScript.Enabled {
 		var output AuthScriptOutput
-		output, err = CheckAuthScript(config.Accounts.AuthScript.ScriptConfig,
+		output, err = CheckAuthScript(am.server.semaphores.AuthScript, config.Accounts.AuthScript.ScriptConfig,
 			AuthScriptInput{Certfp: certfp, IP: client.IP().String()})
 		if err != nil {
 			am.server.logger.Error("internal", "failed shell auth invocation", err.Error())

--- a/irc/authscript.go
+++ b/irc/authscript.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+
+	"github.com/oragono/oragono/irc/utils"
 )
 
 // JSON-serializable input and output types for the script
@@ -23,7 +25,12 @@ type AuthScriptOutput struct {
 	Error       string `json:"error"`
 }
 
-func CheckAuthScript(config ScriptConfig, input AuthScriptInput) (output AuthScriptOutput, err error) {
+func CheckAuthScript(sem utils.Semaphore, config ScriptConfig, input AuthScriptInput) (output AuthScriptOutput, err error) {
+	if sem != nil {
+		sem.Acquire()
+		defer sem.Release()
+	}
+
 	inputBytes, err := json.Marshal(input)
 	if err != nil {
 		return
@@ -65,7 +72,12 @@ type IPScriptOutput struct {
 	Error        string `json:"error"`
 }
 
-func CheckIPBan(config ScriptConfig, addr net.IP) (output IPScriptOutput, err error) {
+func CheckIPBan(sem utils.Semaphore, config ScriptConfig, addr net.IP) (output IPScriptOutput, err error) {
+	if sem != nil {
+		sem.Acquire()
+		defer sem.Release()
+	}
+
 	inputBytes, err := json.Marshal(IPScriptInput{IP: addr.String()})
 	if err != nil {
 		return

--- a/irc/client.go
+++ b/irc/client.go
@@ -317,7 +317,8 @@ func (server *Server) RunClient(conn IRCConn) {
 		}
 		// XXX only run the check script now if the IP cannot be replaced by PROXY or WEBIRC,
 		// otherwise we'll do it in ApplyProxiedIP.
-		checkScripts := config.Server.IPCheckScript.Enabled && !utils.IPInNets(realIP, config.Server.proxyAllowedFromNets)
+		checkScripts := config.Server.IPCheckScript.Enabled &&
+			(proxiedIP != nil || !utils.IPInNets(realIP, config.Server.proxyAllowedFromNets))
 		isBanned, requireSASL, banMsg = server.checkBans(config, ipToCheck, checkScripts)
 	}
 

--- a/irc/client.go
+++ b/irc/client.go
@@ -317,8 +317,7 @@ func (server *Server) RunClient(conn IRCConn) {
 		}
 		// XXX only run the check script now if the IP cannot be replaced by PROXY or WEBIRC,
 		// otherwise we'll do it in ApplyProxiedIP.
-		checkScripts := config.Server.IPCheckScript.Enabled &&
-			(proxiedIP != nil || !utils.IPInNets(realIP, config.Server.proxyAllowedFromNets))
+		checkScripts := proxiedIP != nil || !utils.IPInNets(realIP, config.Server.proxyAllowedFromNets)
 		isBanned, requireSASL, banMsg = server.checkBans(config, ipToCheck, checkScripts)
 	}
 

--- a/irc/client.go
+++ b/irc/client.go
@@ -96,6 +96,7 @@ type Client struct {
 	nickMaskString     string // cache for nickmask string since it's used with lots of replies
 	oper               *Oper
 	preregNick         string
+	ipScriptStatus     IPScriptResult
 	proxiedIP          net.IP // actual remote IP if using the PROXY protocol
 	rawHostname        string
 	cloakedHostname    string
@@ -554,7 +555,7 @@ const (
 	authFailSaslRequired
 )
 
-func (client *Client) isAuthorized(server *Server, config *Config, session *Session) AuthOutcome {
+func (client *Client) isAuthorized(server *Server, config *Config, session *Session, forceRequireSASL bool) AuthOutcome {
 	saslSent := client.account != ""
 	// PASS requirement
 	if (config.Server.passwordBytes != nil) && session.passStatus != serverPassSuccessful && !(config.Accounts.SkipServerPassword && saslSent) {
@@ -565,7 +566,7 @@ func (client *Client) isAuthorized(server *Server, config *Config, session *Sess
 		return authFailTorSaslRequired
 	}
 	// finally, enforce require-sasl
-	if !saslSent && (config.Accounts.RequireSasl.Enabled || server.Defcon() <= 2) &&
+	if !saslSent && (forceRequireSASL || config.Accounts.RequireSasl.Enabled || server.Defcon() <= 2) &&
 		!utils.IPInNets(session.IP(), config.Accounts.RequireSasl.exemptedNets) {
 		return authFailSaslRequired
 	}

--- a/irc/config.go
+++ b/irc/config.go
@@ -283,11 +283,12 @@ type AccountConfig struct {
 }
 
 type ScriptConfig struct {
-	Enabled     bool
-	Command     string
-	Args        []string
-	Timeout     time.Duration
-	KillTimeout time.Duration `yaml:"kill-timeout"`
+	Enabled        bool
+	Command        string
+	Args           []string
+	Timeout        time.Duration
+	KillTimeout    time.Duration `yaml:"kill-timeout"`
+	MaxConcurrency uint          `yaml:"max-concurrency"`
 }
 
 type AuthScriptConfig struct {

--- a/irc/config.go
+++ b/irc/config.go
@@ -282,13 +282,17 @@ type AccountConfig struct {
 	AuthScript  AuthScriptConfig `yaml:"auth-script"`
 }
 
-type AuthScriptConfig struct {
+type ScriptConfig struct {
 	Enabled     bool
 	Command     string
 	Args        []string
-	Autocreate  bool
 	Timeout     time.Duration
 	KillTimeout time.Duration `yaml:"kill-timeout"`
+}
+
+type AuthScriptConfig struct {
+	ScriptConfig `yaml:",inline"`
+	Autocreate   bool
 }
 
 // AccountRegistrationConfig controls account registration.
@@ -526,8 +530,9 @@ type Config struct {
 		supportedCaps *caps.Set
 		capValues     caps.Values
 		Casemapping   Casemapping
-		EnforceUtf8   bool   `yaml:"enforce-utf8"`
-		OutputPath    string `yaml:"output-path"`
+		EnforceUtf8   bool         `yaml:"enforce-utf8"`
+		OutputPath    string       `yaml:"output-path"`
+		IPCheckScript ScriptConfig `yaml:"ip-check-script"`
 	}
 
 	Roleplay struct {

--- a/irc/gateways.go
+++ b/irc/gateways.go
@@ -77,10 +77,11 @@ func (client *Client) ApplyProxiedIP(session *Session, proxiedIP net.IP, tls boo
 	}
 	proxiedIP = proxiedIP.To16()
 
-	isBanned, banMsg := client.server.checkBans(proxiedIP)
+	isBanned, requireSASL, banMsg := client.server.checkBans(client.server.Config(), proxiedIP, true)
 	if isBanned {
 		return errBanned, banMsg
 	}
+	client.requireSASL = requireSASL
 	// successfully added a limiter entry for the proxied IP;
 	// remove the entry for the real IP if applicable (#197)
 	client.server.connectionLimiter.RemoveClient(session.realIP)

--- a/irc/script.go
+++ b/irc/script.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2020 Shivaram Lingamneni
+// released under the MIT license
+
+package irc
+
+import (
+	"bufio"
+	"io"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// general-purpose scripting API for oragono "plugins"
+// invoke a command, send it a single newline-terminated string of bytes (typically JSON)
+// get back another newline-terminated string of bytes (or an error)
+
+// internal tupling of output and error for passing over a channel
+type scriptResponse struct {
+	output []byte
+	err    error
+}
+
+func RunScript(command string, args []string, input []byte, timeout, killTimeout time.Duration) (output []byte, err error) {
+	cmd := exec.Command(command, args...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return
+	}
+
+	channel := make(chan scriptResponse, 1)
+	err = cmd.Start()
+	if err != nil {
+		return
+	}
+	stdin.Write(input)
+	stdin.Write([]byte{'\n'})
+
+	// lots of potential race conditions here. we want to ensure that Wait()
+	// will be called, and will return, on the other goroutine, no matter
+	// where it is blocked. If it's blocked on ReadBytes(), we will kill it
+	// (first with SIGTERM, then with SIGKILL) and ReadBytes will return
+	// with EOF. If it's blocked on Wait(), then one of the kill signals
+	// will succeed and unblock it.
+	go processScriptOutput(cmd, stdout, channel)
+	outputTimer := time.NewTimer(timeout)
+	select {
+	case response := <-channel:
+		return response.output, response.err
+	case <-outputTimer.C:
+	}
+
+	err = errTimedOut
+	cmd.Process.Signal(syscall.SIGTERM)
+	termTimer := time.NewTimer(killTimeout)
+	select {
+	case <-channel:
+		return
+	case <-termTimer.C:
+	}
+
+	cmd.Process.Kill()
+	return
+}
+
+func processScriptOutput(cmd *exec.Cmd, stdout io.Reader, channel chan scriptResponse) {
+	var response scriptResponse
+
+	reader := bufio.NewReader(stdout)
+	response.output, response.err = reader.ReadBytes('\n')
+
+	// always call Wait() to ensure resource cleanup
+	err := cmd.Wait()
+	if err != nil {
+		response.err = err
+	}
+
+	channel <- response
+}

--- a/irc/semaphores.go
+++ b/irc/semaphores.go
@@ -27,6 +27,8 @@ type ServerSemaphores struct {
 	// each distinct operation MUST have its own semaphore;
 	// methods that acquire a semaphore MUST NOT call methods that acquire another
 	ClientDestroy utils.Semaphore
+	IPCheckScript utils.Semaphore
+	AuthScript    utils.Semaphore
 }
 
 // Initialize initializes a set of server semaphores.

--- a/irc/server.go
+++ b/irc/server.go
@@ -209,8 +209,10 @@ func (server *Server) checkBans(config *Config, ipaddr net.IP, checkScripts bool
 		if output.Result == IPBanned {
 			// XXX roll back IP connection/throttling addition for the IP
 			server.connectionLimiter.RemoveClient(ipaddr)
+			server.logger.Info("connect-ip", "Rejected client due to ip-check-script", ipaddr.String())
 			return true, false, output.BanMessage
 		} else if output.Result == IPRequireSASL {
+			server.logger.Info("connect-ip", "Requiring SASL from client due to ip-check-script", ipaddr.String())
 			return false, true, ""
 		}
 	}

--- a/irc/server.go
+++ b/irc/server.go
@@ -150,10 +150,10 @@ func (server *Server) Run() {
 	}
 }
 
-func (server *Server) checkBans(ipaddr net.IP) (banned bool, message string) {
+func (server *Server) checkBans(config *Config, ipaddr net.IP, checkScripts bool) (banned bool, requireSASL bool, message string) {
 	if server.Defcon() == 1 {
 		if !(ipaddr.IsLoopback() || utils.IPInNets(ipaddr, server.Config().Server.secureNets)) {
-			return true, "New connections to this server are temporarily restricted"
+			return true, false, "New connections to this server are temporarily restricted"
 		}
 	}
 
@@ -161,7 +161,7 @@ func (server *Server) checkBans(ipaddr net.IP) (banned bool, message string) {
 	isBanned, info := server.dlines.CheckIP(ipaddr)
 	if isBanned {
 		server.logger.Info("connect-ip", fmt.Sprintf("Client from %v rejected by d-line", ipaddr))
-		return true, info.BanMessage("You are banned from this server (%s)")
+		return true, false, info.BanMessage("You are banned from this server (%s)")
 	}
 
 	// check connection limits
@@ -169,27 +169,53 @@ func (server *Server) checkBans(ipaddr net.IP) (banned bool, message string) {
 	if err == connection_limits.ErrLimitExceeded {
 		// too many connections from one client, tell the client and close the connection
 		server.logger.Info("connect-ip", fmt.Sprintf("Client from %v rejected for connection limit", ipaddr))
-		return true, "Too many clients from your network"
+		return true, false, "Too many clients from your network"
 	} else if err == connection_limits.ErrThrottleExceeded {
-		duration := server.Config().Server.IPLimits.BanDuration
-		if duration == 0 {
-			return false, ""
+		duration := config.Server.IPLimits.BanDuration
+		if duration != 0 {
+			server.dlines.AddIP(ipaddr, duration, throttleMessage,
+				"Exceeded automated connection throttle", "auto.connection.throttler")
+			// they're DLINE'd for 15 minutes or whatever, so we can reset the connection throttle now,
+			// and once their temporary DLINE is finished they can fill up the throttler again
+			server.connectionLimiter.ResetThrottle(ipaddr)
 		}
-		server.dlines.AddIP(ipaddr, duration, throttleMessage, "Exceeded automated connection throttle", "auto.connection.throttler")
-		// they're DLINE'd for 15 minutes or whatever, so we can reset the connection throttle now,
-		// and once their temporary DLINE is finished they can fill up the throttler again
-		server.connectionLimiter.ResetThrottle(ipaddr)
-
-		// this might not show up properly on some clients, but our objective here is just to close it out before it has a load impact on us
 		server.logger.Info(
 			"connect-ip",
 			fmt.Sprintf("Client from %v exceeded connection throttle, d-lining for %v", ipaddr, duration))
-		return true, throttleMessage
+		return true, false, throttleMessage
 	} else if err != nil {
 		server.logger.Warning("internal", "unexpected ban result", err.Error())
 	}
 
-	return false, ""
+	if checkScripts && config.Server.IPCheckScript.Enabled {
+		output, err := CheckIPBan(server.semaphores.IPCheckScript, config.Server.IPCheckScript, ipaddr)
+		if err != nil {
+			server.logger.Error("internal", "couldn't check IP ban script", ipaddr.String(), err.Error())
+			return false, false, ""
+		}
+		// TODO: currently no way to cache results other than IPBanned
+		if output.Result == IPBanned && output.CacheSeconds != 0 {
+			network, err := utils.NormalizedNetFromString(output.CacheNet)
+			if err != nil {
+				server.logger.Error("internal", "invalid dline net from IP ban script", ipaddr.String(), output.CacheNet)
+			} else {
+				dlineDuration := time.Duration(output.CacheSeconds) * time.Second
+				err := server.dlines.AddNetwork(network, dlineDuration, output.BanMessage, "", "")
+				if err != nil {
+					server.logger.Error("internal", "couldn't set dline from IP ban script", ipaddr.String(), err.Error())
+				}
+			}
+		}
+		if output.Result == IPBanned {
+			// XXX roll back IP connection/throttling addition for the IP
+			server.connectionLimiter.RemoveClient(ipaddr)
+			return true, false, output.BanMessage
+		} else if output.Result == IPRequireSASL {
+			return false, true, ""
+		}
+	}
+
+	return false, false, ""
 }
 
 func (server *Server) checkTorLimits() (banned bool, message string) {
@@ -201,30 +227,6 @@ func (server *Server) checkTorLimits() (banned bool, message string) {
 	default:
 		return false, ""
 	}
-}
-
-func (server *Server) checkIPScript(config *Config, ip net.IP) (status IPScriptResult, banMessage string) {
-	output, err := CheckIPBan(server.semaphores.IPCheckScript, config.Server.IPCheckScript, ip)
-	if err != nil {
-		server.logger.Error("internal", "couldn't check IP ban script", ip.String(), err.Error())
-		return IPAccepted, ""
-	}
-
-	// TODO: currently no way to cache results other than IPBanned
-	if output.Result == IPBanned && output.CacheSeconds != 0 {
-		network, err := utils.NormalizedNetFromString(output.CacheNet)
-		if err != nil {
-			server.logger.Error("internal", "invalid dline net from IP ban script", ip.String(), output.CacheNet)
-		} else {
-			dlineDuration := time.Duration(output.CacheSeconds) * time.Second
-			err := server.dlines.AddNetwork(network, dlineDuration, output.BanMessage, "", "")
-			if err != nil {
-				server.logger.Error("internal", "couldn't set dline from IP ban script", ip.String(), err.Error())
-			}
-		}
-	}
-
-	return output.Result, output.BanMessage
 }
 
 //
@@ -240,16 +242,8 @@ func (server *Server) tryRegister(c *Client, session *Session) (exiting bool) {
 
 	// XXX PROXY or WEBIRC MUST be sent as the first line of the session;
 	// if we are here at all that means we have the final value of the IP
-	// TODO: consider moving hostname lookup up here too? unclear whether that actually
-	// affects handshake latency
-	config := server.Config()
-	if config.Server.IPCheckScript.Enabled && c.ipScriptStatus == IPNotChecked {
-		var banMessage string
-		c.ipScriptStatus, banMessage = server.checkIPScript(config, session.IP())
-		if c.ipScriptStatus == IPBanned {
-			c.Quit(fmt.Sprintf(c.t("You are banned from this server (%s)"), banMessage), nil)
-			return true
-		}
+	if session.rawHostname == "" {
+		session.client.lookupHostname(session, false)
 	}
 
 	// try to complete registration normally
@@ -266,7 +260,8 @@ func (server *Server) tryRegister(c *Client, session *Session) (exiting bool) {
 
 	// client MUST send PASS if necessary, or authenticate with SASL if necessary,
 	// before completing the other registration commands
-	authOutcome := c.isAuthorized(server, config, session, c.ipScriptStatus == IPRequireSASL)
+	config := server.Config()
+	authOutcome := c.isAuthorized(server, config, session, c.requireSASL)
 	var quitMessage string
 	switch authOutcome {
 	case authFailPass:
@@ -279,12 +274,6 @@ func (server *Server) tryRegister(c *Client, session *Session) (exiting bool) {
 	if authOutcome != authSuccess {
 		c.Quit(quitMessage, nil)
 		return true
-	}
-
-	// we have the final value of the IP address: do the hostname lookup
-	// (nickmask will be set below once nickname assignment succeeds)
-	if session.rawHostname == "" {
-		session.client.lookupHostname(session, false)
 	}
 
 	rb := NewResponseBuffer(session)


### PR DESCRIPTION
See discussion on #68. 

I'm looking for a volunteer to actually write a script plugin that implements DNSBL lookup. Spec:

1. Self-contained executable (either Go, or Python assuming [socket.getaddrinfo](https://docs.python.org/3/library/socket.html#socket.getaddrinfo) can handle all the cases without needing direct access to the DNS responses)
2. The API (`\n`-terminated line of JSON in, `\n`-terminated line of JSON out) is illustrated by this mock I used for testing: https://gist.github.com/slingamn/b532ec79d20458b4e9ae82f169a6075c
3. The plugin should take a single command-line argument, a path to a config file (either JSON or YAML is fine) that says what DNSBLs to query and how to interpret the results
4. In terms of expressiveness / functionality, @moortens's earlier work on a native DNSBL implementation is a good guide: https://github.com/oragono/oragono/compare/devel+dnsbl