### PR TITLE
hidden operators, tweaks to default operator config

### DIFF
--- a/conventional.yaml
+++ b/conventional.yaml
@@ -597,10 +597,15 @@ opers:
         class: "server-admin"
 
         # custom whois line
-        whois-line: is a cool dude
+        whois-line: is a server admin
 
         # custom hostname
         vhost: "n"
+
+        # normally, operator status is visible to unprivileged users in WHO and WHOIS
+        # responses. this can be disabled with 'hidden'. ('hidden' also causes the
+        # 'vhost' line above to be ignored.)
+        hidden: false
 
         # modes are the modes to auto-set upon opering-up
         modes: +is acjknoqtuxv

--- a/conventional.yaml
+++ b/conventional.yaml
@@ -607,8 +607,10 @@ opers:
         # 'vhost' line above to be ignored.)
         hidden: false
 
-        # modes are the modes to auto-set upon opering-up
-        modes: +is acjknoqtuxv
+        # modes are modes to auto-set upon opering-up. uncomment this to automatically
+        # enable snomasks ("server notification masks" that alert you to server events;
+        # see `/quote help snomasks` while opered-up for more information):
+        #modes: +is acjknoqtuxv
 
         # operators can be authenticated either by password (with the /OPER command),
         # or by certificate fingerprint, or both. if a password hash is set, then a

--- a/conventional.yaml
+++ b/conventional.yaml
@@ -600,7 +600,7 @@ opers:
         whois-line: is a server admin
 
         # custom hostname
-        vhost: "n"
+        vhost: "staff"
 
         # normally, operator status is visible to unprivileged users in WHO and WHOIS
         # responses. this can be disabled with 'hidden'. ('hidden' also causes the

--- a/default.yaml
+++ b/default.yaml
@@ -628,7 +628,7 @@ opers:
         whois-line: is a server admin
 
         # custom hostname
-        vhost: "n"
+        vhost: "staff"
 
         # normally, operator status is visible to unprivileged users in WHO and WHOIS
         # responses. this can be disabled with 'hidden'. ('hidden' also causes the

--- a/default.yaml
+++ b/default.yaml
@@ -625,10 +625,15 @@ opers:
         class: "server-admin"
 
         # custom whois line
-        whois-line: is a cool dude
+        whois-line: is a server admin
 
         # custom hostname
         vhost: "n"
+
+        # normally, operator status is visible to unprivileged users in WHO and WHOIS
+        # responses. this can be disabled with 'hidden'. ('hidden' also causes the
+        # 'vhost' line above to be ignored.)
+        hidden: false
 
         # modes are the modes to auto-set upon opering-up
         modes: +is acjknoqtuxv

--- a/default.yaml
+++ b/default.yaml
@@ -635,8 +635,10 @@ opers:
         # 'vhost' line above to be ignored.)
         hidden: false
 
-        # modes are the modes to auto-set upon opering-up
-        modes: +is acjknoqtuxv
+        # modes are modes to auto-set upon opering-up. uncomment this to automatically
+        # enable snomasks ("server notification masks" that alert you to server events;
+        # see `/quote help snomasks` while opered-up for more information):
+        #modes: +is acjknoqtuxv
 
         # operators can be authenticated either by password (with the /OPER command),
         # or by certificate fingerprint, or both. if a password hash is set, then a

--- a/irc/client.go
+++ b/irc/client.go
@@ -1207,7 +1207,7 @@ func (client *Client) getVHostNoMutex() string {
 	// hostserv vhost OR operclass vhost OR nothing (i.e., normal rdns hostmask)
 	if client.vhost != "" {
 		return client.vhost
-	} else if client.oper != nil {
+	} else if client.oper != nil && !client.oper.Hidden {
 		return client.oper.Vhost
 	} else {
 		return ""

--- a/irc/config.go
+++ b/irc/config.go
@@ -419,6 +419,7 @@ type OperConfig struct {
 	Fingerprint *string // legacy name for certfp, #1050
 	Certfp      string
 	Auto        bool
+	Hidden      bool
 	Modes       string
 }
 
@@ -723,7 +724,13 @@ type Oper struct {
 	Pass      []byte
 	Certfp    string
 	Auto      bool
+	Hidden    bool
 	Modes     []modes.ModeChange
+}
+
+// returns whether this is a publicly visible operator, for WHO/WHOIS purposes
+func (oper *Oper) Visible(hasPrivs bool) bool {
+	return oper != nil && (hasPrivs || !oper.Hidden)
 }
 
 // Operators returns a map of operator configs from the given OperClass and config.
@@ -756,6 +763,7 @@ func (conf *Config) Operators(oc map[string]*OperClass) (map[string]*Oper, error
 			}
 		}
 		oper.Auto = opConf.Auto
+		oper.Hidden = opConf.Hidden
 
 		if oper.Pass == nil && oper.Certfp == "" {
 			return nil, fmt.Errorf("Oper %s has neither a password nor a fingerprint", name)


### PR DESCRIPTION
WHO and WHOIS are the only commands I could find that expose the operator status.

This also disables snomasks by default, as discussed on #1309.