### PR TITLE
fix #1428

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -159,6 +159,7 @@ type Session struct {
 	proxiedIP   net.IP
 	rawHostname string
 	isTor       bool
+	hideSTS     bool
 
 	fakelag              Fakelag
 	deferredFakelagCount int
@@ -376,6 +377,7 @@ func (server *Server) RunClient(conn IRCConn) {
 		realIP:     realIP,
 		proxiedIP:  proxiedIP,
 		isTor:      wConn.Config.Tor,
+		hideSTS:    wConn.Config.Tor || wConn.Config.HideSTS,
 	}
 	client.sessions = []*Session{session}
 

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -442,6 +442,8 @@ func capHandler(server *Server, client *Client, msg ircmsg.IrcMessage, rb *Respo
 	supportedCaps := config.Server.supportedCaps
 	if client.isSTSOnly {
 		supportedCaps = stsOnlyCaps
+	} else if rb.session.hideSTS {
+		supportedCaps = config.Server.supportedCapsWithoutSTS
 	}
 
 	badCaps := false

--- a/irc/utils/proxy.go
+++ b/irc/utils/proxy.go
@@ -54,6 +54,7 @@ type ListenerConfig struct {
 	Tor       bool
 	STSOnly   bool
 	WebSocket bool
+	HideSTS   bool
 }
 
 // read a PROXY header (either v1 or v2), ensuring we don't read anything beyond


### PR DESCRIPTION
Tor listeners should never see an STS cap.

Add an undocumented 'hide-sts' key for listeners that hides the STS cap.
This can be used if the listener is secured at layer 3 or 4 (VPNs,
E2E mixnets). It will be necessary to add the relevant IPs to `secure-nets`.