### PR TITLE
fix #1592

### DIFF
--- a/irc/channel.go
+++ b/irc/channel.go
@@ -920,7 +920,7 @@ func (channel *Channel) autoReplayHistory(client *Client, rb *ResponseBuffer, sk
 		_, seq, _ := channel.server.GetHistorySequence(channel, client, "")
 		if seq != nil {
 			zncMax := channel.server.Config().History.ZNCMax
-			items, _, _ = seq.Between(history.Selector{Time: start}, history.Selector{Time: end}, zncMax)
+			items, _ = seq.Between(history.Selector{Time: start}, history.Selector{Time: end}, zncMax)
 		}
 	} else if !rb.session.HasHistoryCaps() {
 		var replayLimit int
@@ -937,7 +937,7 @@ func (channel *Channel) autoReplayHistory(client *Client, rb *ResponseBuffer, sk
 		if 0 < replayLimit {
 			_, seq, _ := channel.server.GetHistorySequence(channel, client, "")
 			if seq != nil {
-				items, _, _ = seq.Between(history.Selector{}, history.Selector{}, replayLimit)
+				items, _ = seq.Between(history.Selector{}, history.Selector{}, replayLimit)
 			}
 		}
 	}
@@ -1097,19 +1097,14 @@ func (channel *Channel) resumeAndAnnounce(session *Session) {
 
 func (channel *Channel) replayHistoryForResume(session *Session, after time.Time, before time.Time) {
 	var items []history.Item
-	var complete bool
 	afterS, beforeS := history.Selector{Time: after}, history.Selector{Time: before}
 	_, seq, _ := channel.server.GetHistorySequence(channel, session.client, "")
 	if seq != nil {
-		items, complete, _ = seq.Between(afterS, beforeS, channel.server.Config().History.ZNCMax)
+		items, _ = seq.Between(afterS, beforeS, channel.server.Config().History.ZNCMax)
 	}
 	rb := NewResponseBuffer(session)
 	if len(items) != 0 {
 		channel.replayHistoryItems(rb, items, false)
-	}
-	if !complete && !session.resumeDetails.HistoryIncomplete {
-		// warn here if we didn't warn already
-		rb.Add(nil, histservService.prefix, "NOTICE", channel.Name(), session.client.t("Some additional message history may have been lost"))
 	}
 	rb.Send(true)
 }

--- a/irc/channelmanager.go
+++ b/irc/channelmanager.go
@@ -458,3 +458,13 @@ func (cm *ChannelManager) ListPurged() (result []string) {
 	sort.Strings(result)
 	return
 }
+
+func (cm *ChannelManager) UnfoldName(cfname string) (result string) {
+	cm.RLock()
+	entry := cm.chans[cfname]
+	cm.RUnlock()
+	if entry != nil && entry.channel.IsLoaded() {
+		return entry.channel.Name()
+	}
+	return cfname
+}

--- a/irc/client.go
+++ b/irc/client.go
@@ -990,7 +990,7 @@ func (session *Session) playResume() {
 	}
 	_, privmsgSeq, _ := server.GetHistorySequence(nil, client, "*")
 	if privmsgSeq != nil {
-		privmsgs, _, _ := privmsgSeq.Between(history.Selector{}, history.Selector{}, config.History.ClientLength)
+		privmsgs, _ := privmsgSeq.Between(history.Selector{}, history.Selector{}, config.History.ClientLength)
 		for _, item := range privmsgs {
 			sender := server.clients.Get(NUHToNick(item.Nick))
 			if sender != nil {
@@ -1055,10 +1055,10 @@ func (session *Session) playResume() {
 	// replay direct PRIVSMG history
 	if !timestamp.IsZero() && privmsgSeq != nil {
 		after := history.Selector{Time: timestamp}
-		items, complete, _ := privmsgSeq.Between(after, history.Selector{}, config.History.ZNCMax)
+		items, _ := privmsgSeq.Between(after, history.Selector{}, config.History.ZNCMax)
 		if len(items) != 0 {
 			rb := NewResponseBuffer(session)
-			client.replayPrivmsgHistory(rb, items, "", complete)
+			client.replayPrivmsgHistory(rb, items, "")
 			rb.Send(true)
 		}
 	}
@@ -1066,7 +1066,7 @@ func (session *Session) playResume() {
 	session.resumeDetails = nil
 }
 
-func (client *Client) replayPrivmsgHistory(rb *ResponseBuffer, items []history.Item, target string, complete bool) {
+func (client *Client) replayPrivmsgHistory(rb *ResponseBuffer, items []history.Item, target string) {
 	var batchID string
 	details := client.Details()
 	nick := details.nick
@@ -1126,9 +1126,6 @@ func (client *Client) replayPrivmsgHistory(rb *ResponseBuffer, items []history.I
 	}
 
 	rb.EndNestedBatch(batchID)
-	if !complete {
-		rb.Add(nil, histservService.prefix, "NOTICE", nick, client.t("Some additional message history may have been lost"))
-	}
 }
 
 // IdleTime returns how long this client's been idle.

--- a/irc/client_lookup_set.go
+++ b/irc/client_lookup_set.go
@@ -308,3 +308,16 @@ func (clients *ClientManager) FindAll(userhost string) (set ClientSet) {
 
 	return set
 }
+
+// Determine the canonical / unfolded form of a nick, if a client matching it
+// is present (or always-on).
+func (clients *ClientManager) UnfoldNick(cfnick string) (nick string) {
+	clients.RLock()
+	c := clients.byNick[cfnick]
+	clients.RUnlock()
+	if c != nil {
+		return c.Nick()
+	} else {
+		return cfnick
+	}
+}

--- a/irc/history/history.go
+++ b/irc/history/history.go
@@ -44,8 +44,13 @@ type Item struct {
 	// for a DM, this is the casefolded nickname of the other party (whether this is
 	// an incoming or outgoing message). this lets us emulate the "query buffer" functionality
 	// required by CHATHISTORY:
+	CfCorrespondent string `json:"CfCorrespondent,omitempty"`
+	IsBot           bool   `json:"IsBot,omitempty"`
+}
+
+type CorrespondentListing struct {
 	CfCorrespondent string
-	IsBot           bool `json:"IsBot,omitempty"`
+	Time            time.Time
 }
 
 // HasMsgid tests whether a message has the message id `msgid`.
@@ -56,6 +61,13 @@ func (item *Item) HasMsgid(msgid string) bool {
 type Predicate func(item *Item) (matches bool)
 
 func Reverse(results []Item) {
+	for i, j := 0, len(results)-1; i < j; i, j = i+1, j-1 {
+		results[i], results[j] = results[j], results[i]
+	}
+}
+
+func ReverseCorrespondents(results []CorrespondentListing) {
+	// lol, generics when?
 	for i, j := 0, len(results)-1; i < j; i, j = i+1, j-1 {
 		results[i], results[j] = results[j], results[i]
 	}
@@ -201,6 +213,78 @@ func (list *Buffer) betweenHelper(start, end Selector, cutoff time.Time, pred Pr
 	return list.matchInternal(satisfies, ascending, limit), complete, nil
 }
 
+// returns all correspondents, in reverse time order
+func (list *Buffer) allCorrespondents() (results []CorrespondentListing) {
+	seen := make(utils.StringSet)
+
+	list.RLock()
+	defer list.RUnlock()
+	if list.start == -1 || len(list.buffer) == 0 {
+		return
+	}
+
+	// XXX traverse in reverse order, so we get the latest timestamp
+	// of any message sent to/from the correspondent
+	pos := list.prev(list.end)
+	stop := list.start
+
+	for {
+		if !seen.Has(list.buffer[pos].CfCorrespondent) {
+			seen.Add(list.buffer[pos].CfCorrespondent)
+			results = append(results, CorrespondentListing{
+				CfCorrespondent: list.buffer[pos].CfCorrespondent,
+				Time:            list.buffer[pos].Message.Time,
+			})
+		}
+
+		if pos == stop {
+			break
+		}
+		pos = list.prev(pos)
+	}
+	return
+}
+
+// implement LISTCORRESPONDENTS
+func (list *Buffer) listCorrespondents(start, end Selector, cutoff time.Time, limit int) (results []CorrespondentListing, err error) {
+	after := start.Time
+	before := end.Time
+	after, before, ascending := MinMaxAsc(after, before, cutoff)
+
+	correspondents := list.allCorrespondents()
+	if len(correspondents) == 0 {
+		return
+	}
+
+	// XXX allCorrespondents returns results in reverse order,
+	// so if we're ascending, we actually go backwards
+	var i int
+	if ascending {
+		i = len(correspondents) - 1
+	} else {
+		i = 0
+	}
+
+	for 0 <= i && i < len(correspondents) && (limit == 0 || len(results) < limit) {
+		if (after.IsZero() || correspondents[i].Time.After(after)) &&
+			(before.IsZero() || correspondents[i].Time.Before(before)) {
+			results = append(results, correspondents[i])
+		}
+
+		if ascending {
+			i--
+		} else {
+			i++
+		}
+	}
+
+	if !ascending {
+		ReverseCorrespondents(results)
+	}
+
+	return
+}
+
 // implements history.Sequence, emulating a single history buffer (for a channel,
 // a single user's DMs, or a DM conversation)
 type bufferSequence struct {
@@ -223,12 +307,17 @@ func (list *Buffer) MakeSequence(correspondent string, cutoff time.Time) Sequenc
 	}
 }
 
-func (seq *bufferSequence) Between(start, end Selector, limit int) (results []Item, complete bool, err error) {
-	return seq.list.betweenHelper(start, end, seq.cutoff, seq.pred, limit)
+func (seq *bufferSequence) Between(start, end Selector, limit int) (results []Item, err error) {
+	results, _, err = seq.list.betweenHelper(start, end, seq.cutoff, seq.pred, limit)
+	return
 }
 
 func (seq *bufferSequence) Around(start Selector, limit int) (results []Item, err error) {
 	return GenericAround(seq, start, limit)
+}
+
+func (seq *bufferSequence) ListCorrespondents(start, end Selector, limit int) (results []CorrespondentListing, err error) {
+	return seq.list.listCorrespondents(start, end, seq.cutoff, limit)
 }
 
 // you must be holding the read lock to call this

--- a/irc/history/queries.go
+++ b/irc/history/queries.go
@@ -17,15 +17,17 @@ type Selector struct {
 // it encapsulates restrictions such as registration time cutoffs, or
 // only looking at a single "query buffer" (DMs with a particular correspondent)
 type Sequence interface {
-	Between(start, end Selector, limit int) (results []Item, complete bool, err error)
+	Between(start, end Selector, limit int) (results []Item, err error)
 	Around(start Selector, limit int) (results []Item, err error)
+
+	ListCorrespondents(start, end Selector, limit int) (results []CorrespondentListing, err error)
 }
 
 // This is a bad, slow implementation of CHATHISTORY AROUND using the BETWEEN semantics
 func GenericAround(seq Sequence, start Selector, limit int) (results []Item, err error) {
 	var halfLimit int
 	halfLimit = (limit + 1) / 2
-	initialResults, _, err := seq.Between(Selector{}, start, halfLimit)
+	initialResults, err := seq.Between(Selector{}, start, halfLimit)
 	if err != nil {
 		return
 	} else if len(initialResults) == 0 {
@@ -34,7 +36,7 @@ func GenericAround(seq Sequence, start Selector, limit int) (results []Item, err
 		return
 	}
 	newStart := Selector{Time: initialResults[0].Message.Time}
-	results, _, err = seq.Between(newStart, Selector{}, limit)
+	results, err = seq.Between(newStart, Selector{}, limit)
 	return
 }
 

--- a/irc/history/queries.go
+++ b/irc/history/queries.go
@@ -20,7 +20,14 @@ type Sequence interface {
 	Between(start, end Selector, limit int) (results []Item, err error)
 	Around(start Selector, limit int) (results []Item, err error)
 
-	ListCorrespondents(start, end Selector, limit int) (results []CorrespondentListing, err error)
+	ListCorrespondents(start, end Selector, limit int) (results []TargetListing, err error)
+
+	// this are weird hacks that violate the encapsulation of Sequence to some extent;
+	// Cutoff() returns the cutoff time for other code to use (it returns the zero time
+	// if none is set), and Ephemeral() returns whether the backing store is in-memory
+	// or a persistent database.
+	Cutoff() time.Time
+	Ephemeral() bool
 }
 
 // This is a bad, slow implementation of CHATHISTORY AROUND using the BETWEEN semantics

--- a/irc/history/targets.go
+++ b/irc/history/targets.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2021 Shivaram Lingamneni <slingamn@cs.stanford.edu>
+// released under the MIT license
+
+package history
+
+import (
+	"sort"
+	"time"
+)
+
+type TargetListing struct {
+	CfName string
+	Time   time.Time
+}
+
+// Merge `base`, a paging window of targets, with `extras` (the target entries
+// for all joined channels).
+func MergeTargets(base []TargetListing, extra []TargetListing, start, end time.Time, limit int) (results []TargetListing) {
+	if len(extra) == 0 {
+		return base
+	}
+	SortCorrespondents(extra)
+
+	start, end, ascending := MinMaxAsc(start, end, time.Time{})
+	predicate := func(t time.Time) bool {
+		return (start.IsZero() || start.Before(t)) && (end.IsZero() || end.After(t))
+	}
+
+	prealloc := len(base) + len(extra)
+	if limit < prealloc {
+		prealloc = limit
+	}
+	results = make([]TargetListing, 0, prealloc)
+
+	if !ascending {
+		ReverseCorrespondents(base)
+		ReverseCorrespondents(extra)
+	}
+
+	for len(results) < limit {
+		if len(extra) != 0 {
+			if !predicate(extra[0].Time) {
+				extra = extra[1:]
+				continue
+			}
+			if len(base) != 0 {
+				if base[0].Time.Before(extra[0].Time) == ascending {
+					results = append(results, base[0])
+					base = base[1:]
+				} else {
+					results = append(results, extra[0])
+					extra = extra[1:]
+				}
+			} else {
+				results = append(results, extra[0])
+				extra = extra[1:]
+			}
+		} else if len(base) != 0 {
+			results = append(results, base[0])
+			base = base[1:]
+		} else {
+			break
+		}
+	}
+
+	if !ascending {
+		ReverseCorrespondents(results)
+	}
+	return
+}
+
+func ReverseCorrespondents(results []TargetListing) {
+	// lol, generics when?
+	for i, j := 0, len(results)-1; i < j; i, j = i+1, j-1 {
+		results[i], results[j] = results[j], results[i]
+	}
+}
+
+func SortCorrespondents(list []TargetListing) {
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].Time.Before(list[j].Time)
+	})
+}

--- a/irc/histserv.go
+++ b/irc/histserv.go
@@ -238,12 +238,12 @@ func easySelectHistory(server *Server, client *Client, params []string) (items [
 	}
 
 	if duration == 0 {
-		items, _, err = sequence.Between(history.Selector{}, history.Selector{}, limit)
+		items, err = sequence.Between(history.Selector{}, history.Selector{}, limit)
 	} else {
 		now := time.Now().UTC()
 		start := history.Selector{Time: now}
 		end := history.Selector{Time: now.Add(-duration)}
-		items, _, err = sequence.Between(start, end, limit)
+		items, err = sequence.Between(start, end, limit)
 	}
 	return
 }

--- a/irc/server.go
+++ b/irc/server.go
@@ -1017,6 +1017,13 @@ func (server *Server) DeleteMessage(target, msgid, accountName string) (err erro
 	return
 }
 
+func (server *Server) UnfoldName(cfname string) (name string) {
+	if strings.HasPrefix(cfname, "#") {
+		return server.channels.UnfoldName(cfname)
+	}
+	return server.clients.UnfoldNick(cfname)
+}
+
 // elistMatcher takes and matches ELIST conditions
 type elistMatcher struct {
 	MinClientsActive bool

--- a/irc/znc.go
+++ b/irc/znc.go
@@ -16,6 +16,8 @@ import (
 const (
 	// #829, also see "Case 2" in the "three cases" below:
 	zncPlaybackCommandExpiration = time.Second * 30
+
+	zncPrefix = "*playback!znc@znc.in"
 )
 
 type zncCommandHandler func(client *Client, command string, params []string, rb *ResponseBuffer)
@@ -192,9 +194,9 @@ func zncPlayPrivmsgs(client *Client, rb *ResponseBuffer, target string, after, b
 		return
 	}
 	zncMax := client.server.Config().History.ZNCMax
-	items, _, err := sequence.Between(history.Selector{Time: after}, history.Selector{Time: before}, zncMax)
+	items, err := sequence.Between(history.Selector{Time: after}, history.Selector{Time: before}, zncMax)
 	if err == nil && len(items) != 0 {
-		client.replayPrivmsgHistory(rb, items, "", true)
+		client.replayPrivmsgHistory(rb, items, "")
 	}
 }
 
@@ -209,12 +211,31 @@ func zncPlaybackListHandler(client *Client, command string, params []string, rb 
 			client.server.logger.Error("internal", "couldn't get history sequence for ZNC list", err.Error())
 			continue
 		}
-		items, _, err := sequence.Between(history.Selector{}, history.Selector{}, 1) // i.e., LATEST * 1
+		items, err := sequence.Between(history.Selector{}, history.Selector{}, 1) // i.e., LATEST * 1
 		if err != nil {
 			client.server.logger.Error("internal", "couldn't query history for ZNC list", err.Error())
 		} else if len(items) != 0 {
 			stamp := timeToZncWireTime(items[0].Message.Time)
-			rb.Add(nil, "*playback!znc@znc.in", "PRIVMSG", nick, fmt.Sprintf("%s 0 %s", channel.Name(), stamp))
+			rb.Add(nil, zncPrefix, "PRIVMSG", nick, fmt.Sprintf("%s 0 %s", channel.Name(), stamp))
 		}
+	}
+
+	_, seq, err := client.server.GetHistorySequence(nil, client, "*")
+	if seq == nil {
+		return
+	} else if err != nil {
+		client.server.logger.Error("internal", "couldn't get client history sequence for ZNC list", err.Error())
+		return
+	}
+	limit := client.server.Config().History.ChathistoryMax
+	correspondents, err := seq.ListCorrespondents(history.Selector{}, history.Selector{}, limit)
+	if err != nil {
+		client.server.logger.Error("internal", "couldn't get correspondents for ZNC list", err.Error())
+		return
+	}
+	for _, correspondent := range correspondents {
+		stamp := timeToZncWireTime(correspondent.Time)
+		correspondentNick := client.server.clients.UnfoldNick(correspondent.CfCorrespondent)
+		rb.Add(nil, zncPrefix, "PRIVMSG", nick, fmt.Sprintf("%s 0 %s", correspondentNick, stamp))
 	}
 }


### PR DESCRIPTION
Implements the new `CHATHISTORY LISTCORRESPONDENTS` API.

I'm not all that happy with this implementation:

1. The new table is over-indexed (my insistence that all operations have to be O(log n) or better may be counterproductive)
2. We're up to a maximum of 7 inserts for a DM, although if we get rid of the `*` target it will be down to 5.