### PR TITLE
implement mass/global messaging

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -622,6 +622,7 @@ oper-classes:
             - "chanreg"
             - "history"
             - "defcon"
+            - "massmessage"
 
 # ircd operators
 opers:

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2169,7 +2169,7 @@ func dispatchMessageToTarget(client *Client, tags map[string]string, histType hi
 		accountName := details.accountName
 		isBot := client.HasMode(modes.Bot)
 		for _, tClient := range server.clients.AllClients() {
-			if (target[1] == '$' && matcher.MatchString(tClient.server.name)) ||    // $$servername
+			if (target[1] == '$' && matcher.MatchString(tClient.server.name)) || // $$servername
 				(target[1] == '#' && matcher.MatchString(tClient.Hostname())) { // $#hostname
 
 				tnick := tClient.Nick()

--- a/irc/handlers.go
+++ b/irc/handlers.go
@@ -2159,7 +2159,7 @@ func dispatchMessageToTarget(client *Client, tags map[string]string, histType hi
 		channel.SendSplitMessage(command, lowestPrefix, tags, client, message, rb)
 	} else if target[0] == '$' && len(target) > 2 && client.Oper().HasRoleCapab("massmessage") {
 		details := client.Details()
-		matcher, err := utils.CompileGlob(target[1:], false)
+		matcher, err := utils.CompileGlob(target[2:], false)
 		if err != nil {
 			rb.Add(nil, server.name, ERR_UNKNOWNERROR, details.nick, command, client.t("Erroneous target"))
 			return
@@ -2169,10 +2169,10 @@ func dispatchMessageToTarget(client *Client, tags map[string]string, histType hi
 		accountName := details.accountName
 		isBot := client.HasMode(modes.Bot)
 		for _, tClient := range server.clients.AllClients() {
-			if matcher.MatchString(fmt.Sprintf("$%s", tClient.server.name)) ||    // $$servername
-				matcher.MatchString(fmt.Sprintf("#%s", tClient.Hostname())) { // $#hostname
+			if (target[1] == '$' && matcher.MatchString(tClient.server.name)) ||    // $$servername
+				(target[1] == '#' && matcher.MatchString(tClient.Hostname())) { // $#hostname
 
-				tnick := tClient.Details().nick
+				tnick := tClient.Nick()
 				for _, session := range tClient.Sessions() {
 					session.sendSplitMsgFromClientInternal(false, nickMaskString, accountName, isBot, nil, command, tnick, message)
 				}

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -594,6 +594,7 @@ oper-classes:
             - "chanreg"
             - "history"
             - "defcon"
+            - "massmessage"
 
 # ircd operators
 opers:


### PR DESCRIPTION
closes #1153

design choices:
- pretend `$` magic doesn't exist if you're not an oper with `massmessage` capab
- don't do message tags
- `Erroneous target` when glob compilation fails