### PR TITLE
fix output bugs in AMODE handling

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -820,6 +820,11 @@ func (channel *Channel) Join(client *Client, key string, isSajoin bool, rb *Resp
 		// don't send topic and names for a SAJOIN of a different client
 		channel.SendTopic(client, rb, false)
 		channel.Names(client, rb)
+	} else {
+		// ensure that SAJOIN sends a MODE line to the originating client, if applicable
+		if givenMode != 0 {
+			rb.Add(nil, client.server.name, "MODE", chname, modestr, details.nick)
+		}
 	}
 
 	// TODO #259 can be implemented as Flush(false) (i.e., nonblocking) while holding joinPartMutex

--- a/irc/chanserv.go
+++ b/irc/chanserv.go
@@ -265,7 +265,7 @@ func csAmodeHandler(server *Server, client *Client, command string, params []str
 				if member.Account() == change.Arg {
 					applied, change := channel.applyModeToMember(client, change, rb)
 					if applied {
-						announceCmodeChanges(channel, modes.ModeChanges{change}, chanservMask, "*", "", rb)
+						announceCmodeChanges(channel, modes.ModeChanges{change}, server.name, "*", "", rb)
 					}
 				}
 			}
@@ -312,7 +312,7 @@ func csOpHandler(server *Server, client *Client, command string, params []string
 		},
 		rb)
 	if applied {
-		announceCmodeChanges(channelInfo, modes.ModeChanges{change}, chanservMask, "*", "", rb)
+		announceCmodeChanges(channelInfo, modes.ModeChanges{change}, server.name, "*", "", rb)
 	}
 
 	csNotice(rb, client.t("Successfully granted operator privileges"))


### PR DESCRIPTION
reported by @mogad0n :

1. The sources of AMODE changes were inconsistent (sometimes the server, sometimes chanserv); now it's always the server
2. SAJOIN did not send a MODE line to the originating client