### PR TITLE
fix #1622

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -745,6 +745,9 @@ datastore:
         password: "hunter2"
         history-database: "oragono_history"
         timeout: 3s
+        max-conns: 4
+        # this may be necessary to prevent middleware from closing your connections:
+        #conn-max-lifetime: 180s
 
 # languages config
 languages:

--- a/irc/config.go
+++ b/irc/config.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -1478,6 +1479,12 @@ func LoadConfig(filename string) (config *Config, err error) {
 
 	config.Datastore.MySQL.ExpireTime = time.Duration(config.History.Restrictions.ExpireTime)
 	config.Datastore.MySQL.TrackAccountMessages = config.History.Retention.EnableAccountIndexing
+	if config.Datastore.MySQL.MaxConns == 0 {
+		// #1622: not putting an upper limit on the number of MySQL connections is
+		// potentially dangerous. as a naive heuristic, assume they're running on the
+		// same machine:
+		config.Datastore.MySQL.MaxConns = runtime.NumCPU()
+	}
 
 	config.Server.Cloaks.Initialize()
 	if config.Server.Cloaks.Enabled {

--- a/irc/mysql/config.go
+++ b/irc/mysql/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	Password        string
 	HistoryDatabase string `yaml:"history-database"`
 	Timeout         time.Duration
+	MaxConns        int           `yaml:"max-conns"`
+	ConnMaxLifetime time.Duration `yaml:"conn-max-lifetime"`
 
 	// XXX these are copied from elsewhere in the config:
 	ExpireTime           time.Duration

--- a/irc/mysql/history.go
+++ b/irc/mysql/history.go
@@ -100,6 +100,14 @@ func (m *MySQL) Open() (err error) {
 		return err
 	}
 
+	if m.config.MaxConns != 0 {
+		m.db.SetMaxOpenConns(m.config.MaxConns)
+		m.db.SetMaxIdleConns(m.config.MaxConns)
+	}
+	if m.config.ConnMaxLifetime != 0 {
+		m.db.SetConnMaxLifetime(m.config.ConnMaxLifetime)
+	}
+
 	err = m.fixSchemas()
 	if err != nil {
 		return err

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -718,6 +718,9 @@ datastore:
         password: "hunter2"
         history-database: "oragono_history"
         timeout: 3s
+        max-conns: 4
+        # this may be necessary to prevent middleware from closing your connections:
+        #conn-max-lifetime: 180s
 
 # languages config
 languages:


### PR DESCRIPTION
Allow users to set max MySQL connections and connection lifetime;
set a sane default for max connections if it's not present.