### PR TITLE
fix always-on expiration checks

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -443,7 +443,7 @@ func (server *Server) AddAlwaysOnClient(account ClientAccount, channelToModes ma
 		nextSessionID: 1,
 	}
 
-	if client.checkAlwaysOnExpirationNoMutex(config) {
+	if client.checkAlwaysOnExpirationNoMutex(config, true) {
 		server.logger.Debug("accounts", "always-on client not created due to expiration", account.Name)
 		return
 	}
@@ -1403,7 +1403,7 @@ func (client *Client) destroy(session *Session) {
 	alwaysOn := registered && client.alwaysOn
 	// if we hit always-on-expiration, confirm the expiration and then proceed as though
 	// always-on is disabled:
-	if alwaysOn && session == nil && client.checkAlwaysOnExpirationNoMutex(config) {
+	if alwaysOn && session == nil && client.checkAlwaysOnExpirationNoMutex(config, false) {
 		quitMessage = "Timed out due to inactivity"
 		alwaysOn = false
 		client.alwaysOn = false

--- a/irc/getters.go
+++ b/irc/getters.go
@@ -452,11 +452,11 @@ func (client *Client) Realname() string {
 func (client *Client) IsExpiredAlwaysOn(config *Config) (result bool) {
 	client.stateMutex.Lock()
 	defer client.stateMutex.Unlock()
-	return client.checkAlwaysOnExpirationNoMutex(config)
+	return client.checkAlwaysOnExpirationNoMutex(config, false)
 }
 
-func (client *Client) checkAlwaysOnExpirationNoMutex(config *Config) (result bool) {
-	if !(client.registered && client.alwaysOn) {
+func (client *Client) checkAlwaysOnExpirationNoMutex(config *Config, ignoreRegistration bool) (result bool) {
+	if !((client.registered || ignoreRegistration) && client.alwaysOn) {
 		return false
 	}
 	deadline := time.Duration(config.Accounts.Multiclient.AlwaysOnExpiration)


### PR DESCRIPTION
checkAlwaysOnExpirationNoMutex was respecting registered status, but
always-on clients were not considered registered at the time of the
initial check, so they were being created regardless of expiration.