### PR TITLE
replace suppress-ident with coerce-ident; make coerce-ident a recommended default

### DIFF
--- a/conventional.yaml
+++ b/conventional.yaml
@@ -127,9 +127,10 @@ server:
     # use ident protocol to get usernames
     check-ident: true
 
-    # ignore the supplied user/ident string from the USER command; always set the value to
-    # `~user` (literally) instead. this can potentially reduce confusion and simplify bans.
-    suppress-ident: false
+    # ignore the supplied user/ident string from the USER command, always setting user/ident
+    # to the following literal value; this can potentially reduce confusion and simplify bans.
+    # the value must begin with a '~' character. comment out / omit to disable:
+    #coerce-ident: '~u'
 
     # password to login to the server
     # generated using  "oragono genpasswd"

--- a/default.yaml
+++ b/default.yaml
@@ -154,9 +154,10 @@ server:
     # use ident protocol to get usernames
     check-ident: false
 
-    # ignore the supplied user/ident string from the USER command; always set the value to
-    # `~user` (literally) instead. this can potentially reduce confusion and simplify bans.
-    suppress-ident: false
+    # ignore the supplied user/ident string from the USER command, always setting user/ident
+    # to the following literal value; this can potentially reduce confusion and simplify bans.
+    # the value must begin with a '~' character. comment out / omit to disable:
+    coerce-ident: '~u'
 
     # password to login to the server
     # generated using  "oragono genpasswd"

--- a/irc/client.go
+++ b/irc/client.go
@@ -416,6 +416,11 @@ func (server *Server) AddAlwaysOnClient(account ClientAccount, chnames []string,
 		cloakedHostname = config.Server.Cloaks.ComputeAccountCloak(account.Name)
 	}
 
+	username := "~u"
+	if config.Server.CoerceIdent != "" {
+		username = config.Server.CoerceIdent
+	}
+
 	client := &Client{
 		lastSeen:   lastSeen,
 		lastActive: now,
@@ -424,7 +429,7 @@ func (server *Server) AddAlwaysOnClient(account ClientAccount, chnames []string,
 		languages:  server.Languages().Default(),
 		server:     server,
 
-		username:        "~user",
+		username:        username,
 		cloakedHostname: cloakedHostname,
 		rawHostname:     rawHostname,
 		realIP:          utils.IPv4LoopbackAddress,
@@ -1118,8 +1123,8 @@ func (client *Client) SetNames(username, realname string, fromIdent bool) error 
 		return errInvalidUsername
 	}
 
-	if config.Server.SuppressIdent {
-		username = "~user"
+	if config.Server.CoerceIdent != "" {
+		username = config.Server.CoerceIdent
 	} else if !fromIdent {
 		username = "~" + username
 	}

--- a/irc/config.go
+++ b/irc/config.go
@@ -505,9 +505,9 @@ type Config struct {
 		STS                     STSConfig
 		LookupHostnames         *bool `yaml:"lookup-hostnames"`
 		lookupHostnames         bool
-		ForwardConfirmHostnames bool `yaml:"forward-confirm-hostnames"`
-		CheckIdent              bool `yaml:"check-ident"`
-		SuppressIdent           bool `yaml:"suppress-ident"`
+		ForwardConfirmHostnames bool   `yaml:"forward-confirm-hostnames"`
+		CheckIdent              bool   `yaml:"check-ident"`
+		CoerceIdent             string `yaml:"coerce-ident"`
 		MOTD                    string
 		motdLines               []string
 		MOTDFormatting          bool `yaml:"motd-formatting"`
@@ -913,8 +913,16 @@ func LoadConfig(filename string) (config *Config, err error) {
 		}
 	}
 
-	if config.Server.CheckIdent && config.Server.SuppressIdent {
-		return nil, errors.New("Can't configure both check-ident and suppress-ident")
+	if config.Server.CoerceIdent != "" {
+		if config.Server.CheckIdent {
+			return nil, errors.New("Can't configure both check-ident and coerce-ident")
+		}
+		if config.Server.CoerceIdent[0] != '~' {
+			return nil, errors.New("coerce-ident value must start with a ~")
+		}
+		if !isIdent(config.Server.CoerceIdent[1:]) {
+			return nil, errors.New("coerce-ident must be valid as an IRC user/ident field")
+		}
 	}
 
 	config.Server.supportedCaps = caps.NewCompleteSet()


### PR DESCRIPTION
suppress-ident was never in a release. However, this needs to be changelogged as a minor compatibility break, since it may invalidate stored bans of always-on clients. (We should also alert hashbang since they're using an unreleased build with suppress-ident enabled.)