### PR TITLE
bump irc-go to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/go-test/deep v1.0.6 // indirect
 	github.com/gorilla/websocket v1.4.2
-	github.com/goshuirc/irc-go v0.0.0-20210215162435-14cd697c0c8c
+	github.com/goshuirc/irc-go v0.0.0-20210222010959-6e139f6c42e9
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/oragono/confusables v0.0.0-20201108231250-4ab98ab61fb1

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/goshuirc/irc-go v0.0.0-20210214015142-9d703e6ac38a h1:PR1tw21nn93AwKm
 github.com/goshuirc/irc-go v0.0.0-20210214015142-9d703e6ac38a/go.mod h1:q/JhvvKLmif3y9q8MDQM+gRCnjEKnu5ClF298TTXJug=
 github.com/goshuirc/irc-go v0.0.0-20210215162435-14cd697c0c8c h1:pOTMO5A1nszuxNyKieZa3owgDqCpN1OhOGbBg8EuLzk=
 github.com/goshuirc/irc-go v0.0.0-20210215162435-14cd697c0c8c/go.mod h1:q/JhvvKLmif3y9q8MDQM+gRCnjEKnu5ClF298TTXJug=
+github.com/goshuirc/irc-go v0.0.0-20210222010959-6e139f6c42e9 h1:A1mSQ0N5Kx8i+aeqeQ0VLbq3swuH0R/JoQcFcR9yUWA=
+github.com/goshuirc/irc-go v0.0.0-20210222010959-6e139f6c42e9/go.mod h1:q/JhvvKLmif3y9q8MDQM+gRCnjEKnu5ClF298TTXJug=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/vendor/github.com/goshuirc/irc-go/ircmsg/message.go
+++ b/vendor/github.com/goshuirc/irc-go/ircmsg/message.go
@@ -419,7 +419,8 @@ func (ircmsg *IRCMessage) line(tagLimit, clientOnlyTagDataLimit, serverAddedTagD
 	buf.WriteString("\r\n")
 
 	result := buf.Bytes()
-	if bytes.IndexByte(result, '\x00') != -1 {
+	toValidate := result[:len(result)-2]
+	if bytes.IndexByte(toValidate, '\x00') != -1 || bytes.IndexByte(toValidate, '\r') != -1 || bytes.IndexByte(toValidate, '\n') != -1 {
 		return nil, ErrorLineContainsBadChar
 	}
 	return result, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -21,7 +21,7 @@ github.com/go-sql-driver/mysql
 # github.com/gorilla/websocket v1.4.2
 ## explicit
 github.com/gorilla/websocket
-# github.com/goshuirc/irc-go v0.0.0-20210215162435-14cd697c0c8c
+# github.com/goshuirc/irc-go v0.0.0-20210222010959-6e139f6c42e9
 ## explicit
 github.com/goshuirc/irc-go/ircfmt
 github.com/goshuirc/irc-go/ircmsg


### PR DESCRIPTION
As discussed on goshuirc/irc-go#36, there are no security implications for Oragono. Given the new message caching layer, I expect negligible performance implications as well.