### PR TITLE
{default,traditional}.yaml: refer to IPs/CIDR instead of addrs

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -184,7 +184,7 @@ server:
         # possibility of real users being silently spoofed
         available-to-chanops: true
 
-    # addresses/CIDRs the PROXY command can be used from
+    # IPs/CIDRs the PROXY command can be used from
     # this should be restricted to localhost (127.0.0.1/8, ::1/128, and unix sockets),
     # unless you have a good reason. you should also add these addresses to the
     # connection limits and throttling exemption lists.
@@ -204,7 +204,7 @@ server:
             # password the gateway uses to connect, made with oragono genpasswd
             password: "$2a$04$abcdef0123456789abcdef0123456789abcdef0123456789abcde"
 
-            # addresses/CIDRs that can use this webirc command
+            # IPs/CIDRs that can use this webirc command
             # you should also add these addresses to the connection limits and throttling exemption lists
             hosts:
                 - localhost

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -157,7 +157,7 @@ server:
         # possibility of real users being silently spoofed
         available-to-chanops: true
 
-    # addresses/CIDRs the PROXY command can be used from
+    # IPs/CIDRs the PROXY command can be used from
     # this should be restricted to localhost (127.0.0.1/8, ::1/128, and unix sockets),
     # unless you have a good reason. you should also add these addresses to the
     # connection limits and throttling exemption lists.
@@ -177,7 +177,7 @@ server:
             # password the gateway uses to connect, made with oragono genpasswd
             password: "$2a$04$abcdef0123456789abcdef0123456789abcdef0123456789abcde"
 
-            # addresses/CIDRs that can use this webirc command
+            # IPs/CIDRs that can use this webirc command
             # you should also add these addresses to the connection limits and throttling exemption lists
             hosts:
                 - localhost


### PR DESCRIPTION
Whenever CIDR is mentioned in the config, it's in combination with IP so
talking about addressese in these points gives wrong impression that a
domain name would be valid as those are often thought as addresses.