### PR TITLE
Allow atheme2json to handle mlock mode removal (outside of `-t` or `-n`)

### DIFF
--- a/distrib/atheme/atheme2json.py
+++ b/distrib/atheme/atheme2json.py
@@ -65,8 +65,7 @@ def convert(infile):
             for flag, mode in CMODE_FLAG_TO_MODE.items():
                 if flag & mlock_on != 0:
                     modes.add(mode)
-            for flag, mode in CMODE_FLAG_TO_MODE.items():
-                if flag & mlock_off != 0:
+                elif flag & mlock_off != 0 and mode in modes:
                     modes.remove(mode)
             chdata['modes'] = ''.join(modes)
             chdata['limit'] = int(parts[7])


### PR DESCRIPTION
For example, if the mlock is set to `-i`, `i` is not present in the `modes` set a few lines above and thus it would error.

```python
modes = {'n', 't'}
```

I'm inclined to think that the negative mlock feature doesn't behave correctly. Or atleast, Oragono's interpretation of the Atheme feature is not the same as how Atheme would treat it as far as I can understand it. The mlock of `-i` (or `-n`) would prevent anyone from ever setting those modes on the channel. Which this does not appear to be the case on Oragono. I think this is just setting the channel modes to be equivilent to the MLOCK which isn't what the MLOCK is used for in Atheme. However, this fix is orthogonal to that issue, as I believe that applies also to the `n` and `t` modes.

Atheme help on this feature:

```
<ChanServ> ***** ChanServ Help *****
<ChanServ> Help for SET MLOCK:
<ChanServ>  
<ChanServ> MLOCK (or "mode lock") allows you to enforce a set
<ChanServ> of modes on a channel.  This can prevent abuse in cases
<ChanServ> such as +kl. It can also make it harder to fight evil
<ChanServ> bots, be careful. Locked modes can be seen by anyone
<ChanServ> recreating the channel (this includes keys).
<ChanServ>  
<ChanServ> Syntax: SET <#channel> MLOCK [modes]
<ChanServ>  
<ChanServ> Examples: (some may use modes your ircd does not support)
<ChanServ>     /msg ChanServ SET #foo MLOCK +nt-lk
<ChanServ>     /msg ChanServ SET #foo MLOCK +inst-kl
<ChanServ>     /msg ChanServ SET #c MLOCK +ntk c
<ChanServ>     /msg ChanServ SET #foo MLOCK +ntcjf-kl 2:30 #overflow
<ChanServ>     /msg ChanServ SET #overflow MLOCK +mntF-kljf
<ChanServ>     /msg ChanServ SET #foo1 MLOCK +ntlL 40 #foo2
<ChanServ> ***** End of Help *****
```

The behaviour of this feature:

```
<kylef> set #kylef MLOCK -i
<ChanServ> The MLOCK for #kylef has been set to -i.
```

If I try to set `+i`, then Atheme removes it.

```
C: MODE #kylef +i
S: @time=2020-11-27T16:34:28.783Z :kylef!~kyle@staff.darkscience.net MODE #kylef :+i
S: @time=2020-11-27T16:34:28.791Z :ChanServ!ChanServ@services.darkscience.net MODE #kylef :-i
```

Fixes #1401