### PR TITLE
make MaxLineLen configurable

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -360,6 +360,11 @@ server:
     # e.g., `NickServ!NickServ@localhost`. uncomment this to override:
     #override-services-hostname: "example.network"
 
+    # in a "closed-loop" system where you control the server and all the clients,
+    # you may want to increase the maximum (non-tag) length of an IRC line from
+    # the default value of 512. do not do this on a public server:
+    # max-line-len: 512
+
 # account options
 accounts:
     # is account authentication enabled, i.e., can users log into existing accounts?

--- a/default.yaml
+++ b/default.yaml
@@ -362,7 +362,7 @@ server:
 
     # in a "closed-loop" system where you control the server and all the clients,
     # you may want to increase the maximum (non-tag) length of an IRC line from
-    # the default value of 512. do not do this on a public server:
+    # the default value of 512. DO NOT change this on a public server:
     # max-line-len: 512
 
 # account options

--- a/irc/client.go
+++ b/irc/client.go
@@ -31,8 +31,8 @@ import (
 )
 
 const (
-	// maximum line length not including tags; don't change this for a public server
-	MaxLineLen = 512
+	// maximum IRC line length, not including tags
+	DefaultMaxLineLen = 512
 
 	// IdentTimeout is how long before our ident (username) check times out.
 	IdentTimeout         = time.Second + 500*time.Millisecond
@@ -59,6 +59,10 @@ const (
 
 	// round off the ping interval by this much, see below:
 	PingCoalesceThreshold = time.Second
+)
+
+var (
+	MaxLineLen = DefaultMaxLineLen
 )
 
 // Client is an IRC client.

--- a/irc/config.go
+++ b/irc/config.go
@@ -590,6 +590,7 @@ type Config struct {
 		OutputPath               string       `yaml:"output-path"`
 		IPCheckScript            ScriptConfig `yaml:"ip-check-script"`
 		OverrideServicesHostname string       `yaml:"override-services-hostname"`
+		MaxLineLen               int          `yaml:"max-line-len"`
 	}
 
 	Roleplay struct {
@@ -1131,6 +1132,9 @@ func LoadConfig(filename string) (config *Config, err error) {
 	}
 	if config.Limits.RegistrationMessages == 0 {
 		config.Limits.RegistrationMessages = 1024
+	}
+	if config.Server.MaxLineLen < DefaultMaxLineLen {
+		config.Server.MaxLineLen = DefaultMaxLineLen
 	}
 	if config.Datastore.MySQL.Enabled {
 		if config.Limits.NickLen > mysql.MaxTargetLength || config.Limits.ChannelLen > mysql.MaxTargetLength {

--- a/irc/ircconn.go
+++ b/irc/ircconn.go
@@ -16,13 +16,17 @@ import (
 )
 
 const (
-	maxReadQBytes     = ircmsg.MaxlenTagsFromClient + MaxLineLen + 1024
 	initialBufferSize = 1024
 )
 
 var (
 	crlf = []byte{'\r', '\n'}
 )
+
+// maximum total length, in bytes, of a single IRC message:
+func maxReadQBytes() int {
+	return ircmsg.MaxlenTagsFromClient + MaxLineLen + 1024
+}
 
 // IRCConn abstracts away the distinction between a regular
 // net.Conn (which includes both raw TCP and TLS) and a websocket.
@@ -51,7 +55,7 @@ type IRCStreamConn struct {
 func NewIRCStreamConn(conn *utils.WrappedConn) *IRCStreamConn {
 	var c IRCStreamConn
 	c.conn = conn
-	c.reader.Initialize(conn.Conn, initialBufferSize, maxReadQBytes)
+	c.reader.Initialize(conn.Conn, initialBufferSize, maxReadQBytes())
 	return &c
 }
 

--- a/irc/listeners.go
+++ b/irc/listeners.go
@@ -185,7 +185,7 @@ func (wl *WSListener) handle(w http.ResponseWriter, r *http.Request) {
 	confirmProxyData(wConn, remoteAddr, xff, xfp, config)
 
 	// avoid a DoS attack from buffering excessively large messages:
-	conn.SetReadLimit(maxReadQBytes)
+	conn.SetReadLimit(int64(maxReadQBytes()))
 
 	go wl.server.RunClient(NewIRCWSConn(conn))
 }

--- a/irc/server.go
+++ b/irc/server.go
@@ -554,6 +554,7 @@ func (server *Server) applyConfig(config *Config) (err error) {
 		server.nameCasefolded = config.Server.nameCasefolded
 		globalCasemappingSetting = config.Server.Casemapping
 		globalUtf8EnforcementSetting = config.Server.EnforceUtf8
+		MaxLineLen = config.Server.MaxLineLen
 	} else {
 		// enforce configs that can't be changed after launch:
 		if server.name != config.Server.Name {
@@ -577,6 +578,8 @@ func (server *Server) applyConfig(config *Config) (err error) {
 			return fmt.Errorf("Cannot change override-services-hostname after launching the server, rehash aborted")
 		} else if !oldConfig.Datastore.MySQL.Enabled && config.Datastore.MySQL.Enabled {
 			return fmt.Errorf("Cannot enable MySQL after launching the server, rehash aborted")
+		} else if oldConfig.Server.MaxLineLen != config.Server.MaxLineLen {
+			return fmt.Errorf("Cannot change max-line-len after launching the server, rehash aborted")
 		}
 	}
 

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -334,7 +334,7 @@ server:
 
     # in a "closed-loop" system where you control the server and all the clients,
     # you may want to increase the maximum (non-tag) length of an IRC line from
-    # the default value of 512. do not do this on a public server:
+    # the default value of 512. DO NOT change this on a public server:
     # max-line-len: 512
 
 # account options

--- a/traditional.yaml
+++ b/traditional.yaml
@@ -332,6 +332,11 @@ server:
     # e.g., `NickServ!NickServ@localhost`. uncomment this to override:
     #override-services-hostname: "example.network"
 
+    # in a "closed-loop" system where you control the server and all the clients,
+    # you may want to increase the maximum (non-tag) length of an IRC line from
+    # the default value of 512. do not do this on a public server:
+    # max-line-len: 512
+
 # account options
 accounts:
     # is account authentication enabled, i.e., can users log into existing accounts?


### PR DESCRIPTION
This is somewhat irresponsible, but I know someone who patches this value out for a private server, and this would allow them to use official builds.

This is similar to `globalUtf8EnforcementSetting`; it's set on initial config load and can't be modified subsequently, so the application code can read it without any data race.