### PR TITLE
fix #414

### DIFF
--- a/irc/accounts.go
+++ b/irc/accounts.go
@@ -5,6 +5,7 @@ package irc
 
 import (
 	"bytes"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -1466,7 +1467,7 @@ func (am *AccountManager) ChannelsForAccount(account string) (channels []string)
 	return unmarshalRegisteredChannels(channelStr)
 }
 
-func (am *AccountManager) AuthenticateByCertFP(client *Client, certfp, authzid string) (err error) {
+func (am *AccountManager) AuthenticateByCertificate(client *Client, certfp string, peerCerts []*x509.Certificate, authzid string) (err error) {
 	if certfp == "" {
 		return errAccountInvalidCredentials
 	}
@@ -1495,7 +1496,7 @@ func (am *AccountManager) AuthenticateByCertFP(client *Client, certfp, authzid s
 	if config.Accounts.AuthScript.Enabled {
 		var output AuthScriptOutput
 		output, err = CheckAuthScript(am.server.semaphores.AuthScript, config.Accounts.AuthScript.ScriptConfig,
-			AuthScriptInput{Certfp: certfp, IP: client.IP().String()})
+			AuthScriptInput{Certfp: certfp, IP: client.IP().String(), peerCerts: peerCerts})
 		if err != nil {
 			am.server.logger.Error("internal", "failed shell auth invocation", err.Error())
 		} else if output.Success && output.AccountName != "" {

--- a/irc/client.go
+++ b/irc/client.go
@@ -6,6 +6,7 @@
 package irc
 
 import (
+	"crypto/x509"
 	"fmt"
 	"net"
 	"runtime/debug"
@@ -163,6 +164,7 @@ type Session struct {
 	destroyed            uint32
 
 	certfp     string
+	peerCerts  []*x509.Certificate
 	sasl       saslStatus
 	passStatus serverPassStatus
 
@@ -384,7 +386,7 @@ func (server *Server) RunClient(conn IRCConn) {
 
 	if wConn.Config.TLSConfig != nil {
 		// error is not useful to us here anyways so we can ignore it
-		session.certfp, _ = utils.GetCertFP(wConn.Conn, RegisterTimeout)
+		session.certfp, session.peerCerts, _ = utils.GetCertFP(wConn.Conn, RegisterTimeout)
 	}
 
 	if session.isTor {

--- a/irc/gateways.go
+++ b/irc/gateways.go
@@ -99,6 +99,7 @@ func (client *Client) ApplyProxiedIP(session *Session, proxiedIP net.IP, tls boo
 	// nickmask will be updated when the client completes registration
 	// set tls info
 	session.certfp = ""
+	session.peerCerts = nil
 	client.SetMode(modes.TLS, tls)
 
 	return nil, ""

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -303,7 +303,7 @@ func authExternalHandler(server *Server, client *Client, mechanism string, value
 				rb.session.deviceID = deviceID
 			}
 		}
-		err = server.accounts.AuthenticateByCertFP(client, rb.session.certfp, authzid)
+		err = server.accounts.AuthenticateByCertificate(client, rb.session.certfp, rb.session.peerCerts, authzid)
 	}
 
 	if err != nil {

--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -721,7 +721,7 @@ func nsIdentifyHandler(server *Server, client *Client, command string, params []
 
 	// try certfp
 	if !loginSuccessful && rb.session.certfp != "" {
-		err = server.accounts.AuthenticateByCertFP(client, rb.session.certfp, "")
+		err = server.accounts.AuthenticateByCertificate(client, rb.session.certfp, rb.session.peerCerts, "")
 		loginSuccessful = (err == nil)
 	}
 


### PR DESCRIPTION
Nice and short, kicks the can over to whoever's doing the CA system.

I think a fairly short Python script that shells out to [openssl-verify](https://www.openssl.org/docs/man1.1.1/man1/openssl-verify.html) will work fine for this. I don't think I'll bother implementing it though.