### PR TITLE
fix #1531

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -621,10 +621,6 @@ In this section, we give an overview of the modes Oragono supports.
 
 These are the modes which can be set on you when you're connected.
 
-### +a - Away
-
-If this mode is set, you're marked as being away. This mode is set with the /AWAY command.
-
 ### +i - Invisible
 
 If this mode is set, you're marked as 'invisible'. This means that your channels won't be shown when users `/WHOIS` you (except for IRC operators, they can see all the channels you're in).

--- a/irc/client.go
+++ b/irc/client.go
@@ -78,8 +78,6 @@ type Client struct {
 	accountName        string // display name of the account: uncasefolded, '*' if not logged in
 	accountRegDate     time.Time
 	accountSettings    AccountSettings
-	away               bool
-	autoAway           bool
 	awayMessage        string
 	brbTimer           BrbTimer
 	channels           ChannelSet
@@ -176,6 +174,9 @@ type Session struct {
 	batchCounter uint32
 
 	quitMessage string
+
+	awayMessage string
+	awayAt      time.Time
 
 	capabilities caps.Set
 	capState     caps.State
@@ -486,8 +487,6 @@ func (server *Server) AddAlwaysOnClient(account ClientAccount, channelToStatus m
 	}
 
 	if persistenceEnabled(config.Accounts.Multiclient.AutoAway, client.accountSettings.AutoAway) {
-		client.autoAway = true
-		client.away = true
 		client.awayMessage = client.t("User is currently disconnected")
 	}
 }
@@ -675,7 +674,7 @@ func (client *Client) run(session *Session) {
 			session.playResume()
 			session.resumeDetails = nil
 			client.brbTimer.Disable()
-			client.SetAway(false, "") // clear BRB message if any
+			session.SetAway("") // clear BRB message if any
 		} else {
 			client.playReattachMessages(session)
 		}
@@ -1458,15 +1457,13 @@ func (client *Client) destroy(session *Session) {
 		client.dirtyBits |= IncludeLastSeen
 	}
 
-	autoAway := false
+	becameAutoAway := false
 	var awayMessage string
-	if alwaysOn && !client.away && remainingSessions == 0 &&
-		persistenceEnabled(config.Accounts.Multiclient.AutoAway, client.accountSettings.AutoAway) {
-		autoAway = true
-		client.autoAway = true
-		client.away = true
-		awayMessage = config.languageManager.Translate(client.languages, `User is currently disconnected`)
-		client.awayMessage = awayMessage
+	if alwaysOn && persistenceEnabled(config.Accounts.Multiclient.AutoAway, client.accountSettings.AutoAway) {
+		wasAway := client.awayMessage != ""
+		client.setAutoAwayNoMutex(config)
+		awayMessage = client.awayMessage
+		becameAutoAway = !wasAway && awayMessage != ""
 	}
 
 	if client.registrationTimer != nil {
@@ -1523,7 +1520,7 @@ func (client *Client) destroy(session *Session) {
 		client.server.stats.Remove(registered, invisible, operator)
 	}
 
-	if autoAway {
+	if becameAutoAway {
 		dispatchAwayNotify(client, true, awayMessage)
 	}
 

--- a/irc/client.go
+++ b/irc/client.go
@@ -487,7 +487,7 @@ func (server *Server) AddAlwaysOnClient(account ClientAccount, channelToStatus m
 	}
 
 	if persistenceEnabled(config.Accounts.Multiclient.AutoAway, client.accountSettings.AutoAway) {
-		client.awayMessage = client.t("User is currently disconnected")
+		client.setAutoAwayNoMutex(config)
 	}
 }
 

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -352,7 +352,7 @@ func awayHandler(server *Server, client *Client, msg ircmsg.Message, rb *Respons
 		}
 	}
 
-	client.SetAway(isAway, awayMessage)
+	rb.session.SetAway(awayMessage)
 
 	if isAway {
 		rb.Add(nil, server.name, RPL_NOWAWAY, client.nick, client.t("You have been marked as being away"))
@@ -439,7 +439,7 @@ func brbHandler(server *Server, client *Client, msg ircmsg.Message, rb *Response
 
 	if len(client.Sessions()) == 1 {
 		// true BRB
-		client.SetAway(true, message)
+		rb.session.SetAway(message)
 	}
 
 	return true


### PR DESCRIPTION
AWAY status should be tracked per-session:

1. With auto-away enabled, away status is aggregated across sessions
   (if any session is not away, the client is not away, else use
   the away status that was set most recently)
2. With auto-away disabled, we get the legacy behavior where AWAY
   applies directly to the client