### PR TITLE
reduce recommended bcrypt cost to the lowest allowed value

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -372,7 +372,8 @@ accounts:
             max-attempts: 30
 
         # this is the bcrypt cost we'll use for account passwords
-        bcrypt-cost: 9
+        # (note that 4 is the lowest value allowed by the bcrypt library)
+        bcrypt-cost: 4
 
         # length of time a user has to verify their account before it can be re-registered
         verify-timeout: "32h"

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -344,7 +344,8 @@ accounts:
             max-attempts: 30
 
         # this is the bcrypt cost we'll use for account passwords
-        bcrypt-cost: 9
+        # (note that 4 is the lowest value allowed by the bcrypt library)
+        bcrypt-cost: 4
 
         # length of time a user has to verify their account before it can be re-registered
         verify-timeout: "32h"


### PR DESCRIPTION
Two objectives:

1. Reduce thundering-herd effects on server restart (a cost of 4 should be
approximately 1 millisecond of CPU time per reconnecting client)
2. Speed up mobile reattach as much as possible (see also #1420)