### PR TITLE
initial work on #1483

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -686,9 +686,12 @@ func (client *Client) run(session *Session) {
 		if err == errInvalidUtf8 {
 			invalidUtf8 = true // handle as normal, including labeling
 		} else if err != nil {
-			quitMessage := "connection closed"
-			if err == errReadQ {
-				quitMessage = "readQ exceeded"
+			var quitMessage string
+			switch err {
+			case errReadQ, errWSBinaryMessage:
+				quitMessage = err.Error()
+			default:
+				quitMessage = "connection closed"
 			}
 			client.Quit(quitMessage, session)
 			// since the client did not actually send us a QUIT,

--- a/irc/config.go
+++ b/irc/config.go
@@ -837,6 +837,9 @@ func (conf *Config) prepareListeners() (err error) {
 		}
 		lconf.RequireProxy = block.TLS.Proxy || block.Proxy
 		lconf.WebSocket = block.WebSocket
+		if lconf.WebSocket && !conf.Server.EnforceUtf8 {
+			return fmt.Errorf("enabling a websocket listener requires the use of server.enforce-utf8")
+		}
 		lconf.HideSTS = block.HideSTS
 		conf.Server.trueListeners[addr] = lconf
 	}
@@ -1445,6 +1448,9 @@ func (config *Config) generateISupport() (err error) {
 	isupport.Add("TOPICLEN", strconv.Itoa(config.Limits.TopicLen))
 	if config.Server.Casemapping == CasemappingPRECIS {
 		isupport.Add("UTF8MAPPING", precisUTF8MappingToken)
+	}
+	if config.Server.EnforceUtf8 {
+		isupport.Add("UTF8ONLY", "")
 	}
 	isupport.Add("WHOX", "")
 

--- a/irc/listeners.go
+++ b/irc/listeners.go
@@ -166,6 +166,7 @@ func (wl *WSListener) handle(w http.ResponseWriter, r *http.Request) {
 			}
 			return false
 		},
+		Subprotocols: []string{"text.ircv3.net"},
 	}
 
 	conn, err := wsUpgrader.Upgrade(w, r, nil)


### PR DESCRIPTION
This adds a cap named `draft/utf8-only`; my sense is still that this proposal belongs in the public draft process, as part of the conversation around the status of legacy encodings. If you have strong feelings, I can go back to a vendor prefix.

This also enforces that (websockets implies enforce-utf8), and cleans up some enforcement code.