### PR TITLE
fix #1387

### DIFF
--- a/irc/message_cache.go
+++ b/irc/message_cache.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2020 Shivaram Lingamneni <slingamn@cs.stanford.edu>
+// released under the MIT license
+
+package irc
+
+import (
+	"time"
+
+	"github.com/goshuirc/irc-go/ircmsg"
+
+	"github.com/oragono/oragono/irc/caps"
+	"github.com/oragono/oragono/irc/utils"
+)
+
+// MessageCache caches serialized IRC messages.
+// First call Initialize or InitializeSplitMessage, which records
+// the parameters and builds the cache. Then call Send, which will
+// either send a cached version of the message or dispatch to another
+// send routine that can synthesize the necessary version on the fly.
+type MessageCache struct {
+	// these cache a single-line message (e.g., JOIN, or PRIVMSG with a 512-byte message)
+	// one version is "plain" (legacy clients with no tags) and one is "full" (client has
+	// the message-tags cap)
+	plain    []byte
+	fullTags []byte
+	// these cache a multiline message (a PRIVMSG that was sent as a multiline batch)
+	// one version is "plain" (legacy clients with no tags) and one is "full" (client has
+	// the multiline cap)
+	plainMultiline    [][]byte
+	fullTagsMultiline [][]byte
+
+	time        time.Time
+	msgid       string
+	accountName string
+	tags        map[string]string
+	source      string
+	command     string
+
+	params []string
+
+	target       string
+	splitMessage utils.SplitMessage
+}
+
+func addAllTags(msg *ircmsg.IrcMessage, tags map[string]string, serverTime time.Time, msgid, accountName string) {
+	msg.UpdateTags(tags)
+	msg.SetTag("time", serverTime.Format(IRCv3TimestampFormat))
+	if accountName != "*" {
+		msg.SetTag("account", accountName)
+	}
+	if msgid != "" {
+		msg.SetTag("msgid", msgid)
+	}
+}
+
+func (m *MessageCache) handleErr(server *Server, err error) bool {
+	if err != nil {
+		server.logger.Error("internal", "Error assembling message for sending", err.Error())
+		// blank these out so Send will be a no-op
+		m.fullTags = nil
+		m.fullTagsMultiline = nil
+		return true
+	}
+	return false
+}
+
+func (m *MessageCache) Initialize(server *Server, serverTime time.Time, msgid string, nickmask, accountName string, tags map[string]string, command string, params ...string) (err error) {
+	m.time = serverTime
+	m.msgid = msgid
+	m.source = nickmask
+	m.accountName = accountName
+	m.tags = tags
+	m.command = command
+	m.params = params
+
+	var msg ircmsg.IrcMessage
+	config := server.Config()
+	if config.Server.Compatibility.forceTrailing && commandsThatMustUseTrailing[command] {
+		msg.ForceTrailing()
+	}
+	msg.Prefix = nickmask
+	msg.Command = command
+	msg.Params = make([]string, len(params))
+	copy(msg.Params, params)
+	m.plain, err = msg.LineBytesStrict(false, MaxLineLen)
+	if m.handleErr(server, err) {
+		return
+	}
+
+	addAllTags(&msg, tags, serverTime, msgid, accountName)
+	m.fullTags, err = msg.LineBytesStrict(false, MaxLineLen)
+	if m.handleErr(server, err) {
+		return
+	}
+	return
+}
+
+func (m *MessageCache) InitializeSplitMessage(server *Server, nickmask, accountName string, tags map[string]string, command, target string, message utils.SplitMessage) (err error) {
+	m.time = message.Time
+	m.msgid = message.Msgid
+	m.source = nickmask
+	m.accountName = accountName
+	m.tags = tags
+	m.command = command
+	m.target = target
+	m.splitMessage = message
+
+	config := server.Config()
+	forceTrailing := config.Server.Compatibility.forceTrailing && commandsThatMustUseTrailing[command]
+
+	if message.Is512() {
+		isTagmsg := command == "TAGMSG"
+		var msg ircmsg.IrcMessage
+		if forceTrailing {
+			msg.ForceTrailing()
+		}
+
+		msg.Prefix = nickmask
+		msg.Command = command
+		if isTagmsg {
+			msg.Params = []string{target}
+		} else {
+			msg.Params = []string{target, message.Message}
+		}
+		m.params = msg.Params
+		if !isTagmsg {
+			m.plain, err = msg.LineBytesStrict(false, MaxLineLen)
+			if m.handleErr(server, err) {
+				return
+			}
+		}
+
+		addAllTags(&msg, tags, message.Time, message.Msgid, accountName)
+		m.fullTags, err = msg.LineBytesStrict(false, MaxLineLen)
+		if m.handleErr(server, err) {
+			return
+		}
+	} else {
+		var msg ircmsg.IrcMessage
+		if forceTrailing {
+			msg.ForceTrailing()
+		}
+		msg.Prefix = nickmask
+		msg.Command = command
+		msg.Params = make([]string, 2)
+		msg.Params[0] = target
+		m.plainMultiline = make([][]byte, len(message.Split))
+		for i, pair := range message.Split {
+			msg.Params[1] = pair.Message
+			m.plainMultiline[i], err = msg.LineBytesStrict(false, MaxLineLen)
+			if m.handleErr(server, err) {
+				return
+			}
+		}
+
+		// we need to send the same batch ID to all recipient sessions;
+		// use a uuidv4-alike to ensure that it won't collide
+		batch := composeMultilineBatch(utils.GenerateSecretToken(), nickmask, accountName, tags, command, target, message)
+		m.fullTagsMultiline = make([][]byte, len(batch))
+		for i, msg := range batch {
+			if forceTrailing {
+				msg.ForceTrailing()
+			}
+			m.fullTagsMultiline[i], err = msg.LineBytesStrict(false, MaxLineLen)
+			if m.handleErr(server, err) {
+				return
+			}
+		}
+	}
+	return
+}
+
+func (m *MessageCache) Send(session *Session) {
+	if m.fullTags != nil {
+		if session.capabilities.Has(caps.MessageTags) {
+			session.sendBytes(m.fullTags, false)
+		} else if !(session.capabilities.Has(caps.ServerTime) || session.capabilities.Has(caps.AccountTag)) {
+			if m.plain != nil {
+				session.sendBytes(m.plain, false)
+			}
+		} else {
+			session.sendFromClientInternal(false, m.time, m.msgid, m.source, m.accountName, nil, m.command, m.params...)
+		}
+	} else if m.fullTagsMultiline != nil {
+		if session.capabilities.Has(caps.Multiline) {
+			for _, line := range m.fullTagsMultiline {
+				session.sendBytes(line, false)
+			}
+		} else if !(session.capabilities.Has(caps.ServerTime) || session.capabilities.Has(caps.AccountTag)) {
+			for _, line := range m.plainMultiline {
+				session.sendBytes(line, false)
+			}
+		} else {
+			session.sendSplitMsgFromClientInternal(false, m.source, m.accountName, m.tags, m.command, m.target, m.splitMessage)
+		}
+	}
+}

