### PR TITLE
Make atheme2json sort channel modes

### DIFF
--- a/distrib/atheme/atheme2json.py
+++ b/distrib/atheme/atheme2json.py
@@ -67,7 +67,7 @@ def convert(infile):
                     modes.add(mode)
                 elif flag & mlock_off != 0 and mode in modes:
                     modes.remove(mode)
-            chdata['modes'] = ''.join(modes)
+            chdata['modes'] = ''.join(sorted(modes))
             chdata['limit'] = int(parts[7])
         elif category == 'MDC':
             # auxiliary data for a channel registration


### PR DESCRIPTION
This makes invoking the script multiple times with the same input return the same result, which may not be the case before because sets are unordered and thus the channel modes can become reordered across multiple invocations of the script.

This is something I noticed while testing, is that the order flipped making my tests fail sometimes.

##### Before

```
$ python atheme2json.py services.db test1.json
$ python atheme2json.py services.db test2.json
$ openssl sha1 *.json 
SHA1(test1.json)= ca80825857bd56dc6f170168e70aacefaf762300
SHA1(test2.json)= 0a0ad289d664b14f929797d4e7cb85810c3a8391
```

##### After

```
$ python atheme2json.py services.db test1.json
$ python atheme2json.py services.db test2.json
$ python atheme2json.py services.db test3.json
$ python atheme2json.py services.db test4.json
$ python atheme2json.py services.db test5.json
$ openssl sha1 *.json
SHA1(test1.json)= 5b569c49a072e819bed504d093d16b9e0875a538
SHA1(test2.json)= 5b569c49a072e819bed504d093d16b9e0875a538
SHA1(test3.json)= 5b569c49a072e819bed504d093d16b9e0875a538
SHA1(test4.json)= 5b569c49a072e819bed504d093d16b9e0875a538
SHA1(test5.json)= 5b569c49a072e819bed504d093d16b9e0875a538
```