### PR TITLE
run irctest in travis

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "irctest"]
+	path = irctest
+	url = https://github.com/oragono/irctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 
+dist: focal
+
 go:
     - "1.15.x"
 
@@ -8,6 +10,7 @@ before_install:
   - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
 
 script:
-- make
+- make install
 - make test
 - make smoke
+- make irctest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install build release capdefs test smoke gofmt
+.PHONY: all install build release capdefs test smoke gofmt irctest
 
 GIT_COMMIT := $(shell git rev-parse HEAD 2> /dev/null)
 
@@ -39,3 +39,7 @@ smoke:
 
 gofmt:
 	./.check-gofmt.sh --fix
+
+irctest:
+	git submodule update --init
+	cd irctest && make integration


### PR DESCRIPTION
This adds irctest as a submodule. I don't know if this is a good idea at all. But the idea (compare #1270) is that you can push a branch to the irctest repo, then update the submodule pointer in your oragono branch, and then rely on the normal conflict resolution mechanism for submodules.