### PR TITLE
deprecate message truncation

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -235,6 +235,13 @@ server:
         # this works around that bug, allowing them to use SASL.
         send-unprefixed-sasl: true
 
+        # traditionally, IRC servers will truncate and send messages that are
+        # too long to be relayed intact. this behavior can be disabled by setting
+        # allow-truncation to false, in which case Oragono will reject the message
+        # and return an error to the client. (note that this option defaults to true
+        # when unset.)
+        allow-truncation: false
+
     # IP-based DoS protection
     ip-limits:
         # whether to limit the total number of concurrent connections per IP/CIDR

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/go-test/deep v1.0.6 // indirect
 	github.com/gorilla/websocket v1.4.2
-	github.com/goshuirc/irc-go v0.0.0-20210301225436-2c4b83d64847
+	github.com/goshuirc/irc-go v0.0.0-20210304031553-cf78e9176f96
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/oragono/confusables v0.0.0-20201108231250-4ab98ab61fb1
@@ -24,4 +24,4 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 )
 
-replace github.com/gorilla/websocket  => github.com/oragono/websocket v1.4.2-oragono1
+replace github.com/gorilla/websocket => github.com/oragono/websocket v1.4.2-oragono1

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/goshuirc/irc-go v0.0.0-20210223005429-8d38e43fc6ed h1:cwwqHrmLafgEucS
 github.com/goshuirc/irc-go v0.0.0-20210223005429-8d38e43fc6ed/go.mod h1:q/JhvvKLmif3y9q8MDQM+gRCnjEKnu5ClF298TTXJug=
 github.com/goshuirc/irc-go v0.0.0-20210301225436-2c4b83d64847 h1:MmsZRpAsMxyw0P5/SFn2L6edhmIXRlolgXvOF+fgEiQ=
 github.com/goshuirc/irc-go v0.0.0-20210301225436-2c4b83d64847/go.mod h1:q/JhvvKLmif3y9q8MDQM+gRCnjEKnu5ClF298TTXJug=
+github.com/goshuirc/irc-go v0.0.0-20210304031553-cf78e9176f96 h1:sihI3HsrJWyS4MtBmxh5W4gDZD34SWodkWyUvJltswY=
+github.com/goshuirc/irc-go v0.0.0-20210304031553-cf78e9176f96/go.mod h1:q/JhvvKLmif3y9q8MDQM+gRCnjEKnu5ClF298TTXJug=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -1361,6 +1361,15 @@ func (channel *Channel) SendSplitMessage(command string, minPrefixMode modes.Mod
 	details := client.Details()
 	chname := channel.Name()
 
+	if !client.server.Config().Server.Compatibility.allowTruncation {
+		if !validateSplitMessageLen(histType, details.nickMask, chname, message) {
+			rb.Add(nil, client.server.name, ERR_INPUTTOOLONG, details.nick, client.t("Line too long to be relayed without truncation"))
+			// TODO(#1577) remove this logline:
+			client.server.logger.Debug("internal", "rejected truncation-requiring DM from client", details.nick)
+			return
+		}
+	}
+
 	// STATUSMSG targets are prefixed with the supplied min-prefix, e.g., @#channel
 	if minPrefixMode != modes.Mode(0) {
 		chname = fmt.Sprintf("%s%s", modes.ChannelModePrefixes[minPrefixMode], chname)

--- a/irc/config.go
+++ b/irc/config.go
@@ -569,7 +569,9 @@ type Config struct {
 		Compatibility        struct {
 			ForceTrailing      *bool `yaml:"force-trailing"`
 			forceTrailing      bool
-			SendUnprefixedSasl bool `yaml:"send-unprefixed-sasl"`
+			SendUnprefixedSasl bool  `yaml:"send-unprefixed-sasl"`
+			AllowTruncation    *bool `yaml:"allow-truncation"`
+			allowTruncation    bool
 		}
 		isupport                 isupport.List
 		IPLimits                 connection_limits.LimiterConfig `yaml:"ip-limits"`
@@ -1378,6 +1380,7 @@ func LoadConfig(filename string) (config *Config, err error) {
 	}
 
 	config.Server.Compatibility.forceTrailing = utils.BoolDefaultTrue(config.Server.Compatibility.ForceTrailing)
+	config.Server.Compatibility.allowTruncation = utils.BoolDefaultTrue(config.Server.Compatibility.AllowTruncation)
 
 	config.loadMOTD()
 

--- a/irc/message_cache.go
+++ b/irc/message_cache.go
@@ -54,7 +54,7 @@ func addAllTags(msg *ircmsg.IRCMessage, tags map[string]string, serverTime time.
 }
 
 func (m *MessageCache) handleErr(server *Server, err error) bool {
-	if err != nil {
+	if !(err == nil || err == ircmsg.ErrorBodyTooLong) {
 		server.logger.Error("internal", "Error assembling message for sending", err.Error())
 		// blank these out so Send will be a no-op
 		m.fullTags = nil

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -208,6 +208,13 @@ server:
         # this works around that bug, allowing them to use SASL.
         send-unprefixed-sasl: true
 
+        # traditionally, IRC servers will truncate and send messages that are
+        # too long to be relayed intact. this behavior can be disabled by setting
+        # allow-truncation to false, in which case Oragono will reject the message
+        # and return an error to the client. (note that this option defaults to true
+        # when unset.)
+        allow-truncation: true
+
     # IP-based DoS protection
     ip-limits:
         # whether to limit the total number of concurrent connections per IP/CIDR

--- a/vendor/github.com/goshuirc/irc-go/ircreader/ircreader.go
+++ b/vendor/github.com/goshuirc/irc-go/ircreader/ircreader.go
@@ -63,6 +63,10 @@ func (cc *IRCReader) ReadLine() ([]byte, error) {
 			line := cc.buf[cc.start : cc.searchFrom+nlidx]
 			cc.start = cc.searchFrom + nlidx + 1
 			cc.searchFrom = cc.start
+			// treat \r\n as the line terminator if it was present
+			if 0 < len(line) && line[len(line)-1] == '\r' {
+				line = line[:len(line)-1]
+			}
 			return line, nil
 		}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -21,7 +21,7 @@ github.com/go-sql-driver/mysql
 # github.com/gorilla/websocket v1.4.2 => github.com/oragono/websocket v1.4.2-oragono1
 ## explicit
 github.com/gorilla/websocket
-# github.com/goshuirc/irc-go v0.0.0-20210301225436-2c4b83d64847
+# github.com/goshuirc/irc-go v0.0.0-20210304031553-cf78e9176f96
 ## explicit
 github.com/goshuirc/irc-go/ircfmt
 github.com/goshuirc/irc-go/ircmsg


### PR DESCRIPTION
Implements #1577, but the issue should remain open until we clean up the debugging loglines.

This splits the baby: `default.yaml` has `allow-truncation: false` (and I plan for the test suite to run in this mode), but `traditional.yaml` has it as `true`, and it will default to true when unset (so no one gets surprised by their bots breaking).