### PR TITLE
fix #1337

### DIFF
--- a/conventional.yaml
+++ b/conventional.yaml
@@ -433,6 +433,11 @@ accounts:
         # as equivalent for the purpose of ban/invite/exception lists.
         force-nick-equals-account: false
 
+        # parallel setting to force-nick-equals-account: if true, this forbids
+        # anonymous users (i.e., users not logged into an account) to change their
+        # nickname after the initial connection is complete
+        forbid-anon-nick-changes: false
+
     # multiclient controls whether oragono allows multiple connections to
     # attach to the same client/nickname identity; this is part of the
     # functionality traditionally provided by a bouncer like ZNC

--- a/default.yaml
+++ b/default.yaml
@@ -461,6 +461,11 @@ accounts:
         # as equivalent for the purpose of ban/invite/exception lists.
         force-nick-equals-account: true
 
+        # parallel setting to force-nick-equals-account: if true, this forbids
+        # anonymous users (i.e., users not logged into an account) to change their
+        # nickname after the initial connection is complete
+        forbid-anonymous-nick-changes: false
+
     # multiclient controls whether oragono allows multiple connections to
     # attach to the same client/nickname identity; this is part of the
     # functionality traditionally provided by a bouncer like ZNC

--- a/irc/config.go
+++ b/irc/config.go
@@ -274,6 +274,7 @@ type AccountConfig struct {
 		guestRegexpFolded      *regexp.Regexp
 		ForceGuestFormat       bool `yaml:"force-guest-format"`
 		ForceNickEqualsAccount bool `yaml:"force-nick-equals-account"`
+		ForbidAnonNickChanges  bool `yaml:"forbid-anonymous-nick-changes"`
 	} `yaml:"nick-reservation"`
 	Multiclient MulticlientConfig
 	Bouncer     *MulticlientConfig // # handle old name for 'multiclient'

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -1919,6 +1919,10 @@ func namesHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Res
 // NICK <nickname>
 func nickHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *ResponseBuffer) bool {
 	if client.registered {
+		if client.account == "" && server.Config().Accounts.NickReservation.ForbidAnonNickChanges {
+			rb.Add(nil, server.name, ERR_UNKNOWNERROR, client.Nick(), client.t("You may not change your nickname"))
+			return false
+		}
 		performNickChange(server, client, client, nil, msg.Params[0], rb)
 	} else {
 		client.preregNick = msg.Params[0]


### PR DESCRIPTION
Very easy: we just put the check in `nickHandler`, so it only affects user-initiated nick changes and not `SANICK`, `RandomlyRename`, or `fixupNickEqualsAccount`.