### PR TITLE
fix #1449

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -1537,11 +1537,10 @@ func (channel *Channel) Invite(invitee *Client, inviter *Client, rb *ResponseBuf
 	details := inviter.Details()
 	tDetails := invitee.Details()
 	tnick := invitee.Nick()
-	message := utils.MakeMessage("")
+	message := utils.MakeMessage(chname)
 	item := history.Item{
 		Type:    history.Invite,
 		Message: message,
-		Params:  [1]string{chname},
 	}
 
 	for _, member := range channel.Members() {

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -1073,14 +1073,6 @@ func (channel *Channel) replayHistoryForResume(session *Session, after time.Time
 	rb.Send(true)
 }
 
-func stripMaskFromNick(nickMask string) (nick string) {
-	index := strings.Index(nickMask, "!")
-	if index == -1 {
-		return nickMask
-	}
-	return nickMask[0:index]
-}
-
 func (channel *Channel) replayHistoryItems(rb *ResponseBuffer, items []history.Item, autoreplay bool) {
 	// send an empty batch if necessary, as per the CHATHISTORY spec
 	chname := channel.Name()
@@ -1103,7 +1095,7 @@ func (channel *Channel) replayHistoryItems(rb *ResponseBuffer, items []history.I
 	defer rb.EndNestedBatch(batchID)
 
 	for _, item := range items {
-		nick := stripMaskFromNick(item.Nick)
+		nick := NUHToNick(item.Nick)
 		switch item.Type {
 		case history.Privmsg:
 			rb.AddSplitMessageFromClient(item.Nick, item.AccountName, item.Tags, "PRIVMSG", chname, item.Message)

--- a/irc/client.go
+++ b/irc/client.go
@@ -975,7 +975,7 @@ func (session *Session) playResume() {
 	if privmsgSeq != nil {
 		privmsgs, _, _ := privmsgSeq.Between(history.Selector{}, history.Selector{}, config.History.ClientLength)
 		for _, item := range privmsgs {
-			sender := server.clients.Get(stripMaskFromNick(item.Nick))
+			sender := server.clients.Get(NUHToNick(item.Nick))
 			if sender != nil {
 				friends.Add(sender)
 			}
@@ -1079,7 +1079,7 @@ func (client *Client) replayPrivmsgHistory(rb *ResponseBuffer, items []history.I
 			if hasEventPlayback {
 				rb.AddFromClient(item.Message.Time, item.Message.Msgid, item.Nick, item.AccountName, nil, "INVITE", nick, item.Message.Message)
 			} else {
-				rb.AddFromClient(item.Message.Time, utils.MungeSecretToken(item.Message.Msgid), histservService.prefix, "*", nil, "PRIVMSG", fmt.Sprintf(client.t("%[1]s invited you to channel %[2]s"), stripMaskFromNick(item.Nick), item.Message.Message))
+				rb.AddFromClient(item.Message.Time, utils.MungeSecretToken(item.Message.Msgid), histservService.prefix, "*", nil, "PRIVMSG", fmt.Sprintf(client.t("%[1]s invited you to channel %[2]s"), NUHToNick(item.Nick), item.Message.Message))
 			}
 			continue
 		case history.Privmsg:

--- a/irc/histserv.go
+++ b/irc/histserv.go
@@ -173,7 +173,7 @@ func histservPlayHandler(service *ircService, server *Server, client *Client, co
 	}
 
 	playMessage := func(timestamp time.Time, nick, message string) {
-		service.Notice(rb, fmt.Sprintf("%s <%s> %s", timestamp.Format("15:04:05"), stripMaskFromNick(nick), message))
+		service.Notice(rb, fmt.Sprintf("%s <%s> %s", timestamp.Format("15:04:05"), NUHToNick(nick), message))
 	}
 
 	for _, item := range items {

--- a/irc/strings.go
+++ b/irc/strings.go
@@ -308,3 +308,11 @@ func foldPermissive(str string) (result string, err error) {
 	str = norm.NFD.String(str)
 	return str, nil
 }
+
+// Reduce, e.g., `alice!~u@host` to `alice`
+func NUHToNick(nuh string) (nick string) {
+	if idx := strings.IndexByte(nuh, '!'); idx != -1 {
+		return nuh[0:idx]
+	}
+	return nuh
+}


### PR DESCRIPTION
INVITE playback (#1409) was buggy, due to the double use of (Item).Params[0]
for the channel name and the recipient nick. Stuff the channel name in
(Item).Message.Message instead.