### PR TITLE
fix #1547

### DIFF
--- a/irc/nickserv.go
+++ b/irc/nickserv.go
@@ -222,6 +222,9 @@ indicate an empty password, use * instead.`,
 			enabled:   servCmdRequiresAuthEnabled,
 			minParams: 2,
 		},
+		"password": {
+			aliasOf: "passwd",
+		},
 		"get": {
 			handler: nsGetHandler,
 			help: `Syntax: $bGET <setting>$b


### PR DESCRIPTION
Make PASSWORD an alias for PASSWD in nickserv. It's too much work to make PASSWORD the canonical name. And doing this now doesn't preclude doing that in future.