### PR TITLE
implement candidate compromise proposal for websockets

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -691,7 +691,7 @@ func (client *Client) run(session *Session) {
 		} else if err != nil {
 			var quitMessage string
 			switch err {
-			case ircreader.ErrReadQ, errWSBinaryMessage:
+			case ircreader.ErrReadQ:
 				quitMessage = err.Error()
 			default:
 				quitMessage = "connection closed"

--- a/irc/ircconn.go
+++ b/irc/ircconn.go
@@ -126,10 +126,8 @@ func (wc IRCWSConn) WriteLines(buffers [][]byte) (err error) {
 func (wc IRCWSConn) ReadLine() (line []byte, err error) {
 	messageType, line, err := wc.conn.ReadMessage()
 	if err == nil {
-		if messageType == websocket.BinaryMessage && globalUtf8EnforcementSetting {
-			if !utf8.Valid(line) {
-				return line, errInvalidUtf8
-			}
+		if messageType == websocket.BinaryMessage && !utf8.Valid(line) {
+			return line, errInvalidUtf8
 		}
 		return line, nil
 	} else if err == websocket.ErrReadLimit {

--- a/irc/listeners.go
+++ b/irc/listeners.go
@@ -166,7 +166,7 @@ func (wl *WSListener) handle(w http.ResponseWriter, r *http.Request) {
 			}
 			return false
 		},
-		Subprotocols: []string{"text.ircv3.net"},
+		Subprotocols: []string{"text.ircv3.net", "binary.ircv3.net"},
 	}
 
 	conn, err := wsUpgrader.Upgrade(w, r, nil)


### PR DESCRIPTION
1. Text and binary frames are accepted
2. Text frames are sent by default
3. Binary frames are sent to clients who negotiate `binary.ircv3.net`
4. Non-UTF8 data is not accepted (enabling websockets still enables UTFONLY)