### PR TITLE
fix websocket listeners with proxy-before-TLS closing on bad PROXY lines

### DIFF
--- a/irc/utils/proxy.go
+++ b/irc/utils/proxy.go
@@ -21,8 +21,24 @@ const (
 	maxProxyLineLen = 107
 )
 
+// XXX implement net.Error with a Temporary() method that returns true;
+// otherwise, ErrBadProxyLine will cause (*http.Server).Serve() to exit
+type proxyLineError struct{}
+
+func (p *proxyLineError) Error() string {
+	return "invalid PROXY line"
+}
+
+func (p *proxyLineError) Timeout() bool {
+	return false
+}
+
+func (p *proxyLineError) Temporary() bool {
+	return true
+}
+
 var (
-	ErrBadProxyLine = errors.New("invalid PROXY line")
+	ErrBadProxyLine error = &proxyLineError{}
 	// TODO(golang/go#4373): replace this with the stdlib ErrNetClosing
 	ErrNetClosing = errors.New("use of closed network connection")
 )


### PR DESCRIPTION
cc @RyanSquared @daurnimator (just as an FYI; I'll send a PR for gitops later)

`http.Server` was considering these fatal errors and exiting, closing the listener:

https://github.com/golang/go/blob/9706f510a5e2754595d716bd64be8375997311fb/src/net/http/server.go#L2944-L2957

This is still a bit awkward because even with `Temporary()` returning true, the server loop will back off and sleep for up to a second. Avoiding this seems nontrivial. Since these proxy-before-TLS listeners can only be exposed to trusted clients anyway, this doesn't seem to pose a DoS issue. (I assume the bad proxy lines were coming from the healthcheck, which just opens and closes the port?)

I tested this on my stage.