--- a/irc/responsebuffer.go
+++ b/irc/responsebuffer.go
@@ -127,7 +127,7 @@ func (rb *ResponseBuffer) AddSplitMessageFromClient(fromNickMask string, fromAcc
 		}
 	} else {
 		if rb.session.capabilities.Has(caps.Multiline) {
-			batch := rb.session.composeMultilineBatch(fromNickMask, fromAccount, tags, command, target, message)
+			batch := composeMultilineBatch(rb.session.generateBatchID(), fromNickMask, fromAccount, tags, command, target, message)
 			rb.setNestedBatchTag(&batch[0])
 			rb.setNestedBatchTag(&batch[len(batch)-1])
 			rb.messages = append(rb.messages, batch...)

--- a/irc/utils/bitset.go
+++ b/irc/utils/bitset.go
@@ -17,6 +17,14 @@ func BitsetGet(set []uint32, position uint) bool {
 	return (block & (1 << bit)) != 0
 }
 
+// BitsetGetLocal returns whether a given bit of the bitset is set,
+// without synchronization.
+func BitsetGetLocal(set []uint32, position uint) bool {
+	idx := position / 32
+	bit := position % 32
+	return (set[idx] & (1 << bit)) != 0
+}
+
 // BitsetSet sets a given bit of the bitset to 0 or 1, returning whether it changed.
 func BitsetSet(set []uint32, position uint, on bool) (changed bool) {
 	idx := position / 32
@@ -76,6 +84,15 @@ func BitsetCopy(set []uint32, other []uint32) {
 	for i := 0; i < len(set); i++ {
 		data := atomic.LoadUint32(&other[i])
 		atomic.StoreUint32(&set[i], data)
+	}
+}
+
+// BitsetCopyLocal copies the contents of `other` over `set`,
+// without synchronizing the writes to `set`.
+func BitsetCopyLocal(set []uint32, other []uint32) {
+	for i := 0; i < len(set); i++ {
+		data := atomic.LoadUint32(&other[i])
+		set[i] = data
 	}
 }
 

--- a/irc/utils/bitset_test.go
+++ b/irc/utils/bitset_test.go
@@ -80,4 +80,14 @@ func TestSets(t *testing.T) {
 	if !BitsetGet(t3s, 0) || BitsetGet(t3s, 72) || !BitsetGet(t3s, 74) || BitsetGet(t3s, 71) {
 		t.Error("subtract doesn't work")
 	}
+
+	var tlocal testBitset
+	tlocals := tlocal[:]
+	BitsetCopyLocal(tlocals, t1s)
+	for i = 0; i < 128; i++ {
+		expected := (i != 72)
+		if BitsetGetLocal(tlocals, i) != expected {
+			t.Error("all bits should be set except 72")
+		}
+	}
 }


### PR DESCRIPTION
I measured a speedup of around 20% on the chanflood benchmark from this.

One area where this actually makes things worse: we're using longer batch IDs now when relaying multilines, because they're shared globally (due to caching) so we need to make them longer for uniqueness. This could conceivably reduce performance in some workloads.

The new bitset routines are not used.