### PR TITLE
plugin API for IP bans

### DIFF
--- a/conventional.yaml
+++ b/conventional.yaml
@@ -243,6 +243,12 @@ server:
             #     max-concurrent-connections: 128
             #     max-connections-per-window: 1024
 
+    # dynamically link against a plugin for checking IPs; see the manual for details
+    ip-check-plugin:
+        enabled: false
+        path: '/path/to/ipcheck.so'
+        init-args: ['/path/to/config/file']
+
     # IP cloaking hides users' IP addresses from other users and from channel admins
     # (but not from server admins), while still allowing channel admins to ban
     # offending IP addresses or networks. In place of hostnames derived from reverse

--- a/default.yaml
+++ b/default.yaml
@@ -270,6 +270,12 @@ server:
             #     max-concurrent-connections: 128
             #     max-connections-per-window: 1024
 
+    # dynamically link against a plugin for checking IPs; see the manual for details
+    ip-check-plugin:
+        enabled: false
+        path: '/path/to/ipcheck.so'
+        init-args: ['/path/to/config/file']
+
     # IP cloaking hides users' IP addresses from other users and from channel admins
     # (but not from server admins), while still allowing channel admins to ban
     # offending IP addresses or networks. In place of hostnames derived from reverse

--- a/irc/config.go
+++ b/irc/config.go
@@ -528,6 +528,12 @@ type Config struct {
 		Casemapping   Casemapping
 		EnforceUtf8   bool   `yaml:"enforce-utf8"`
 		OutputPath    string `yaml:"output-path"`
+		IPCheckPlugin struct {
+			Enabled  bool
+			Path     string
+			InitArgs []string `yaml:"init-args"`
+		} `yaml:"ip-check-plugin"`
+		ipChecker IPChecker
 	}
 
 	Roleplay struct {

--- a/irc/plugins.go
+++ b/irc/plugins.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 Shivaram Lingamneni
+// released under the MIT license
+
+package irc
+
+import (
+	"errors"
+	"net"
+	"plugin"
+)
+
+const (
+	IPPluginNotChecked  = 0
+	IPPluginAccepted    = 1
+	IPPluginBanned      = 2
+	IPPluginRequireSASL = 3
+)
+
+// XXX the '=' makes this a "type alias" instead of a "type definition",
+// allowing us to type-assert directly on the plugin.Symbol (since the plugin
+// doesn't see our type definitions)
+type IPChecker = func(ip net.IP) (result int, banMessage string, err error)
+
+func LoadIPCheckPlugin(path string, args []string) (checker IPChecker, err error) {
+	p, err := plugin.Open(path)
+	if err != nil {
+		return
+	}
+	initialize, err := p.Lookup("Initialize")
+	if err != nil {
+		return
+	}
+	check, err := p.Lookup("CheckIP")
+	if err != nil {
+		return
+	}
+	initializer, ok := initialize.(func([]string) error)
+	if !ok {
+		err = errors.New("ip check plugin exposes invalid signature for Initialize")
+		return
+	}
+	checker, ok = check.(IPChecker)
+	if !ok {
+		err = errors.New("ip check plugin exposes invalid signature for CheckIP")
+		return
+	}
+	err = initializer(args)
+	return
+}


### PR DESCRIPTION
This competes with #1263. Pros: better performance. Cons: decreased portability (only Linux/MacOS/OpenBSD), plugins are generally sketchy (golang/go#19282).

Here's the mock plugin I used for testing: https://gist.github.com/slingamn/450b19fa7bb5e325a29b48f71f3c0842